### PR TITLE
Targetクラスを実装し、グローバル変数 target_who/target_row/target_col を廃止して代わりにTargetクラスを使用する その2

### DIFF
--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -376,7 +376,7 @@ static void process_game_turn(PlayerType *player_ptr)
         world.character_xtra = true;
         handle_stuff(player_ptr);
         world.character_xtra = false;
-        target_who = 0;
+        Target::clear_last_target();
         health_track(player_ptr, 0);
         forget_lite(floor);
         forget_view(floor);

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -102,7 +102,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     command_arg = 0;
     command_dir = Direction::none();
 
-    target_who = 0;
+    Target::clear_last_target();
     player_ptr->pet_t_m_idx = 0;
     player_ptr->riding_t_m_idx = 0;
     player_ptr->ambush_flag = false;

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -125,10 +125,7 @@ bool rush_attack(PlayerType *player_ptr, bool *mdeath)
     }
 
     const auto p_pos = player_ptr->get_position();
-    auto pos_target = p_pos + dir.vec() * project_length;
-    if (dir.is_targetting() && target_okay(player_ptr)) {
-        pos_target = { target_row, target_col };
-    }
+    const auto pos_target = dir.get_target_position(p_pos, project_length);
 
     auto tm_idx = 0;
     auto &floor = *player_ptr->current_floor_ptr;

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -53,8 +53,9 @@ void delete_monster_idx(PlayerType *player_ptr, short m_idx)
         (void)set_monster_invulner(player_ptr, m_idx, 0, false);
     }
 
-    if (m_idx == target_who) {
-        target_who = 0;
+    const auto target_m_idx = Target::get_last_target().get_m_idx();
+    if (m_idx == target_m_idx) {
+        Target::clear_last_target();
     }
 
     if (HealthBarTracker::get_instance().is_tracking(m_idx)) {
@@ -118,7 +119,7 @@ void wipe_monsters_list(PlayerType *player_ptr)
     floor.m_cnt = 0;
     floor.reset_mproc_max();
     floor.num_repro = 0;
-    target_who = 0;
+    Target::clear_last_target();
     player_ptr->pet_t_m_idx = 0;
     player_ptr->riding_t_m_idx = 0;
     health_track(player_ptr, 0);

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -255,11 +255,9 @@ public:
         const auto p_pos = this->player_ptr->get_position();
         const auto m_pos = monster.get_position();
 
-        /// @todo std::views::enumerate
-        constexpr auto directions = Direction::directions_8();
         for (auto i = 0; i < 8; i++) {
             const auto d = (this->m_idx + i) & 7;
-            const auto pos_move = p_pos + directions[d].vec();
+            const auto pos_move = p_pos + Direction::directions_8()[d].vec();
             if (m_pos == pos_move) {
                 // プレイヤーを攻撃する
                 return p_pos;

--- a/src/monster/monster-compaction.cpp
+++ b/src/monster/monster-compaction.cpp
@@ -43,8 +43,9 @@ static void compact_monsters_aux(PlayerType *player_ptr, MONSTER_IDX i1, MONSTER
         o_ptr->held_m_idx = i2;
     }
 
-    if (target_who == i1) {
-        target_who = i2;
+    const auto target_m_idx = Target::get_last_target().get_m_idx();
+    if (target_m_idx == i1) {
+        Target::set_last_target(Target::create_monster_target(player_ptr, i2));
     }
 
     if (player_ptr->pet_t_m_idx == i1) {

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -138,13 +138,9 @@ bool ObjectThrowEntity::calc_throw_grid()
         return false;
     }
 
-    const auto vec = dir.vec();
-    this->tx = this->player_ptr->x + 99 * vec.x;
-    this->ty = this->player_ptr->y + 99 * vec.y;
-    if (dir.is_targetting() && target_okay(this->player_ptr)) {
-        this->tx = target_col;
-        this->ty = target_row;
-    }
+    const auto pos_target = dir.get_target_position(this->player_ptr->get_position(), 99);
+    this->tx = pos_target.x;
+    this->ty = pos_target.y;
 
     project_length = 0;
     return true;

--- a/src/specific-object/death-crimson.cpp
+++ b/src/specific-object/death-crimson.cpp
@@ -26,11 +26,7 @@ static bool fire_crimson(PlayerType *player_ptr)
         return false;
     }
 
-    auto [ty, tx] = player_ptr->get_position() + dir.vec() * 99;
-    if (dir.is_targetting() && target_okay(player_ptr)) {
-        tx = target_col;
-        ty = target_row;
-    }
+    const auto [ty, tx] = dir.get_target_position(player_ptr->get_position(), 99);
 
     int num = 1;
     if (PlayerClass(player_ptr).equals(PlayerClassType::ARCHER)) {

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -199,13 +199,13 @@ void SpellsMirrorMaster::seal_of_mirror(const int dam)
 
 void SpellsMirrorMaster::seeker_ray(const Direction &dir, int dam)
 {
-    const auto pos = (dir.is_targetting() && target_okay(this->player_ptr)) ? Pos2D(target_row, target_col) : this->player_ptr->get_neighbor(dir);
+    const auto pos = dir.get_target_position(this->player_ptr->get_position());
     project_seeker_ray(pos.x, pos.y, dam);
 }
 
 void SpellsMirrorMaster::super_ray(const Direction &dir, int dam)
 {
-    const auto pos = (dir.is_targetting() && target_okay(this->player_ptr)) ? Pos2D(target_row, target_col) : this->player_ptr->get_neighbor(dir);
+    const auto pos = dir.get_target_position(this->player_ptr->get_position());
     project_super_ray(pos.x, pos.y, dam);
 }
 

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -44,8 +44,8 @@ void fetch_item(PlayerType *player_ptr, const Direction &dir, WEIGHT wgt, bool r
 
     Grid *grid_ptr;
     const auto &system = AngbandSystem::get_instance();
-    if (dir.is_targetting() && target_okay(player_ptr)) {
-        const Pos2D pos(target_row, target_col);
+    if (dir.is_target_okay()) {
+        const auto pos = dir.get_target_position(p_pos);
         if (Grid::calc_distance(p_pos, pos) > system.get_max_range()) {
             msg_print(_("そんなに遠くにある物は取れません！", "You can't fetch something that far away!"));
             return;

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -72,7 +72,8 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     auto &monster = floor.m_list[grid.m_idx];
     MonraceId new_r_idx;
     MonraceId old_r_idx = monster.r_idx;
-    bool targeted = target_who == grid.m_idx;
+    const auto target_m_idx = Target::get_last_target().get_m_idx();
+    const auto targeted = target_m_idx == grid.m_idx;
     auto health_tracked = HealthBarTracker::get_instance().is_tracking(grid.m_idx);
 
     if (floor.inside_arena || AngbandSystem::get_instance().is_phase_out()) {
@@ -134,7 +135,11 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
     }
 
     if (targeted) {
-        target_who = m_idx.value_or(0);
+        if (m_idx) {
+            Target::set_last_target(Target::create_monster_target(player_ptr, *m_idx));
+        } else {
+            Target::clear_last_target();
+        }
     }
     if (health_tracked) {
         health_track(player_ptr, m_idx.value_or(0));

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -46,7 +46,7 @@
  */
 bool teleport_swap(PlayerType *player_ptr, const Direction &dir)
 {
-    const auto pos = (dir.is_targetting() && target_okay(player_ptr)) ? Pos2D(target_row, target_col) : player_ptr->get_neighbor(dir);
+    const auto pos = dir.get_target_position(player_ptr->get_position());
     if (player_ptr->anti_tele) {
         msg_print(_("不思議な力がテレポートを防いだ！", "A mysterious force prevents you from teleporting!"));
         return false;

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -37,10 +37,7 @@ bool cast_wrath_of_the_god(PlayerType *player_ptr, int dam, POSITION rad)
     }
 
     const auto p_pos = player_ptr->get_position();
-    auto pos_target = p_pos + dir.vec() * 99;
-    if (dir.is_targetting() && target_okay(player_ptr)) {
-        pos_target = { target_row, target_col };
-    }
+    auto pos_target = dir.get_target_position(p_pos, 99);
 
     auto pos = p_pos;
     auto &floor = *player_ptr->current_floor_ptr;

--- a/src/target/target-checker.cpp
+++ b/src/target/target-checker.cpp
@@ -133,27 +133,3 @@ void verify_panel(PlayerType *player_ptr)
     };
     rfu.set_flags(flags);
 }
-
-/*
- * Update (if necessary) and verify (if possible) the target.
- * We return TRUE if the target is "okay" and FALSE otherwise.
- */
-bool target_okay(PlayerType *player_ptr)
-{
-    if (target_who < 0) {
-        return true;
-    }
-
-    if (target_who <= 0) {
-        return false;
-    }
-
-    if (!target_able(player_ptr, target_who)) {
-        return false;
-    }
-
-    const auto &monster = player_ptr->current_floor_ptr->m_list[target_who];
-    target_row = monster.fy;
-    target_col = monster.fx;
-    return true;
-}

--- a/src/target/target-checker.h
+++ b/src/target/target-checker.h
@@ -1,11 +1,4 @@
 #pragma once
 
-#include "system/angband.h"
-
-extern MONSTER_IDX target_who;
-extern POSITION target_col;
-extern POSITION target_row;
-
 class PlayerType;
 void verify_panel(PlayerType *player_ptr);
-bool target_okay(PlayerType *player_ptr);

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -32,6 +32,7 @@
 Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
 {
     auto dir = Direction::none();
+    auto target = Target::get_last_target();
     if (enable_repeat) {
         dir = command_dir;
         auto try_old_target = use_old_target;
@@ -46,19 +47,14 @@ Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
             }
         }
 
-        if (try_old_target && target_okay(player_ptr)) {
-            if (target_who > 0) {
-                dir = Direction::targetting(Target(player_ptr, Target::Monster{ target_who }));
-            }
-            if (target_who < 0) {
-                dir = Direction::targetting(Target(player_ptr, Target::Grid{ { target_row, target_col } }));
-            }
+        if (try_old_target && target.is_okay()) {
+            dir = Direction::targetting(target);
         }
     }
 
     while (!dir) {
         const auto prompt =
-            target_okay(player_ptr)
+            target.is_okay()
                 ? _("方向 ('5'でターゲットへ, '*'でターゲット再選択, ESCで中断)? ", "Direction ('5' for target, '*' to re-target, Escape to cancel)? ")
                 : _("方向 ('*'でターゲット選択, ESCで中断)? ", "Direction ('*' to choose a target, Escape to cancel)? ");
 
@@ -77,15 +73,10 @@ Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
         static const std::unordered_set target_commands = { '*', ' ', '\r', 'T', 't', '.', '5', '0', '*' };
         if (target_commands.contains(command)) {
             if (select_new_target_commands.contains(command)) {
-                target_set(player_ptr, TARGET_KILL);
+                target = target_set(player_ptr, TARGET_KILL);
             }
-            if (target_okay(player_ptr)) {
-                if (target_who > 0) {
-                    dir = Direction::targetting(Target(player_ptr, Target::Monster{ target_who }));
-                }
-                if (target_who < 0) {
-                    dir = Direction::targetting(Target(player_ptr, Target::Grid{ { target_row, target_col } }));
-                }
+            if (target.is_okay()) {
+                dir = Direction::targetting(target);
             }
         } else {
             dir = get_keymap_dir(command);

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -47,7 +47,12 @@ Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
         }
 
         if (try_old_target && target_okay(player_ptr)) {
-            dir = Direction::targetting();
+            if (target_who > 0) {
+                dir = Direction::targetting(Target(player_ptr, Target::Monster{ target_who }));
+            }
+            if (target_who < 0) {
+                dir = Direction::targetting(Target(player_ptr, Target::Grid{ { target_row, target_col } }));
+            }
         }
     }
 
@@ -75,7 +80,12 @@ Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
                 target_set(player_ptr, TARGET_KILL);
             }
             if (target_okay(player_ptr)) {
-                dir = Direction::targetting();
+                if (target_who > 0) {
+                    dir = Direction::targetting(Target(player_ptr, Target::Monster{ target_who }));
+                }
+                if (target_who < 0) {
+                    dir = Direction::targetting(Target(player_ptr, Target::Grid{ { target_row, target_col } }));
+                }
             }
         } else {
             dir = get_keymap_dir(command);

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -110,7 +110,7 @@ static bool is_revealed_wall(const FloorType &floor, const Pos2D &pos)
         return true;
     }
 
-    constexpr auto dirs = Direction::directions_8();
+    const auto dirs = Direction::directions_8();
     const auto num_of_walls = std::count_if(dirs.begin(), dirs.end(),
         [&floor, &pos](const auto &d) {
             const auto pos_neighbor = pos + d.vec();

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -190,11 +190,13 @@ void wiz_summon_horde(PlayerType *player_ptr)
  */
 void wiz_teleport_back(PlayerType *player_ptr)
 {
-    if (!target_who) {
+    const auto target = Target::get_last_target();
+    const auto pos = target.get_position();
+    if (!pos || !target.get_m_idx()) {
         return;
     }
 
-    teleport_player_to(player_ptr, target_row, target_col, TELEPORT_NONMAGICAL);
+    teleport_player_to(player_ptr, pos->y, pos->x, TELEPORT_NONMAGICAL);
 }
 
 /*!


### PR DESCRIPTION
#4993 続き。

DirectionクラスにTargetを持たせるようにし、get_aim_dir() 後の各種処理で方向ではなく特定ターゲットを目標とする時に使用するようにすることで、グローバル変数 target_who/target_row/target_col を参照せずにすむようにしました。
また、グローバル変数 target_who/target_row/target_col は廃止したうえで、前回狙ったターゲットを引き継ぐ処理のために静的変数（前コミットで追加済）を使用するようにします。