### PR TITLE
ターゲット座標のYとXが逆だったのを修正した

### DIFF
--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -45,7 +45,7 @@ void fetch_item(PlayerType *player_ptr, const Direction &dir, WEIGHT wgt, bool r
     Grid *grid_ptr;
     const auto &system = AngbandSystem::get_instance();
     if (dir.is_targetting() && target_okay(player_ptr)) {
-        const Pos2D pos(target_col, target_row);
+        const Pos2D pos(target_row, target_col);
         if (Grid::calc_distance(p_pos, pos) > system.get_max_range()) {
             msg_print(_("そんなに遠くにある物は取れません！", "You can't fetch something that far away!"));
             return;

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -39,7 +39,7 @@ bool cast_wrath_of_the_god(PlayerType *player_ptr, int dam, POSITION rad)
     const auto p_pos = player_ptr->get_position();
     auto pos_target = p_pos + dir.vec() * 99;
     if (dir.is_targetting() && target_okay(player_ptr)) {
-        pos_target = { target_col, target_row };
+        pos_target = { target_row, target_col };
     }
 
     auto pos = p_pos;


### PR DESCRIPTION
エンバグの時期は調べてませんがrowとcolが逆でした
未報告ですが神の怒りも似たような問題を起こすことが分かったので併せて修正済です
ご確認下さい