### PR TITLE
[Refactor] MonsterSweepGrid::mmを削除

### DIFF
--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -195,7 +195,7 @@ static bool random_walk(PlayerType *player_ptr, std::span<Direction> mm, const M
  * @param m_idx モンスターID
  * @return モンスターがペットであればTRUE
  */
-static bool decide_pet_movement_direction(MonsterSweepGrid *msd)
+static bool decide_pet_movement_direction(MonsterSweepGrid *msd, std::span<Direction> mm)
 {
     const auto &monster = msd->player_ptr->current_floor_ptr->m_list[msd->m_idx];
     if (!monster.is_pet()) {
@@ -205,8 +205,8 @@ static bool decide_pet_movement_direction(MonsterSweepGrid *msd)
     bool avoid = ((msd->player_ptr->pet_follow_distance < 0) && (monster.cdis <= (0 - msd->player_ptr->pet_follow_distance)));
     bool lonely = (!avoid && (monster.cdis > msd->player_ptr->pet_follow_distance));
     bool distant = (monster.cdis > PET_SEEK_DIST);
-    msd->mm[0] = msd->mm[1] = msd->mm[2] = msd->mm[3] = Direction::self();
-    if (get_enemy_dir(msd->player_ptr, msd->m_idx, msd->mm)) {
+    mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
+    if (get_enemy_dir(msd->player_ptr, msd->m_idx, mm)) {
         return true;
     }
 
@@ -219,7 +219,7 @@ static bool decide_pet_movement_direction(MonsterSweepGrid *msd)
         msd->player_ptr->pet_follow_distance = PET_SEEK_DIST;
     }
 
-    (void)msd->get_movable_grid();
+    (void)msd->get_movable_grid(mm);
     msd->player_ptr->pet_follow_distance = (int16_t)dis;
     return true;
 }
@@ -251,8 +251,8 @@ bool decide_monster_movement_direction(PlayerType *player_ptr, std::span<Directi
         return true;
     }
 
-    MonsterSweepGrid msd(player_ptr, m_idx, mm);
-    if (decide_pet_movement_direction(&msd)) {
+    MonsterSweepGrid msd(player_ptr, m_idx);
+    if (decide_pet_movement_direction(&msd, mm)) {
         return true;
     }
 
@@ -262,5 +262,5 @@ bool decide_monster_movement_direction(PlayerType *player_ptr, std::span<Directi
         return true;
     }
 
-    return msd.get_movable_grid();
+    return msd.get_movable_grid(mm);
 }

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -513,21 +513,20 @@ public:
  * @brief コンストラクタ
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx 移動するモンスターの参照ID
- * @param mm 移動方向を返す方向IDの参照ポインタ
  */
-MonsterSweepGrid::MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx, std::span<Direction> mm)
+MonsterSweepGrid::MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx)
     : player_ptr(player_ptr)
     , m_idx(m_idx)
-    , mm(mm)
 {
 }
 
 /*!
  * @brief モンスターの移動方向を返す
+ * @param mm 移動方向を格納する配列への参照
  * @return 有効方向があった場合TRUEを返す
  * @todo 分割したいが条件が多すぎて適切な関数名と詳細処理を追いきれない……
  */
-bool MonsterSweepGrid::get_movable_grid()
+bool MonsterSweepGrid::get_movable_grid(std::span<Direction> mm)
 {
     const auto deciders = MonsterMoveGridDecidersFactory::create_deciders(this->player_ptr, this->m_idx);
     auto pos_move = MonsterMoveGridDecider::evalute_deciders(deciders, this->player_ptr->get_position());
@@ -542,6 +541,6 @@ bool MonsterSweepGrid::get_movable_grid()
         return false;
     }
 
-    store_moves_val(this->mm, vec);
+    store_moves_val(mm, vec);
     return true;
 }

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -10,10 +10,8 @@ class Direction;
 class PlayerType;
 class MonsterSweepGrid {
 public:
-    MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx, std::span<Direction> mm);
-    virtual ~MonsterSweepGrid() = default;
+    MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx);
     PlayerType *player_ptr;
     MONSTER_IDX m_idx;
-    std::span<Direction> mm;
-    bool get_movable_grid();
+    bool get_movable_grid(std::span<Direction> mm);
 };


### PR DESCRIPTION
Resolves #4992

Apple Clang 15で暗黙のコピーコンストラクタ宣言によりmmの型である`std::span<Direction>`においてDirection型の完全な型が必要となりコンパイル エラーが発生する。
mmをメンバで持たせるのがそもそも違和感があるので、メンバから削除しget_movable_grid()の引数として渡すようにする。

最終的にはモンスターの移動候補クラスのようなものにしたいが、複数の関数に範囲にわたって配列の参照を引き回しているため設計の見直しが必要となりそうなので、とりあえずコンパイルエラーを回避する暫定処置。