### PR TITLE
EnumRangeとRectangle2Dをrangeコンセプトに対応させる

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -21,6 +21,7 @@
 #include <ostream>
 #include <queue>
 #include <random>
+#include <range/v3/all.hpp>
 #include <set>
 #include <span>
 #include <sstream>

--- a/src/util/enum-range.h
+++ b/src/util/enum-range.h
@@ -2,6 +2,7 @@
 
 #include <concepts>
 #include <iterator>
+#include <range/v3/range/concepts.hpp>
 #include <type_traits>
 
 /*!
@@ -22,6 +23,8 @@ public:
         using difference_type = int;
         using value_type = EnumType;
         using iterator_concept = std::input_iterator_tag;
+
+        constexpr iterator() noexcept = default;
 
         /*!
          * @brief 引数で与えた列挙値を指すイテレータオブジェクトを生成する
@@ -215,3 +218,10 @@ public:
 private:
     EnumRange<EnumType> range;
 };
+
+namespace ranges {
+template <typename T>
+inline constexpr bool enable_view<EnumRange<T>> = true;
+template <typename T>
+inline constexpr bool enable_view<EnumRangeInclusive<T>> = true;
+}

--- a/src/util/point-2d.h
+++ b/src/util/point-2d.h
@@ -217,8 +217,9 @@ struct Rectangle2D {
         using value_type = Point2D<T>;
         using iterator_category = std::input_iterator_tag;
 
-        constexpr iterator(const Rectangle2D *rect, const value_type &pos_cur) noexcept
-            : rect(rect)
+        constexpr iterator(const Rectangle2D &rect, const value_type &pos_cur) noexcept
+            : pos_top_left(rect.top_left)
+            , pos_bottom_right(rect.bottom_right)
             , pos_cur(pos_cur)
         {
         }
@@ -230,10 +231,10 @@ struct Rectangle2D {
 
         constexpr iterator &operator++() noexcept
         {
-            if (this->pos_cur.x < this->rect->bottom_right.x) {
+            if (this->pos_cur.x < this->pos_bottom_right.x) {
                 ++(this->pos_cur.x);
             } else {
-                this->pos_cur.x = this->rect->top_left.x;
+                this->pos_cur.x = this->pos_top_left.x;
                 ++(this->pos_cur.y);
             }
             return *this;
@@ -245,18 +246,19 @@ struct Rectangle2D {
         }
 
     private:
-        const Rectangle2D *rect;
+        value_type pos_top_left;
+        value_type pos_bottom_right;
         value_type pos_cur;
     };
 
     constexpr iterator begin() const noexcept
     {
-        return iterator(this, this->top_left);
+        return iterator(*this, this->top_left);
     }
 
     constexpr iterator end() const noexcept
     {
-        return iterator(this, Point2D<T>(this->bottom_right.y + 1, this->top_left.x));
+        return iterator(*this, Point2D<T>(this->bottom_right.y + 1, this->top_left.x));
     }
 };
 

--- a/src/util/point-2d.h
+++ b/src/util/point-2d.h
@@ -3,7 +3,9 @@
 #include "system/h-type.h"
 #include <algorithm>
 #include <concepts>
+#include <iterator>
 #include <numeric>
+#include <range/v3/range/concepts.hpp>
 #include <type_traits>
 
 /**
@@ -50,6 +52,9 @@ template <typename T>
 struct Point2D {
     T y{};
     T x{};
+
+    constexpr Point2D() = default;
+
     constexpr Point2D(T y, T x)
         : y(y)
         , x(x)
@@ -161,6 +166,9 @@ template <std::integral T>
 struct Rectangle2D {
     Point2D<T> top_left;
     Point2D<T> bottom_right;
+
+    constexpr Rectangle2D() = default;
+
     constexpr Rectangle2D(T y1, T x1, T y2, T x2)
         : top_left(std::min<T>(y1, y2), std::min<T>(x1, x2))
         , bottom_right(std::max<T>(y1, y2), std::max<T>(x1, x2))
@@ -214,8 +222,11 @@ struct Rectangle2D {
     /// @brief 長方形内の座標を走査するイテレータ
     class iterator {
     public:
+        using difference_type = T;
         using value_type = Point2D<T>;
-        using iterator_category = std::input_iterator_tag;
+        using iterator_concept = std::input_iterator_tag;
+
+        constexpr iterator() noexcept = default;
 
         constexpr iterator(const Rectangle2D &rect, const value_type &pos_cur) noexcept
             : pos_top_left(rect.top_left)
@@ -240,6 +251,13 @@ struct Rectangle2D {
             return *this;
         }
 
+        constexpr iterator operator++(int) noexcept
+        {
+            auto old = *this;
+            ++*this;
+            return old;
+        }
+
         constexpr bool operator==(const iterator &other) const noexcept
         {
             return this->pos_cur == other.pos_cur;
@@ -251,6 +269,8 @@ struct Rectangle2D {
         value_type pos_cur;
     };
 
+    using const_iterator = iterator;
+
     constexpr iterator begin() const noexcept
     {
         return iterator(*this, this->top_left);
@@ -261,6 +281,11 @@ struct Rectangle2D {
         return iterator(*this, Point2D<T>(this->bottom_right.y + 1, this->top_left.x));
     }
 };
+
+namespace ranges {
+template <typename T>
+inline constexpr bool enable_view<Rectangle2D<T>> = true;
+}
 
 //! ゲームの平面マップ上の座標位置を表す構造体
 using Pos2D = Point2D<POSITION>;


### PR DESCRIPTION
#4926 に関連

この修正により、EnumRangeやRectangle2Dをrange-v3の各種APIにわたすことが可能になります。