### PR TITLE
[Fix] {fmt}におけるSJISのダメ文字問題

### DIFF
--- a/src/external-lib/include/fmt/base.h
+++ b/src/external-lib/include/fmt/base.h
@@ -1616,12 +1616,23 @@ FMT_CONSTEXPR FMT_INLINE auto parse_replacement_field(const Char* begin,
   return begin + 1;
 }
 
+FMT_CONSTEXPR bool is_sjis_multibyte_char(char c) {
+  const auto ch = static_cast<unsigned char>(c);
+  return (0x81 <= ch && ch <= 0x9f) || (0xe0 <= ch && ch <= 0xfc);
+}
+
 template <typename Char, typename Handler>
 FMT_CONSTEXPR void parse_format_string(basic_string_view<Char> fmt,
                                        Handler&& handler) {
   auto begin = fmt.data(), end = begin + fmt.size();
   auto p = begin;
   while (p != end) {
+#ifdef WINDOWS
+    if (is_sjis_multibyte_char(*p)) {
+      p += 2;
+      continue;
+    }
+#endif
     auto c = *p++;
     if (c == '{') {
       handler.on_text(begin, p - 1);


### PR DESCRIPTION
'{' や '}' を含むSJISの文字が渡されると誤動作を起こすのでその対策として書式のパース中にSJIS文字が現れたら飛ばすようにする。

Resolves #5023