### PR TITLE
[Refactor] モンスターの移動方向のリスト管理

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -295,6 +295,7 @@
     <ClCompile Include="..\..\src\action\movement-execution.cpp" />
     <ClCompile Include="..\..\src\core\score-util.cpp" />
     <ClCompile Include="..\..\src\external-lib\fmt\format.cc" />
+    <ClCompile Include="..\..\src\monster-floor\monster-movement-direction-list.cpp" />
     <ClCompile Include="..\..\src\system\floor\wilderness-grid.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
@@ -1017,6 +1018,7 @@
     <ClInclude Include="..\..\src\action\open-util.h" />
     <ClInclude Include="..\..\src\action\run-execution.h" />
     <ClInclude Include="..\..\src\external-lib\include-json.h" />
+    <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h" />
     <ClInclude Include="..\..\src\system\enums\terrain\terrain-kind.h" />
     <ClInclude Include="..\..\src\system\enums\terrain\wilderness-terrain.h" />
     <ClInclude Include="..\..\src\system\floor\wilderness-grid.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2556,6 +2556,9 @@
     <ClCompile Include="..\..\src\system\floor\wilderness-grid.cpp">
       <Filter>system\floor</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\monster-floor\monster-movement-direction-list.cpp">
+      <Filter>monster-floor</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5546,6 +5549,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\system\floor\wilderness-grid.h">
       <Filter>system\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h">
+      <Filter>monster-floor</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -829,6 +829,7 @@ hengband_SOURCES = \
 	monster-floor/monster-dist-offsets.cpp monster-floor/monster-dist-offsets.h \
 	monster-floor/monster-generator.cpp monster-floor/monster-generator.h \
 	monster-floor/monster-move.cpp monster-floor/monster-move.h \
+	monster-floor/monster-movement-direction-list.cpp monster-floor/monster-movement-direction-list.h \
 	monster-floor/monster-object.cpp monster-floor/monster-object.h \
 	monster-floor/monster-remover.cpp monster-floor/monster-remover.h \
 	monster-floor/monster-runaway.cpp monster-floor/monster-runaway.h \

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -106,10 +106,9 @@ static void decide_enemy_approch_direction(PlayerType *player_ptr, MONSTER_IDX m
  * Calculate the direction to the next enemy
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx モンスターの参照ID
- * @param mm 移動するべき方角IDを返す参照ポインタ
- * @return 方向が確定した場合TRUE、接近する敵がそもそもいない場合FALSEを返す
+ * @return 方向が確定した場合移動方向のリスト、接近する敵がそもそもいない場合std::nullopt
  */
-static bool get_enemy_dir(PlayerType *player_ptr, MONSTER_IDX m_idx, std::span<Direction> mm)
+static std::optional<MonsterMovementDirectionList> get_enemy_dir(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
@@ -136,26 +135,23 @@ static bool get_enemy_dir(PlayerType *player_ptr, MONSTER_IDX m_idx, std::span<D
         decide_enemy_approch_direction(player_ptr, m_idx, start, plus, &y, &x);
 
         if ((x == 0) && (y == 0)) {
-            return false;
+            return std::nullopt;
         }
     }
 
-    x -= monster.fx;
-    y -= monster.fy;
+    const Pos2D pos(y, x);
+    const auto vec = pos - monster.get_position();
 
-    store_enemy_approch_direction(mm, y, x);
-    return true;
+    return get_enemy_approch_direction(m_idx, vec);
 }
 
 /*!
- * @brief 不規則歩行フラグを持つモンスターの移動方向をその確率に基づいて決定する
+ * @brief 不規則歩行フラグを持つモンスターが不規則な方向に移動するかどうかをその確率に基づいて決定する
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param mm 移動方向
- * @param m_ptr モンスターへの参照ポインタ
- * @return 不規則な方向へ歩くことになったらTRUE
- * @todo "5"とはもしかして「その場に留まる」という意味か？
+ * @param mosnter モンスターへの参照
+ * @return 不規則な方向へ移動するならtrue
  */
-static bool random_walk(PlayerType *player_ptr, std::span<Direction> mm, const MonsterEntity &monster)
+static bool random_walk(PlayerType *player_ptr, const MonsterEntity &monster)
 {
     auto &monrace = monster.get_monrace();
     if (monrace.behavior_flags.has_all_of({ MonsterBehaviorType::RAND_MOVE_50, MonsterBehaviorType::RAND_MOVE_25 }) && evaluate_percent(75)) {
@@ -163,7 +159,6 @@ static bool random_walk(PlayerType *player_ptr, std::span<Direction> mm, const M
             monrace.r_behavior_flags.set({ MonsterBehaviorType::RAND_MOVE_50, MonsterBehaviorType::RAND_MOVE_25 });
         }
 
-        mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
         return true;
     }
 
@@ -172,7 +167,6 @@ static bool random_walk(PlayerType *player_ptr, std::span<Direction> mm, const M
             monrace.r_behavior_flags.set(MonsterBehaviorType::RAND_MOVE_50);
         }
 
-        mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
         return true;
     }
 
@@ -181,7 +175,6 @@ static bool random_walk(PlayerType *player_ptr, std::span<Direction> mm, const M
             monrace.r_behavior_flags.set(MonsterBehaviorType::RAND_MOVE_25);
         }
 
-        mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
         return true;
     }
 
@@ -189,78 +182,74 @@ static bool random_walk(PlayerType *player_ptr, std::span<Direction> mm, const M
 }
 
 /*!
- * @brief ペットや友好的なモンスターがフロアから逃げる処理を行う
+ * @brief ペットの移動方向のリストを決定する
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param mm 移動方向
  * @param m_idx モンスターID
- * @return モンスターがペットであればTRUE
+ * @return ペットであれば移動方向のリスト、そうでなければstd::nullopt
  */
-static bool decide_pet_movement_direction(MonsterSweepGrid *msd, std::span<Direction> mm)
+static std::optional<MonsterMovementDirectionList> decide_pet_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
-    const auto &monster = msd->player_ptr->current_floor_ptr->m_list[msd->m_idx];
+    const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
     if (!monster.is_pet()) {
-        return false;
+        return std::nullopt;
     }
 
-    bool avoid = ((msd->player_ptr->pet_follow_distance < 0) && (monster.cdis <= (0 - msd->player_ptr->pet_follow_distance)));
-    bool lonely = (!avoid && (monster.cdis > msd->player_ptr->pet_follow_distance));
-    bool distant = (monster.cdis > PET_SEEK_DIST);
-    mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
-    if (get_enemy_dir(msd->player_ptr, msd->m_idx, mm)) {
-        return true;
+    if (const auto mmdl = get_enemy_dir(player_ptr, m_idx)) {
+        return mmdl;
     }
 
+    auto &pet_follow_distance = player_ptr->pet_follow_distance;
+    const auto avoid = ((pet_follow_distance < 0) && (monster.cdis <= (0 - pet_follow_distance)));
+    const auto lonely = (!avoid && (monster.cdis > pet_follow_distance));
+    const auto distant = (monster.cdis > PET_SEEK_DIST);
     if (!avoid && !lonely && !distant) {
-        return true;
+        return MonsterMovementDirectionList::random_move(m_idx);
     }
 
-    POSITION dis = msd->player_ptr->pet_follow_distance;
-    if (msd->player_ptr->pet_follow_distance > PET_SEEK_DIST) {
-        msd->player_ptr->pet_follow_distance = PET_SEEK_DIST;
+    const auto distance_orig = pet_follow_distance;
+    if (pet_follow_distance > PET_SEEK_DIST) {
+        pet_follow_distance = PET_SEEK_DIST;
     }
 
-    (void)msd->get_movable_grid(mm);
-    msd->player_ptr->pet_follow_distance = (int16_t)dis;
-    return true;
+    MonsterSweepGrid msd(player_ptr, m_idx);
+    const auto mmdl = msd.get_movable_grid();
+    pet_follow_distance = distance_orig;
+    return mmdl;
 }
 
 /*!
- * @brief モンスターの移動パターンを決定する
+ * @brief モンスターの移動方向のリストを決定する
  * @param player_ptr プレイヤーへの参照ポインタ
- * @param mm 移動方向
  * @param m_idx モンスターID
  * @param aware モンスターがプレイヤーに気付いているならばTRUE、超隠密状態ならばFALSE
- * @return 移動先が存在すればTRUE
+ * @return 移動方向のリスト。移動しない場合はstd::nullopt
  */
-bool decide_monster_movement_direction(PlayerType *player_ptr, std::span<Direction> mm, MONSTER_IDX m_idx, bool aware)
+std::optional<MonsterMovementDirectionList> decide_monster_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx, bool aware)
 {
     const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
     const auto &monrace = monster.get_monrace();
 
     if (monster.is_confused() || !aware) {
-        mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
-        return true;
+        return MonsterMovementDirectionList::random_move(m_idx);
     }
 
-    if (random_walk(player_ptr, mm, monster)) {
-        return true;
+    if (random_walk(player_ptr, monster)) {
+        return MonsterMovementDirectionList::random_move(m_idx);
     }
 
     if (monrace.behavior_flags.has(MonsterBehaviorType::NEVER_MOVE) && (monster.cdis > 1)) {
-        mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
-        return true;
+        return MonsterMovementDirectionList::random_move(m_idx);
     }
 
-    MonsterSweepGrid msd(player_ptr, m_idx);
-    if (decide_pet_movement_direction(&msd, mm)) {
-        return true;
+    if (const auto mmdl = decide_pet_movement_direction(player_ptr, m_idx)) {
+        return mmdl;
     }
 
     if (!monster.is_hostile()) {
-        mm[0] = mm[1] = mm[2] = mm[3] = Direction::self();
-        get_enemy_dir(player_ptr, m_idx, mm);
-        return true;
+        const auto mmdl = get_enemy_dir(player_ptr, m_idx);
+        return mmdl ? mmdl : MonsterMovementDirectionList::random_move(m_idx);
     }
 
-    return msd.get_movable_grid(mm);
+    MonsterSweepGrid msd(player_ptr, m_idx);
+    return msd.get_movable_grid();
 }

--- a/src/monster-floor/monster-direction.h
+++ b/src/monster-floor/monster-direction.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "monster-floor/monster-movement-direction-list.h"
 #include "system/angband.h"
-#include <span>
+#include <optional>
 
 class Direction;
 class PlayerType;
-bool decide_monster_movement_direction(PlayerType *player_ptr, std::span<Direction> mm, MONSTER_IDX m_idx, bool aware);
+std::optional<MonsterMovementDirectionList> decide_monster_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx, bool aware);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -17,6 +17,7 @@
 #include "grid/grid.h"
 #include "io/files-util.h"
 #include "monster-attack/monster-attack-processor.h"
+#include "monster-floor/monster-movement-direction-list.h"
 #include "monster-floor/monster-object.h"
 #include "monster/monster-describer.h"
 #include "monster/monster-flag-types.h"
@@ -380,19 +381,16 @@ void activate_explosive_rune(PlayerType *player_ptr, const Pos2D &pos, const Mon
  * @brief モンスターの移動に関するメインルーチン
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param turn_flags_ptr ターン経過処理フラグへの参照ポインタ
- * @param m_idx モンスターID
- * @param mm モンスターの移動方向
+ * @param mmdl モンスターの移動方向リスト
  * @param pos モンスターの移動前座標
  * @param count 移動回数 (のはず todo)
  * @return 移動が阻害される何か (ドア等)があったらFALSE
  * @todo 少し長いが、これといってブロックとしてまとまった部分もないので暫定でこのままとする
  */
-bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, std::span<Direction> mm, const Pos2D &pos, int *count)
+bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr, const MonsterMovementDirectionList &mmdl, const Pos2D &pos, int *count)
 {
-    for (const auto &dir : mm) {
-        if (!dir) {
-            return true;
-        }
+    const auto m_idx = mmdl.get_m_idx();
+    for (const auto &dir : mmdl.get_movement_directions()) {
         const auto dir_move = dir.has_direction() ? dir : rand_choice(Direction::directions_8());
         const auto pos_neighbor = pos + dir_move.vec();
         if (!in_bounds2(*player_ptr->current_floor_ptr, pos_neighbor.y, pos_neighbor.x)) {

--- a/src/monster-floor/monster-move.h
+++ b/src/monster-floor/monster-move.h
@@ -2,16 +2,16 @@
 
 #include "system/angband.h"
 #include "util/point-2d.h"
-#include <span>
 
 constexpr auto BREAK_RUNE_PROTECTION = 550; /*!< 守りのルーンの強靭度 / Rune of protection resistance */
 constexpr auto BREAK_RUNE_EXPLOSION = 299; /*!< 爆発のルーンの発動しやすさ / For explosive runes */
 
 class Direction;
 class MonsterEntity;
+class MonsterMovementDirectionList;
 class MonraceDefinition;
 class PlayerType;
 struct turn_flags;
 void activate_explosive_rune(PlayerType *player_ptr, const Pos2D &pos, const MonraceDefinition &monrace);
-bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MONSTER_IDX m_idx, std::span<Direction> mm, const Pos2D &pos, int *count);
+bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr, const MonsterMovementDirectionList &mmdl, const Pos2D &pos, int *count);
 void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSITION ox, bool aware);

--- a/src/monster-floor/monster-movement-direction-list.cpp
+++ b/src/monster-floor/monster-movement-direction-list.cpp
@@ -1,0 +1,63 @@
+#include "monster-floor/monster-movement-direction-list.h"
+#include "floor/geometry.h"
+
+/*!
+ * @brief MonsterMoveクラスのコンストラクタ
+ *
+ * 移動方向のリストが空の状態のインスタンスを生成する
+ *
+ * @param m_idx モンスターの参照インデックス
+ */
+MonsterMovementDirectionList::MonsterMovementDirectionList(MONSTER_IDX m_idx)
+    : m_idx(m_idx)
+{
+}
+
+/*!
+ * @brief ランダムに移動するように設定したMonsterMoveクラスのインスタンスを生成する
+ *
+ * @param m_idx モンスターの参照インデックス
+ * @return 生成したインスタンス
+ */
+MonsterMovementDirectionList MonsterMovementDirectionList::random_move(MONSTER_IDX m_idx)
+{
+    MonsterMovementDirectionList mmdl(m_idx);
+    mmdl.movement_directions.assign(4, Direction::self());
+    return mmdl;
+}
+
+/*!
+ * @brief モンスターの移動方向をリストに追加する
+ * @param move 移動方向
+ */
+void MonsterMovementDirectionList::add_movement_direction(const Direction &dir)
+{
+    this->movement_directions.push_back(dir);
+}
+
+/*!
+ * @brief モンスターの移動方向をリストに追加する
+ * @param moves 移動方向のリスト
+ */
+void MonsterMovementDirectionList::add_movement_directions(std::initializer_list<Direction> dirs)
+{
+    this->movement_directions.insert(this->movement_directions.end(), dirs.begin(), dirs.end());
+}
+
+/*!
+ * @brief モンスターの移動方向のリストを取得する
+ * @return モンスターの移動方向のリスト
+ */
+std::span<const Direction> MonsterMovementDirectionList::get_movement_directions() const
+{
+    return this->movement_directions;
+}
+
+/*!
+ * @brief モンスターの参照インデックスを取得する
+ * @return モンスターの参照インデックス
+ */
+MONSTER_IDX MonsterMovementDirectionList::get_m_idx() const
+{
+    return this->m_idx;
+}

--- a/src/monster-floor/monster-movement-direction-list.h
+++ b/src/monster-floor/monster-movement-direction-list.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "system/angband.h"
+#include <span>
+
+class Direction;
+
+/*!
+ * @brief モンスターの移動方向のリストを管理するクラス
+ */
+class MonsterMovementDirectionList {
+public:
+    explicit MonsterMovementDirectionList(MONSTER_IDX m_idx);
+    static MonsterMovementDirectionList random_move(MONSTER_IDX m_idx);
+
+    void add_movement_direction(const Direction &dir);
+    void add_movement_directions(std::initializer_list<Direction> dirs);
+    std::span<const Direction> get_movement_directions() const;
+    MONSTER_IDX get_m_idx() const;
+
+private:
+    std::vector<Direction> movement_directions; ///< 移動方向のリスト
+    MONSTER_IDX m_idx; ///< モンスターの参照インデックス
+};

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -521,12 +521,11 @@ MonsterSweepGrid::MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx)
 }
 
 /*!
- * @brief モンスターの移動方向を返す
- * @param mm 移動方向を格納する配列への参照
- * @return 有効方向があった場合TRUEを返す
+ * @brief モンスターの移動方向のリストを返す
+ * @return 移動方向のリスト。移動できない場合はstd::nullopt
  * @todo 分割したいが条件が多すぎて適切な関数名と詳細処理を追いきれない……
  */
-bool MonsterSweepGrid::get_movable_grid(std::span<Direction> mm)
+std::optional<MonsterMovementDirectionList> MonsterSweepGrid::get_movable_grid()
 {
     const auto deciders = MonsterMoveGridDecidersFactory::create_deciders(this->player_ptr, this->m_idx);
     auto pos_move = MonsterMoveGridDecider::evalute_deciders(deciders, this->player_ptr->get_position());
@@ -537,10 +536,6 @@ bool MonsterSweepGrid::get_movable_grid(std::span<Direction> mm)
     const auto &floor = *this->player_ptr->current_floor_ptr;
     const auto &monster = floor.m_list[this->m_idx];
     const auto vec = monster.get_position() - pos_move;
-    if (vec == Pos2DVec(0, 0)) {
-        return false;
-    }
 
-    store_moves_val(mm, vec);
-    return true;
+    return get_moves_val(this->m_idx, vec);
 }

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "monster-floor/monster-movement-direction-list.h"
 #include "system/angband.h"
 #include "util/point-2d.h"
 #include <optional>
-#include <span>
 #include <utility>
 
 class Direction;
@@ -13,5 +13,5 @@ public:
     MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx);
     PlayerType *player_ptr;
     MONSTER_IDX m_idx;
-    bool get_movable_grid(std::span<Direction> mm);
+    std::optional<MonsterMovementDirectionList> get_movable_grid();
 };

--- a/src/monster/monster-processor-util.h
+++ b/src/monster/monster-processor-util.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "monster-floor/monster-movement-direction-list.h"
 #include "monster-race/race-ability-flags.h"
 #include "monster-race/race-behavior-flags.h"
 #include "monster-race/race-drop-flags.h"
@@ -16,7 +17,7 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include "util/point-2d.h"
-#include <span>
+#include <optional>
 
 struct turn_flags {
     bool see_m;
@@ -70,5 +71,5 @@ struct coordinate_candidate {
 turn_flags *init_turn_flags(bool is_riding, turn_flags *turn_flags_ptr);
 
 class Direction;
-void store_enemy_approch_direction(std::span<Direction> mm, POSITION y, POSITION x);
-void store_moves_val(std::span<Direction> mm, const Pos2DVec &vec);
+MonsterMovementDirectionList get_enemy_approch_direction(MONSTER_IDX m_idx, const Pos2DVec &vec);
+std::optional<MonsterMovementDirectionList> get_moves_val(MONSTER_IDX m_idx, const Pos2DVec &vec);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -213,13 +213,13 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
         return;
     }
 
-    std::vector<Direction> mm(8, Direction::none());
-    if (!decide_monster_movement_direction(player_ptr, mm, m_idx, turn_flags_ptr->aware)) {
+    const auto mmdl = decide_monster_movement_direction(player_ptr, m_idx, turn_flags_ptr->aware);
+    if (!mmdl) {
         return;
     }
 
     int count = 0;
-    if (!process_monster_movement(player_ptr, turn_flags_ptr, m_idx, mm, { oy, ox }, &count)) {
+    if (!process_monster_movement(player_ptr, turn_flags_ptr, *mmdl, { oy, ox }, &count)) {
         return;
     }
 


### PR DESCRIPTION
Resolves #5004 

MonsterMoveListクラスを実装し、現在生の std::vector<Direction> とその 参照で持ち回っているモンスターの移動方向のリストを、MonsterMoveListクラスで管理するようにする。