### PR TITLE
[Refactor] earthquake()のシグネチャ変更

### DIFF
--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -221,7 +221,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         return true;
     }
     case PlayerMutationType::EARTHQUAKE:
-        (void)earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
+        (void)earthquake(player_ptr, player_ptr->get_position(), 10);
         return true;
     case PlayerMutationType::EAT_MAGIC:
         return eat_magic(player_ptr, player_ptr->lev * 2);

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -269,7 +269,7 @@ int staff_effect(PlayerType *player_ptr, int sval, bool *use_charge, bool powerf
     }
 
     case SV_STAFF_EARTHQUAKES: {
-        if (earthquake(player_ptr, player_ptr->y, player_ptr->x, (powerful ? 15 : 10), 0)) {
+        if (earthquake(player_ptr, player_ptr->get_position(), (powerful ? 15 : 10))) {
             ident = true;
         } else {
             msg_print(_("ダンジョンが揺れた。", "The dungeon trembles."));

--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -248,7 +248,7 @@ void decide_monster_attack_effect(PlayerType *player_ptr, mam_type *mam_ptr)
     case RaceBlowEffectType::SHATTER:
         mam_ptr->damage -= (mam_ptr->damage * ((mam_ptr->ac < 150) ? mam_ptr->ac : 150) / 250);
         if (mam_ptr->damage > 23) {
-            earthquake(player_ptr, mam_ptr->m_ptr->fy, mam_ptr->m_ptr->fx, 8, mam_ptr->m_idx);
+            earthquake(player_ptr, mam_ptr->m_ptr->get_position(), 8, mam_ptr->m_idx);
         }
 
         break;
@@ -291,7 +291,7 @@ void decide_monster_attack_effect(PlayerType *player_ptr, mam_type *mam_ptr)
             if (floor.is_underground() && (!floor.is_in_quest() || !QuestType::is_fixed(floor.quest_number))) {
                 if (mam_ptr->damage > 23) {
                     msg_print(_("カオスの力でダンジョンが崩れ始める！", "The dungeon tumbles by the chaotic power!"));
-                    earthquake(player_ptr, mam_ptr->m_ptr->fy, mam_ptr->m_ptr->fx, 8, mam_ptr->m_idx);
+                    earthquake(player_ptr, mam_ptr->m_ptr->get_position(), 8, mam_ptr->m_idx);
                 }
             }
         }

--- a/src/mind/mind-berserker.cpp
+++ b/src/mind/mind-berserker.cpp
@@ -70,7 +70,7 @@ bool cast_berserk_spell(PlayerType *player_ptr, MindBerserkerType spell)
         return true;
     }
     case MindBerserkerType::QUAKE:
-        earthquake(player_ptr, player_ptr->y, player_ptr->x, 8 + randint0(5), 0);
+        earthquake(player_ptr, player_ptr->get_position(), 8 + randint0(5));
         return true;
     case MindBerserkerType::MASSACRE:
         massacre(player_ptr);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1509,7 +1509,7 @@ bool switch_element_execution(PlayerType *player_ptr)
         reserve_alter_reality(player_ptr, randint0(21) + 15);
         return true;
     case ElementRealmType::EARTH:
-        (void)earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
+        (void)earthquake(player_ptr, player_ptr->get_position(), 10);
         return true;
     case ElementRealmType::DEATH:
         if (player_ptr->current_floor_ptr->num_repro <= MAX_REPRODUCTION) {

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -489,7 +489,7 @@ void switch_monster_blow_to_player(PlayerType *player_ptr, MonsterAttackPlayer *
         monap_ptr->damage -= (monap_ptr->damage * ((monap_ptr->ac < 150) ? monap_ptr->ac : 150) / 250);
         monap_ptr->get_damage += take_hit(player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (monap_ptr->damage > 23 || monap_ptr->explode) {
-            earthquake(player_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, 8, monap_ptr->m_idx);
+            earthquake(player_ptr, monap_ptr->m_ptr->get_position(), 8, monap_ptr->m_idx);
         }
 
         break;
@@ -566,7 +566,7 @@ void switch_monster_blow_to_player(PlayerType *player_ptr, MonsterAttackPlayer *
             if (floor.is_underground() && (!floor.is_in_quest() || !QuestType::is_fixed(floor.quest_number))) {
                 if (monap_ptr->damage > 23 || monap_ptr->explode) {
                     msg_print(_("カオスの力でダンジョンが崩れ始める！", "The dungeon tumbles by the chaotic power!"));
-                    earthquake(player_ptr, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, 8, monap_ptr->m_idx);
+                    earthquake(player_ptr, monap_ptr->m_ptr->get_position(), 8, monap_ptr->m_idx);
                     break;
                 }
             }

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -316,7 +316,7 @@ bool activate_door_destroy(PlayerType *player_ptr)
 
 bool activate_earthquake(PlayerType *player_ptr)
 {
-    earthquake(player_ptr, player_ptr->y, player_ptr->x, 5, 0);
+    earthquake(player_ptr, player_ptr->get_position(), 5);
     return true;
 }
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -504,7 +504,7 @@ static void cause_earthquake(PlayerType *player_ptr, player_attack_type *pa_ptr,
         return;
     }
 
-    earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
+    earthquake(player_ptr, player_ptr->get_position(), 10);
     if (!player_ptr->current_floor_ptr->grid_array[y][x].has_monster()) {
         *(pa_ptr->mdeath) = true;
     }

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -453,7 +453,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             if (floor.get_grid(pos).has_monster()) {
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_QUAKE);
             } else {
-                earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
+                earthquake(player_ptr, player_ptr->get_position(), 10);
             }
         }
         break;

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -372,7 +372,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         }
 
         if (cast) {
-            earthquake(player_ptr, player_ptr->y, player_ptr->x, rad, 0);
+            earthquake(player_ptr, player_ptr->get_position(), rad);
         }
     } break;
 
@@ -475,7 +475,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
 
         if (cast) {
             dispel_monsters(player_ptr, d_dam);
-            earthquake(player_ptr, player_ptr->y, player_ptr->x, q_rad, 0);
+            earthquake(player_ptr, player_ptr->get_position(), q_rad);
             project(player_ptr, 0, b_rad, player_ptr->y, player_ptr->x, b_dam, AttributeType::DISINTEGRATE, PROJECT_KILL | PROJECT_ITEM);
         }
     } break;

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -683,7 +683,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
             }
 
             if (cont) {
-                earthquake(player_ptr, player_ptr->y, player_ptr->x, 10, 0);
+                earthquake(player_ptr, player_ptr->get_position(), 10);
             }
         }
 

--- a/src/spell-kind/blood-curse.cpp
+++ b/src/spell-kind/blood-curse.cpp
@@ -31,7 +31,7 @@ void blood_curse_to_enemy(PlayerType *player_ptr, MONSTER_IDX m_idx)
         case 2:
             if (!count) {
                 msg_print(_("地面が揺れた...", "The ground trembles..."));
-                earthquake(player_ptr, monster.fy, monster.fx, 4 + randint0(4), 0);
+                earthquake(player_ptr, monster.get_position(), 4 + randint0(4), 0); // 血の呪いによる地震なのでm_idxではなく0を渡す
                 if (!one_in_(6)) {
                     break;
                 }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -337,28 +337,29 @@ void set_redrawing_flags()
 /*!
  * @brief 地震処理
  * Induce an "earthquake" of the given radius at the given location.
- * @param player_ptrプレイヤーへの参照ポインタ
- * @param cy 中心Y座標
- * @param cx 中心X座標
- * @param r 効果半径
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param center 中心座標
+ * @param radius 効果半径
  * @param m_idx 地震を起こしたモンスターID(0ならばプレイヤー)
  * @return 効力があった場合TRUEを返す
+ * @note 効果半径は15に制限される。
+ * 現状効果半径が15より大きく設定されているのは自然の脅威による地震(半径 20+(レベル/2)、でかすぎ)のみ。
  */
-bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MONSTER_IDX m_idx)
+bool earthquake(PlayerType *player_ptr, const Pos2D &center, int radius, MONSTER_IDX m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     if ((floor.is_in_quest() && QuestType::is_fixed(floor.quest_number)) || !floor.is_underground()) {
         return false;
     }
 
-    if (r > 15) {
-        r = 15;
+    if (radius > 15) {
+        radius = 15;
     }
 
-    const auto earthquake_area = get_earthquake_area(floor, { cy, cx }, r);
+    const auto earthquake_area = get_earthquake_area(floor, center, radius);
     reset_grid_info(floor, earthquake_area);
 
-    auto pos_collapses = decide_collapse_positions(floor, earthquake_area, { cy, cx });
+    auto pos_collapses = decide_collapse_positions(floor, earthquake_area, center);
     process_hit_to_player(player_ptr, pos_collapses, m_idx);
     process_hit_to_monsters(player_ptr, pos_collapses);
 

--- a/src/spell-kind/earthquake.h
+++ b/src/spell-kind/earthquake.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
+#include "util/point-2d.h"
 
 class PlayerType;
-bool earthquake(PlayerType *player_ptr, POSITION cy, POSITION cx, POSITION r, MONSTER_IDX m_idx);
+bool earthquake(PlayerType *player_ptr, const Pos2D &center, int radius, MONSTER_IDX m_idx = 0);

--- a/src/spell-kind/spells-neighbor.cpp
+++ b/src/spell-kind/spells-neighbor.cpp
@@ -147,7 +147,7 @@ void wall_breaker(PlayerType *player_ptr)
     }
 
     if (randint1(100) > 30) {
-        earthquake(player_ptr, player_ptr->y, player_ptr->x, 1, 0);
+        earthquake(player_ptr, player_ptr->get_position(), 1);
         return;
     }
 

--- a/src/spell-kind/spells-random.cpp
+++ b/src/spell-kind/spells-random.cpp
@@ -108,7 +108,7 @@ bool activate_ty_curse(PlayerType *player_ptr, bool stop_ty, int *count)
         case 29:
             if (!(*count)) {
                 msg_print(_("地面が揺れた...", "The ground trembles..."));
-                earthquake(player_ptr, player_ptr->y, player_ptr->x, 5 + randint0(10), 0);
+                earthquake(player_ptr, player_ptr->get_position(), 5 + randint0(10));
                 if (!one_in_(6)) {
                     break;
                 }
@@ -309,7 +309,7 @@ void wild_magic(PlayerType *player_ptr, int spell)
         aggravate_monsters(player_ptr, 0);
         break;
     case 26:
-        earthquake(player_ptr, player_ptr->y, player_ptr->x, 5, 0);
+        earthquake(player_ptr, player_ptr->get_position(), 5);
         break;
     case 27:
     case 28:
@@ -478,7 +478,7 @@ void cast_wonder(PlayerType *player_ptr, const Direction &dir)
     }
 
     if (die < 104) {
-        earthquake(player_ptr, player_ptr->y, player_ptr->x, 12, 0);
+        earthquake(player_ptr, player_ptr->get_position(), 12);
         return;
     }
 

--- a/src/spell-realm/spells-trump.cpp
+++ b/src/spell-realm/spells-trump.cpp
@@ -156,7 +156,7 @@ void cast_shuffle(PlayerType *player_ptr)
 
     if (die < 80) {
         msg_print(_("《塔》だ。", "It's the Tower."));
-        earthquake(player_ptr, player_ptr->y, player_ptr->x, 5, 0);
+        earthquake(player_ptr, player_ptr->get_position(), 5);
         return;
     }
 

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -516,7 +516,7 @@ void cast_invoke_spirits(PlayerType *player_ptr, const Direction &dir)
     } else if (die < 101) {
         hypodynamic_bolt(player_ptr, dir, 100 + plev);
     } else if (die < 104) {
-        earthquake(player_ptr, player_ptr->y, player_ptr->x, 12, 0);
+        earthquake(player_ptr, player_ptr->get_position(), 12);
     } else if (die < 106) {
         (void)destroy_area(player_ptr, player_ptr->y, player_ptr->x, 13 + randint0(5), false);
     } else if (die < 108) {


### PR DESCRIPTION
#4846 関連作業。

中心座標をy, x別々でなくPos2D型で受け取る。
また、ほとんどがプレイヤーによる地震なので引数m_idxのデフォルトを0とする。