### PR TITLE
[Feature] lookコマンドから直接トラベルする機能 

### DIFF
--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -204,6 +204,17 @@ Travel &Travel::get_instance()
     return instance;
 }
 
+bool Travel::can_travel_to(const FloorType &floor, const Pos2D &pos)
+{
+    const auto &grid = floor.get_grid(pos);
+    const auto &terrain = grid.get_terrain();
+    const auto is_marked = grid.is_mark();
+    const auto is_wall = terrain.flags.has_any_of({ TerrainCharacteristics::WALL, TerrainCharacteristics::CAN_DIG });
+    const auto is_door = terrain.flags.has(TerrainCharacteristics::DOOR) && (grid.mimic > 0);
+
+    return !is_marked || (!is_wall && !is_door);
+}
+
 const std::optional<Pos2D> &Travel::get_goal() const
 {
     return this->pos_goal;

--- a/src/action/travel-execution.h
+++ b/src/action/travel-execution.h
@@ -27,6 +27,7 @@ public:
     Travel &operator=(Travel &&) = delete;
 
     static Travel &get_instance();
+    static bool can_travel_to(const FloorType &floor, const Pos2D &pos);
 
     const std::optional<Pos2D> &get_goal() const;
     void set_goal(PlayerType *player_ptr, const Pos2D &pos);

--- a/src/cmd-action/cmd-travel.cpp
+++ b/src/cmd-action/cmd-travel.cpp
@@ -38,13 +38,7 @@ void do_cmd_travel(PlayerType *player_ptr)
         return;
     }
 
-    const auto &floor = *player_ptr->current_floor_ptr;
-    const auto &grid = floor.get_grid(*pos);
-    const auto &terrain = grid.get_terrain();
-    const auto is_marked = grid.is_mark();
-    const auto is_wall = terrain.flags.has_any_of({ TerrainCharacteristics::WALL, TerrainCharacteristics::CAN_DIG });
-    const auto is_door = terrain.flags.has(TerrainCharacteristics::DOOR) && (grid.mimic > 0);
-    if (is_marked && (is_wall || is_door)) {
+    if (Travel::can_travel_to(*player_ptr->current_floor_ptr, *pos)) {
         msg_print(_("そこには行くことができません！", "You cannot travel there!"));
         return;
     }


### PR DESCRIPTION
lookコマンド中に`g`キーを入力することで、そのマスへのトラベルに移行する
機能を実装する。

Resolves #5000 

トラベルの開始確認は不要かなと思ったのでとりあえず無しにしています。