### PR TITLE
[Fix] トラベルコマンドで移動中のディレイをなくす

### DIFF
--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -119,8 +119,6 @@ void travel_step(PlayerType *player_ptr)
     } else if (travel.run > 0) {
         travel.run--;
     }
-
-    term_xtra(TERM_XTRA_DELAY, delay_factor);
 }
 
 /*!


### PR DESCRIPTION
トラベルコマンドで移動している時、一歩ごとに基本ウェイト量に設定されたディレイがかかるようになっている。
移動経路をじっくり確認できることよりも、無駄に時間がかかるデメリットのほうが大きいと思われるのでディレイを削除する。

Resolves #4976 