### PR TITLE
Directionクラスの機能追加と関連する修正

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -336,7 +336,7 @@ void exe_movement(PlayerType *player_ptr, const Direction &dir, bool do_pickup, 
     }
 
     if (world.is_wild_mode()) {
-        const auto vec = Direction(dir).vec();
+        const auto vec = dir.vec();
         if (vec.y > 0) {
             player_ptr->oldpy = 1;
         }

--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -260,7 +260,7 @@ static bool run_test(PlayerType *player_ptr)
             inv = false;
         }
 
-        if (!inv && see_wall(player_ptr, Direction(5), pos)) {
+        if (!inv && see_wall(player_ptr, Direction::self(), pos)) {
             if (find_openarea) {
                 if (i < 0) {
                     find_breakright = true;

--- a/src/cmd-action/cmd-move.cpp
+++ b/src/cmd-action/cmd-move.cpp
@@ -411,7 +411,7 @@ void do_cmd_run(PlayerType *player_ptr)
 
     if (const auto dir = get_rep_dir(player_ptr)) {
         player_ptr->running = (command_arg ? command_arg : 1000);
-        run_step(player_ptr, Direction(dir));
+        run_step(player_ptr, dir);
     }
 }
 

--- a/src/floor/geometry.h
+++ b/src/floor/geometry.h
@@ -144,6 +144,15 @@ public:
     }
 
     /*!
+     * @brief 方向が軸方向(上下左右)のいずれかを示しているかどうかを返す
+     * @return 上下左右ならばtrue、そうでなければfalse
+     */
+    constexpr bool is_axial() const noexcept
+    {
+        return this->dir_ == 2 || this->dir_ == 4 || this->dir_ == 6 || this->dir_ == 8;
+    }
+
+    /*!
      * @brief 方向が斜め方向かどうかを返す
      * @return 斜め方向ならばtrue、そうでなければfalse
      */

--- a/src/floor/geometry.h
+++ b/src/floor/geometry.h
@@ -61,6 +61,17 @@ public:
     }
 
     /*!
+     * @brief 特定のマスをターゲット中であることを示す方向クラスのインスタンスを生成する
+     * @todo 将来的にはできればDirectionクラスにtarget_row/target_colを繰り込みたい
+     */
+    static constexpr Direction targetting()
+    {
+        auto dir = Direction::self();
+        dir.is_targetting_ = true;
+        return dir;
+    }
+
+    /*!
      * @brief 引数に指定した、円周順に方向を示す値から方向クラスのインスタンスを生成する
      *
      * 引数 cdir は南を0とし反時計回りの順。
@@ -162,6 +173,14 @@ public:
     }
 
     /*!
+     * @brief 特定のマスをターゲット中であるかどうかを返す
+     */
+    constexpr bool is_targetting() const noexcept
+    {
+        return this->dir_ == 5 && this->is_targetting_;
+    }
+
+    /*!
      * @brief 方向を45度単位で回転させた方向クラスのインスタンスを生成する
      *
      * すなわち、 cdir をdeltaだけ増減させた(0↔7でつながる)方向を示すインスタンスを返す。
@@ -199,11 +218,12 @@ private:
     static constexpr std::array<std::optional<int>, 10> DIR_TO_CDIR = { { std::nullopt, 7, 0, 1, 6, std::nullopt, 2, 5, 4, 3 } };
 
     int dir_; //<! 方向ID
+    bool is_targetting_ = false; //<! 特定のマスをターゲット中であるかどうか
 };
 
 constexpr bool operator==(const Direction &dir1, const Direction &dir2) noexcept
 {
-    return dir1.dir() == dir2.dir();
+    return dir1.dir() == dir2.dir() && dir1.is_targetting() == dir2.is_targetting();
 }
 
 /* 以降の定義は直接使用しないようdetail名前空間に入れておく*/

--- a/src/floor/geometry.h
+++ b/src/floor/geometry.h
@@ -53,6 +53,14 @@ public:
     }
 
     /*!
+     * @brief 自身のマスを示す方向クラスのインスタンスを生成する
+     */
+    static constexpr Direction self()
+    {
+        return Direction(5);
+    }
+
+    /*!
      * @brief 引数に指定した、円周順に方向を示す値から方向クラスのインスタンスを生成する
      *
      * 引数 cdir は南を0とし反時計回りの順。

--- a/src/io-dump/dump-util.cpp
+++ b/src/io-dump/dump-util.cpp
@@ -131,18 +131,12 @@ bool visual_mode_command(char ch, bool *visual_list_ptr,
             eff_width = width;
         }
 
-        const auto vec = Direction(d).vec();
-        if ((a == 0) && (vec.y < 0)) {
-            d = 0;
-        }
-        if ((c == 0) && (vec.x < 0)) {
-            d = 0;
-        }
-        if ((a == 0x7f) && (vec.y > 0)) {
-            d = 0;
-        }
-        if (((byte)c == 0xff) && (vec.x > 0)) {
-            d = 0;
+        auto vec = Direction(d).vec();
+        if (((a == 0) && (vec.y < 0)) ||
+            ((c == 0) && (vec.x < 0)) ||
+            ((a == 0x7f) && (vec.y > 0)) ||
+            (((byte)c == 0xff) && (vec.x > 0))) {
+            vec = Direction::self().vec();
         }
 
         a += (TERM_COLOR)vec.y;

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -230,7 +230,7 @@ static void display_monster_list(int col, int row, int per_page, const std::vect
         c_prt(color, (monrace.name.data()), row + i, col);
         const auto &symbol_config = monrace.symbol_config;
         if (per_page == 1) {
-            c_prt(color, format("%02x/%02x", symbol_config.color, symbol_config.character), row + i, (is_wizard || visual_only) ? 56 : 61);
+            c_prt(color, format("%02x/%02x", symbol_config.color, static_cast<uint8_t>(symbol_config.character)), row + i, (is_wizard || visual_only) ? 56 : 61);
         }
 
         if (is_wizard || visual_only) {

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -192,7 +192,7 @@ Direction get_rep_dir(PlayerType *player_ptr, bool under)
         }
 
         if (under && ((command == '5') || (command == '-') || (command == '.'))) {
-            dir = Direction(5);
+            dir = Direction::self();
             break;
         }
 
@@ -202,7 +202,7 @@ Direction get_rep_dir(PlayerType *player_ptr, bool under)
         }
     }
 
-    if (dir == Direction(5) && !under) {
+    if (dir == Direction::self() && !under) {
         return Direction::none();
     }
 


### PR DESCRIPTION
# 機能追加

- Direction::self() : 自身のマスを示すインスタンスを生成するstaticメンバ関数（Direction(5)の代わりに意図をわかりやすくする。また、下記のtargetting()との区別がつきやすくする）
- Direction::is_axial() : 軸方向（上下左右）を指しているかを返す関数
- Direction::targetting() / is_targetting() : 特定のマスをターゲット中であることを示すインスタンスを生成するstaticメンバ関数と、その状態であるかをテストするメンバ関数

# 修正

- 不要なコピーコンストラクタ呼び出しの削除
- シンボルエディタで端を超えて移動できてしまう（Directionクラスに置き換えた時のエンバグ）
- ついでに見つけたシンボルエディタでの文字コード表示の不具合