### PR TITLE
フォーマット指定子がlong になっている箇所をintまたはfmt::format() に差し替えた

### DIFF
--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -82,17 +82,16 @@ void do_cmd_inven(PlayerType *player_ptr)
 
     screen_save();
     (void)show_inventory(player_ptr, 0, USE_FULL, AllMatchItemTester());
-    WEIGHT weight = calc_inventory_weight(player_ptr);
-    WEIGHT weight_lim = calc_weight_limit(player_ptr);
-    std::string out_val;
+    const auto weight = calc_inventory_weight(player_ptr);
+    const auto weight_lim = calc_weight_limit(player_ptr);
+    const auto percentage = weight * 100 / weight_lim;
 #ifdef JP
-    out_val = format("持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight),
+    const auto mes = format("持ち物： 合計 %3d.%1d kg (限界の%d%%) コマンド: ", lb_to_kg_integer(weight), lb_to_kg_fraction(weight), percentage);
 #else
-    out_val = format("Inventory: carrying %d.%d pounds (%ld%% of capacity). Command: ", weight / 10, weight % 10,
+    const auto mes = format("Inventory: carrying %d.%d pounds (%d%% of capacity). Command: ", weight / 10, weight % 10, percentage);
 #endif
-        (long int)(weight * 100) / weight_lim);
 
-    prt(out_val, 0, 0);
+    prt(mes, 0, 0);
     command_new = inkey();
     screen_load();
     if (command_new != ESCAPE) {

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -192,7 +192,7 @@ errr top_twenty(PlayerType *player_ptr)
     snprintf(the_score.pts, sizeof(the_score.pts), "%9u", calc_score(player_ptr));
     the_score.pts[9] = '\0';
 
-    snprintf(the_score.gold, sizeof(the_score.gold), "%9lu", (long)player_ptr->au);
+    snprintf(the_score.gold, sizeof(the_score.gold), "%9d", player_ptr->au);
     the_score.gold[9] = '\0';
 
     const auto &igd = InnerGameData::get_instance();
@@ -256,8 +256,8 @@ errr predict_score(PlayerType *player_ptr)
 
     const auto &igd = InnerGameData::get_instance();
     snprintf(the_score.what, sizeof(the_score.what), "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
-    snprintf(the_score.pts, sizeof(the_score.pts), "%9ld", (long)calc_score(player_ptr));
-    snprintf(the_score.gold, sizeof(the_score.gold), "%9lu", (long)player_ptr->au);
+    snprintf(the_score.pts, sizeof(the_score.pts), "%9u", calc_score(player_ptr));
+    snprintf(the_score.gold, sizeof(the_score.gold), "%9d", player_ptr->au);
     snprintf(the_score.turns, sizeof(the_score.turns), "%9d", igd.get_real_turns(AngbandWorld::get_instance().game_turn));
     angband_strcpy(the_score.day, _("今日", "TODAY"), sizeof(the_score.day));
     the_score.copy_info(*player_ptr);

--- a/src/core/scores.cpp
+++ b/src/core/scores.cpp
@@ -189,7 +189,7 @@ errr top_twenty(PlayerType *player_ptr)
 {
     high_score the_score = {};
     snprintf(the_score.what, sizeof(the_score.what), "%u.%u.%u", H_VER_MAJOR, H_VER_MINOR, H_VER_PATCH);
-    snprintf(the_score.pts, sizeof(the_score.pts), "%9ld", (long)calc_score(player_ptr));
+    snprintf(the_score.pts, sizeof(the_score.pts), "%9u", calc_score(player_ptr));
     the_score.pts[9] = '\0';
 
     snprintf(the_score.gold, sizeof(the_score.gold), "%9lu", (long)player_ptr->au);

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -33,7 +33,6 @@
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
 #include "monster/monster-util.h"
-#include "player/player-status.h"
 #include "system/angband-system.h"
 #include "system/building-type-definition.h"
 #include "system/dungeon/dungeon-definition.h"
@@ -143,7 +142,10 @@ static void generate_challenge_arena(PlayerType *player_ptr)
     }
 
     const auto pos = build_arena(player_ptr);
-    player_place(player_ptr, pos.y, pos.x);
+    if (!player_ptr->try_set_position(pos)) {
+        return;
+    }
+
     auto &entries = ArenaEntryList::get_instance();
     const auto &monrace = entries.get_monrace();
     if (place_specific_monster(player_ptr, player_ptr->y + 5, player_ptr->x, monrace.idx, PM_NO_KAGE | PM_NO_PET)) {
@@ -242,7 +244,10 @@ static void generate_gambling_arena(PlayerType *player_ptr)
     }
 
     const auto pos = build_battle(player_ptr);
-    player_place(player_ptr, pos.y, pos.x);
+    if (!player_ptr->try_set_position(pos)) {
+        return;
+    }
+
     const auto &melee_arena = MeleeArena::get_instance();
     for (auto i = 0; i < NUM_GLADIATORS; i++) {
         const auto &gladiator = melee_arena.get_gladiator(i);

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -24,7 +24,6 @@
 #include "monster/monster-util.h"
 #include "player-status/player-energy.h"
 #include "player/attack-defense-types.h"
-#include "player/player-status.h"
 #include "spell-realm/spells-hex.h"
 #include "status/action-setter.h"
 #include "system/angband-system.h"
@@ -550,7 +549,10 @@ void wilderness_gen(PlayerType *player_ptr)
         player_ptr->teleport_town = false;
     }
 
-    player_place(player_ptr, player_ptr->oldpy, player_ptr->oldpx);
+    if (!player_ptr->try_set_position(player_ptr->get_old_position())) {
+        return;
+    }
+
     generate_wild_monsters(player_ptr);
     if (wilderness.should_ambush()) {
         player_ptr->ambush_flag = true;

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -35,6 +35,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <algorithm>
+#include <fmt/format.h>
 #include <fstream>
 #include <span>
 #include <sstream>
@@ -271,23 +272,23 @@ bool report_score(PlayerType *player_ptr)
 
     PlayerRealm pr(player_ptr);
     const auto &realm1_name = PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(player_ptr->element) : pr.realm1().get_name().string();
-    score_ss << format("name: %s\n", player_ptr->name)
-             << format("version: %s\n", AngbandSystem::get_instance().build_version_expression(VersionExpression::FULL).data())
-             << format("score: %ld\n", calc_score(player_ptr))
-             << format("level: %d\n", player_ptr->lev)
-             << format("depth: %d\n", player_ptr->current_floor_ptr->dun_level)
-             << format("maxlv: %d\n", player_ptr->max_plv)
-             << format("maxdp: %d\n", DungeonRecords::get_instance().get_record(DungeonId::ANGBAND).get_max_level())
-             << format("au: %d\n", player_ptr->au);
+    score_ss << fmt::format("name: {}\n", player_ptr->name)
+             << fmt::format("version: {}\n", AngbandSystem::get_instance().build_version_expression(VersionExpression::FULL))
+             << fmt::format("score: {}\n", calc_score(player_ptr))
+             << fmt::format("level: {}\n", player_ptr->lev)
+             << fmt::format("depth: {}\n", player_ptr->current_floor_ptr->dun_level)
+             << fmt::format("maxlv: {}\n", player_ptr->max_plv)
+             << fmt::format("maxdp: {}\n", DungeonRecords::get_instance().get_record(DungeonId::ANGBAND).get_max_level())
+             << fmt::format("au: {}\n", player_ptr->au);
     const auto &igd = InnerGameData::get_instance();
-    score_ss << format("turns: %d\n", igd.get_real_turns(AngbandWorld::get_instance().game_turn))
-             << format("sex: %d\n", player_ptr->psex)
-             << format("race: %s\n", rp_ptr->title.data())
-             << format("class: %s\n", cp_ptr->title.data())
-             << format("seikaku: %s\n", personality_desc.data())
-             << format("realm1: %s\n", realm1_name.data())
-             << format("realm2: %s\n", pr.realm2().get_name().data())
-             << format("killer: %s\n", player_ptr->died_from.data())
+    score_ss << fmt::format("turns: {}\n", igd.get_real_turns(AngbandWorld::get_instance().game_turn))
+             << fmt::format("sex: {}\n", enum2i(player_ptr->psex))
+             << fmt::format("race: {}\n", rp_ptr->title)
+             << fmt::format("class: {}\n", cp_ptr->title)
+             << fmt::format("seikaku: {}\n", personality_desc)
+             << fmt::format("realm1: {}\n", realm1_name)
+             << fmt::format("realm2: {}\n", pr.realm2().get_name())
+             << fmt::format("killer: {}\n", player_ptr->died_from)
              << "-----charcter dump-----\n";
 
     make_dump(player_ptr, score_ss);

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -31,6 +31,7 @@
 #include "util/string-processor.h"
 #include "view/display-lore.h"
 #include "world/world.h"
+#include <fmt/format.h>
 #ifdef JP
 #else
 #include "locale/english.h"
@@ -367,7 +368,7 @@ void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool v
             display_visual_list(max + 3, 7, browser_rows - 1, wid - (max + 3), color_top, character_left);
         }
 
-        prt(format(_("%lu 種", "%lu Races"), monrace_ids.size()), 3, 26);
+        prt(fmt::format(_("{} 種", "{} Races"), monrace_ids.size()), 3, 26);
         prt(format(_("<方向>%s%s%s, ESC", "<dir>%s%s%s, ESC"), (!visual_list && !visual_only) ? _(", 'r'で思い出を見る", ", 'r' to recall") : "",
                 visual_list ? _(", ENTERで決定", ", ENTER to accept") : _(", 'v'でシンボル変更", ", 'v' for visuals"),
                 (symbols_cb.symbol != DisplaySymbol()) ? _(", 'c', 'p'でペースト", ", 'c', 'p' to paste") : _(", 'c'でコピー", ", 'c' to copy")),

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -144,8 +144,8 @@ MonraceId get_mon_num(PlayerType *player_ptr, int min_level, int max_level, uint
     }
 
     if (cheat_hear) {
-        msg_format(_("モンスター第3次候補数:%lu(%d-%dF)%d ", "monster third selection:%lu(%d-%dF)%d "), prob_table.item_count(), min_level, max_level,
-            prob_table.total_prob());
+        constexpr auto fmt = _("モンスター第3次候補数:{}({}-{}F){} ", "monster third selection:{}({}-{}F){} ");
+        msg_print(fmt, prob_table.item_count(), min_level, max_level, prob_table.total_prob());
     }
 
     if (prob_table.empty()) {

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -14,6 +14,8 @@
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
+#include <array>
+#include <fmt/format.h>
 
 PlayerAlignment::PlayerAlignment(PlayerType *player_ptr)
 {
@@ -27,9 +29,9 @@ PlayerAlignment::PlayerAlignment(PlayerType *player_ptr)
  */
 std::string PlayerAlignment::get_alignment_description(bool with_value)
 {
-    auto s = alignment_label();
+    const auto s = this->alignment_label();
     if (with_value || show_actual_value) {
-        return format(_("%s(%ld)", "%s (%ld)"), s, static_cast<long>(this->player_ptr->alignment));
+        return fmt::format(_("{}({})", "{} ({})"), s, this->player_ptr->alignment);
     }
 
     return s;
@@ -99,7 +101,7 @@ void PlayerAlignment::update_alignment()
     }
 
     int j = 0;
-    int neutral[2];
+    std::array<int, 2> neutral{};
     for (int i = 0; i < 8; i++) {
         switch (this->player_ptr->vir_types[i]) {
         case Virtue::JUSTICE:
@@ -155,7 +157,7 @@ void PlayerAlignment::reset_alignment()
  * @param player_ptr プレイヤーへの参照ポインタ。
  * @return アライメントの表記名
  */
-concptr PlayerAlignment::alignment_label()
+std::string PlayerAlignment::alignment_label() const
 {
     if (this->player_ptr->alignment > 150) {
         return _("大善", "Lawful");

--- a/src/player-info/alignment.h
+++ b/src/player-info/alignment.h
@@ -13,7 +13,7 @@ public:
 
 private:
     PlayerType *player_ptr;
-    concptr alignment_label();
+    std::string alignment_label() const;
     void bias_good_alignment(int value);
     void bias_evil_alignment(int value);
     void reset_alignment();

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2712,24 +2712,6 @@ bool player_has_no_spellbooks(PlayerType *player_ptr)
 }
 
 /*!
- * @brief プレイヤーを指定座標に配置する / Place the player in the dungeon XXX XXX
- * @param x 配置先X座標
- * @param y 配置先Y座標
- * @return 配置に成功したらTRUE
- */
-bool player_place(PlayerType *player_ptr, int y, int x)
-{
-    if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
-        return false;
-    }
-
-    /* Save player location */
-    player_ptr->y = y;
-    player_ptr->x = x;
-    return true;
-}
-
-/*!
  * @brief 種族アンバライトが出血時パターンの上に乗った際のペナルティ処理
  */
 void wreck_the_pattern(PlayerType *player_ptr)

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -192,18 +192,18 @@ static bool is_heavy_shoot(PlayerType *player_ptr, const ItemEntity *o_ptr)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return 総重量
  */
-WEIGHT calc_inventory_weight(PlayerType *player_ptr)
+int calc_inventory_weight(PlayerType *player_ptr)
 {
-    WEIGHT weight = 0;
-
-    ItemEntity *o_ptr;
+    auto weight = 0;
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
-        if (!o_ptr->is_valid()) {
+        const auto &item = player_ptr->inventory_list[i];
+        if (!item.is_valid()) {
             continue;
         }
-        weight += o_ptr->weight * o_ptr->number;
+
+        weight += item.weight * item.number;
     }
+
     return weight;
 }
 
@@ -2570,12 +2570,13 @@ static int calc_to_weapon_dice_num(PlayerType *player_ptr, INVENTORY_IDX slot)
  * Computes current weight limit.
  * @return 制限重量(ポンド)
  */
-WEIGHT calc_weight_limit(PlayerType *player_ptr)
+int calc_weight_limit(PlayerType *player_ptr)
 {
-    WEIGHT i = (WEIGHT)adj_str_wgt[player_ptr->stat_index[A_STR]] * 50;
+    auto i = adj_str_wgt[player_ptr->stat_index[A_STR]] * 50;
     if (PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER)) {
         i = i * 3 / 2;
     }
+
     return i;
 }
 
@@ -2716,7 +2717,7 @@ bool player_has_no_spellbooks(PlayerType *player_ptr)
  * @param y 配置先Y座標
  * @return 配置に成功したらTRUE
  */
-bool player_place(PlayerType *player_ptr, POSITION y, POSITION x)
+bool player_place(PlayerType *player_ptr, int y, int x)
 {
     if (player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         return false;
@@ -2993,7 +2994,7 @@ int16_t modify_stat_value(int value, int amount)
  * Hack -- Calculates the total number of points earned		-JWT-
  * @details
  */
-long calc_score(PlayerType *player_ptr)
+uint32_t calc_score(PlayerType *player_ptr)
 {
     const auto &entries = ArenaEntryList::get_instance();
     const auto current_entry = entries.get_current_entry();
@@ -3149,10 +3150,9 @@ bool is_chargeman(PlayerType *player_ptr)
     return player_ptr->ppersonality == PERSONALITY_CHARGEMAN;
 }
 
-WEIGHT calc_weapon_weight_limit(PlayerType *player_ptr)
+int calc_weapon_weight_limit(PlayerType *player_ptr)
 {
-    WEIGHT weight = adj_str_hold[player_ptr->stat_index[A_STR]];
-
+    auto weight = adj_str_hold[player_ptr->stat_index[A_STR]];
     if (has_two_handed_weapons(player_ptr)) {
         weight *= 2;
     }
@@ -3160,10 +3160,9 @@ WEIGHT calc_weapon_weight_limit(PlayerType *player_ptr)
     return weight;
 }
 
-WEIGHT calc_bow_weight_limit(PlayerType *player_ptr)
+int calc_bow_weight_limit(PlayerType *player_ptr)
 {
-    WEIGHT weight = adj_str_hold[player_ptr->stat_index[A_STR]];
-
+    auto weight = adj_str_hold[player_ptr->stat_index[A_STR]];
     return weight;
 }
 

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -5,28 +5,28 @@
  * @brief プレイヤーのステータスに関する状態取得処理ヘッダ
  */
 
-#include "system/angband.h"
+#include <cstdint>
 #include <string>
 
 class ItemEntity;
 class PlayerType;
 
-WEIGHT calc_weapon_weight_limit(PlayerType *player_ptr);
-WEIGHT calc_bow_weight_limit(PlayerType *player_ptr);
-WEIGHT calc_inventory_weight(PlayerType *player_ptr);
+int calc_weapon_weight_limit(PlayerType *player_ptr);
+int calc_bow_weight_limit(PlayerType *player_ptr);
+int calc_inventory_weight(PlayerType *player_ptr);
 
 short calc_num_fire(PlayerType *player_ptr, const ItemEntity *o_ptr);
-WEIGHT calc_weight_limit(PlayerType *player_ptr);
+int calc_weight_limit(PlayerType *player_ptr);
 void update_creature(PlayerType *player_ptr);
 bool player_has_no_spellbooks(PlayerType *player_ptr);
 
-bool player_place(PlayerType *player_ptr, POSITION y, POSITION x);
+bool player_place(PlayerType *player_ptr, int y, int x);
 
 void check_experience(PlayerType *player_ptr);
 void wreck_the_pattern(PlayerType *player_ptr);
 std::string cnv_stat(int val);
 int16_t modify_stat_value(int value, int amount);
-long calc_score(PlayerType *player_ptr);
+uint32_t calc_score(PlayerType *player_ptr);
 
 bool is_blessed(PlayerType *player_ptr);
 bool is_time_limit_esp(PlayerType *player_ptr);

--- a/src/player/player-status.h
+++ b/src/player/player-status.h
@@ -20,8 +20,6 @@ int calc_weight_limit(PlayerType *player_ptr);
 void update_creature(PlayerType *player_ptr);
 bool player_has_no_spellbooks(PlayerType *player_ptr);
 
-bool player_place(PlayerType *player_ptr, int y, int x);
-
 void check_experience(PlayerType *player_ptr);
 void wreck_the_pattern(PlayerType *player_ptr);
 std::string cnv_stat(int val);

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -3,6 +3,7 @@
 #include "monster/monster-util.h"
 #include "system/angband-exceptions.h"
 #include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/monster-entity.h"
 #include "system/redrawing-flags-updater.h"
 #include "timed-effect/timed-effects.h"
@@ -122,6 +123,11 @@ Pos2D PlayerType::get_position() const
     return Pos2D(this->y, this->x);
 }
 
+Pos2D PlayerType::get_old_position() const
+{
+    return Pos2D(this->oldpy, this->oldpx);
+}
+
 /*!
  * @brief 現在地の隣 (瞬時値)または現在地を返す
  * @param dir 隣を表す方向番号
@@ -154,6 +160,22 @@ bool PlayerType::is_located_at_running_destination() const
 bool PlayerType::is_located_at(const Pos2D &pos) const
 {
     return (this->y == pos.y) && (this->x == pos.x);
+}
+
+/*!
+ * @brief プレイヤーを指定座標に配置する
+ * @param pos 配置先座標
+ * @return 配置に成功したらTRUE
+ */
+bool PlayerType::try_set_position(const Pos2D &pos)
+{
+    if (this->current_floor_ptr->get_grid(pos).has_monster()) {
+        return false;
+    }
+
+    this->y = pos.y;
+    this->x = pos.x;
+    return true;
 }
 
 void PlayerType::set_position(const Pos2D &pos)

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -381,10 +381,12 @@ public:
     std::string decrease_ability_random();
     std::string decrease_ability_all();
     Pos2D get_position() const;
+    Pos2D get_old_position() const;
     Pos2D get_neighbor(int dir) const;
     Pos2D get_neighbor(const Direction &dir) const;
     bool is_located_at_running_destination() const;
     bool is_located_at(const Pos2D &pos) const;
+    bool try_set_position(const Pos2D &pos);
     void set_position(const Pos2D &pos);
     bool in_saved_floor() const;
     int calc_life_rating() const;


### PR DESCRIPTION
少なくともMSVCにおけるlong はint と変わらないのと、明らかに21億/43億を超える見込みがない箇所しかないです (真に64ビット幅が必要な場所はなく、ある種の固定小数点演算の代わりに使っている箇所のみ)
取り敢えず最低限動いているように見えます
ご確認下さい