### PR TITLE
[Refactor] PlayerType::inventory_list を inventory に改名

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -144,11 +144,11 @@ void exe_movement(PlayerType *player_ptr, const Direction &dir, bool do_pickup, 
     // @todo 「特定の武器を装備している」旨のメソッドを別途作る
     constexpr auto stormbringer = FixedArtifactId::STORMBRINGER;
     auto is_stormbringer = false;
-    if (player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(stormbringer)) {
+    if (player_ptr->inventory[INVEN_MAIN_HAND].is_specific_artifact(stormbringer)) {
         is_stormbringer = true;
     }
 
-    if (player_ptr->inventory_list[INVEN_SUB_HAND].is_specific_artifact(stormbringer)) {
+    if (player_ptr->inventory[INVEN_SUB_HAND].is_specific_artifact(stormbringer)) {
         is_stormbringer = true;
     }
 

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -163,7 +163,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         return true;
     case PlayerMutationType::DET_CURSE:
         for (int i = 0; i < INVEN_TOTAL; i++) {
-            auto *o_ptr = &player_ptr->inventory_list[i];
+            auto *o_ptr = &player_ptr->inventory[i];
             if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
                 continue;
             }

--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -68,7 +68,7 @@ PERCENTAGE racial_chance(PlayerType *player_ptr, rpi_type *rpi_ptr)
     }
 
     auto special_easy = PlayerClass(player_ptr).equals(PlayerClassType::IMITATOR);
-    special_easy &= player_ptr->inventory_list[INVEN_NECK].is_specific_artifact(FixedArtifactId::GOGO_PENDANT);
+    special_easy &= player_ptr->inventory[INVEN_NECK].is_specific_artifact(FixedArtifactId::GOGO_PENDANT);
     special_easy &= rpi_ptr->racial_name == _("倍返し", "Double Revenge");
     if (special_easy) {
         difficulty -= 12;

--- a/src/action/weapon-shield.cpp
+++ b/src/action/weapon-shield.cpp
@@ -28,7 +28,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
             return;
         }
 
-        const auto &item_sub_hand = player_ptr->inventory_list[INVEN_SUB_HAND];
+        const auto &item_sub_hand = player_ptr->inventory[INVEN_SUB_HAND];
         item_name = describe_flavor(player_ptr, item_sub_hand, 0);
 
         if (item_sub_hand.is_cursed()) {
@@ -38,7 +38,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
             return;
         }
 
-        auto &item_main_hand = player_ptr->inventory_list[INVEN_MAIN_HAND];
+        auto &item_main_hand = player_ptr->inventory[INVEN_MAIN_HAND];
         item_main_hand = item_sub_hand.clone();
         inven_item_increase(player_ptr, INVEN_SUB_HAND, -item_sub_hand.number);
         inven_item_optimize(player_ptr, INVEN_SUB_HAND);
@@ -55,7 +55,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
         return;
     }
 
-    const auto &item_main_hand = player_ptr->inventory_list[INVEN_MAIN_HAND];
+    const auto &item_main_hand = player_ptr->inventory[INVEN_MAIN_HAND];
     if (item_main_hand.is_valid()) {
         item_name = describe_flavor(player_ptr, item_main_hand, 0);
     }
@@ -72,7 +72,7 @@ void verify_equip_slot(PlayerType *player_ptr, INVENTORY_IDX i_idx)
         return;
     }
 
-    auto &item_sub_hand = player_ptr->inventory_list[INVEN_SUB_HAND];
+    auto &item_sub_hand = player_ptr->inventory[INVEN_SUB_HAND];
     item_sub_hand = item_main_hand.clone();
     inven_item_increase(player_ptr, INVEN_MAIN_HAND, -item_main_hand.number);
     inven_item_optimize(player_ptr, INVEN_MAIN_HAND);

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -365,7 +365,7 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
          * into an inventory slot.
          * But an item can not be absorbed into itself!
          */
-        if ((&player_ptr->inventory_list[j] != o_ptr) && player_ptr->inventory_list[j].is_similar(*o_ptr)) {
+        if ((&player_ptr->inventory[j] != o_ptr) && player_ptr->inventory[j].is_similar(*o_ptr)) {
             return true;
         }
     }

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -47,7 +47,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     // TODO: キャラ作成からゲーム開始までに  current_floor_ptr を参照しなければならない処理は今後整理して外す。
     player_ptr->current_floor_ptr = &FloorList::get_instance().get_floor(0);
     //! @todo std::make_shared の配列対応版は C++20 から
-    player_ptr->inventory_list = std::shared_ptr<ItemEntity[]>{ new ItemEntity[INVEN_TOTAL] };
+    player_ptr->inventory = std::shared_ptr<ItemEntity[]>{ new ItemEntity[INVEN_TOTAL] };
     for (int i = 0; i < 4; i++) {
         player_ptr->history[i][0] = '\0';
     }
@@ -67,7 +67,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     player_ptr->inven_cnt = 0;
     player_ptr->equip_cnt = 0;
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        (&player_ptr->inventory_list[i])->wipe();
+        (&player_ptr->inventory[i])->wipe();
     }
 
     ArtifactList::get_instance().reset_generated_flags();

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -36,7 +36,7 @@ void wield_all(PlayerType *player_ptr)
     ItemEntity ObjectType_body;
     for (INVENTORY_IDX i_idx = INVEN_PACK - 1; i_idx >= 0; i_idx--) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i_idx];
+        o_ptr = &player_ptr->inventory[i_idx];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -49,7 +49,7 @@ void wield_all(PlayerType *player_ptr)
             continue;
         }
 
-        auto &wield_slot_item = player_ptr->inventory_list[slot];
+        auto &wield_slot_item = player_ptr->inventory[slot];
         if (wield_slot_item.is_valid()) {
             continue;
         }

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -193,8 +193,8 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
     if (monrace.is_female() && !(is_stunned || is_confused || is_hallucinated || !monster.ml)) {
         // @todo 「特定の武器を装備している」旨のメソッドを別途作る
         constexpr auto zantetsu = FixedArtifactId::ZANTETSU;
-        const auto is_main_hand_zantetsu = player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(zantetsu);
-        const auto is_sub_hand_zantetsu = player_ptr->inventory_list[INVEN_SUB_HAND].is_specific_artifact(zantetsu);
+        const auto is_main_hand_zantetsu = player_ptr->inventory[INVEN_MAIN_HAND].is_specific_artifact(zantetsu);
+        const auto is_sub_hand_zantetsu = player_ptr->inventory[INVEN_SUB_HAND].is_specific_artifact(zantetsu);
         if (is_main_hand_zantetsu || is_sub_hand_zantetsu) {
             sound(SoundKind::ATTACK_FAILED);
             msg_print(_("拙者、おなごは斬れぬ！", "I can not attack women!"));
@@ -211,11 +211,11 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
     if (!monster.is_hostile() && !(is_stunned || is_confused || is_hallucinated || is_shero(player_ptr) || !monster.ml)) {
         constexpr auto stormbringer = FixedArtifactId::STORMBRINGER;
         auto is_stormbringer = false;
-        if (player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(stormbringer)) {
+        if (player_ptr->inventory[INVEN_MAIN_HAND].is_specific_artifact(stormbringer)) {
             is_stormbringer = true;
         }
 
-        if (player_ptr->inventory_list[INVEN_SUB_HAND].is_specific_artifact(stormbringer)) {
+        if (player_ptr->inventory[INVEN_SUB_HAND].is_specific_artifact(stormbringer)) {
             is_stormbringer = true;
         }
 

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -281,7 +281,7 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
 
                     chance += player_ptr->to_m_chance;
 
-                    if (player_ptr->inventory_list[INVEN_NECK].is_specific_artifact(FixedArtifactId::GOGO_PENDANT)) {
+                    if (player_ptr->inventory[INVEN_NECK].is_specific_artifact(FixedArtifactId::GOGO_PENDANT)) {
                         chance -= 10;
                     }
 

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -305,7 +305,7 @@ void do_cmd_bash(PlayerType *player_ptr)
 static bool get_spike(PlayerType *player_ptr, INVENTORY_IDX *ip)
 {
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -471,11 +471,11 @@ void do_cmd_pet(PlayerType *player_ptr)
 
     bool empty_main = can_attack_with_main_hand(player_ptr);
     empty_main &= empty_hands(player_ptr, false) == EMPTY_HAND_SUB;
-    empty_main &= player_ptr->inventory_list[INVEN_MAIN_HAND].allow_two_hands_wielding();
+    empty_main &= player_ptr->inventory[INVEN_MAIN_HAND].allow_two_hands_wielding();
 
     bool empty_sub = can_attack_with_sub_hand(player_ptr);
     empty_sub &= empty_hands(player_ptr, false) == EMPTY_HAND_MAIN;
-    empty_sub &= player_ptr->inventory_list[INVEN_SUB_HAND].allow_two_hands_wielding();
+    empty_sub &= player_ptr->inventory[INVEN_SUB_HAND].allow_two_hands_wielding();
 
     if (player_ptr->riding) {
         if (empty_main || empty_sub) {

--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -32,7 +32,7 @@ void do_cmd_fire(PlayerType *player_ptr, SPELL_IDX snipe_type)
     }
 
     player_ptr->is_fired = false;
-    auto *item_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    auto *item_ptr = &player_ptr->inventory[INVEN_BOW];
     const auto tval = item_ptr->bi_key.tval();
     if (tval == ItemKindType::NONE) {
         msg_print(_("射撃用の武器を持っていない。", "You have nothing to fire with."));

--- a/src/cmd-item/cmd-eat.cpp
+++ b/src/cmd-item/cmd-eat.cpp
@@ -194,7 +194,7 @@ static bool exe_eat_charge_of_magic_device(PlayerType *player_ptr, ItemEntity *o
     }
 
     if (i_idx >= 0) {
-        inven_item_charges(player_ptr->inventory_list[i_idx]);
+        inven_item_charges(player_ptr->inventory[i_idx]);
     } else {
         floor_item_charges(*player_ptr->current_floor_ptr, 0 - i_idx);
     }

--- a/src/cmd-item/cmd-equipment.cpp
+++ b/src/cmd-item/cmd-equipment.cpp
@@ -61,8 +61,8 @@ static void do_curse_on_equip(OBJECT_IDX slot, ItemEntity &item, PlayerType *pla
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (set_anubis_and_chariot(player_ptr) && ((slot == INVEN_MAIN_HAND) || (slot == INVEN_SUB_HAND))) {
 
-        ItemEntity *anubis = &(player_ptr->inventory_list[INVEN_MAIN_HAND]);
-        ItemEntity *chariot = &(player_ptr->inventory_list[INVEN_SUB_HAND]);
+        ItemEntity *anubis = &(player_ptr->inventory[INVEN_MAIN_HAND]);
+        ItemEntity *chariot = &(player_ptr->inventory[INVEN_SUB_HAND]);
 
         anubis->curse_flags.set(CurseTraitType::PERSISTENT_CURSE);
         anubis->curse_flags.set(CurseTraitType::HEAVY_CURSE);
@@ -143,8 +143,8 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     auto slot = wield_slot(player_ptr, o_ptr);
-    const auto o_ptr_mh = &player_ptr->inventory_list[INVEN_MAIN_HAND];
-    const auto o_ptr_sh = &player_ptr->inventory_list[INVEN_SUB_HAND];
+    const auto o_ptr_mh = &player_ptr->inventory[INVEN_MAIN_HAND];
+    const auto o_ptr_sh = &player_ptr->inventory[INVEN_SUB_HAND];
     const auto tval = o_ptr->bi_key.tval();
     switch (tval) {
     case ItemKindType::CAPTURE:
@@ -199,7 +199,7 @@ void do_cmd_wield(PlayerType *player_ptr)
         break;
     case ItemKindType::RING: {
         std::string q;
-        if (player_ptr->inventory_list[INVEN_SUB_RING].is_valid() && player_ptr->inventory_list[INVEN_MAIN_RING].is_valid()) {
+        if (player_ptr->inventory[INVEN_SUB_RING].is_valid() && player_ptr->inventory[INVEN_MAIN_RING].is_valid()) {
             q = _("どちらの指輪と取り替えますか?", "Replace which ring? ");
         } else {
             q = _("どちらの手に装備しますか?", "Equip which hand? ");
@@ -219,8 +219,8 @@ void do_cmd_wield(PlayerType *player_ptr)
         break;
     }
 
-    if (player_ptr->inventory_list[slot].is_cursed()) {
-        const auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
+    if (player_ptr->inventory[slot].is_cursed()) {
+        const auto item_name = describe_flavor(player_ptr, player_ptr->inventory[slot], OD_OMIT_PREFIX | OD_NAME_ONLY);
 #ifdef JP
         msg_format("%s%sは呪われているようだ。", describe_use(player_ptr, slot), item_name.data());
 #else
@@ -254,9 +254,9 @@ void do_cmd_wield(PlayerType *player_ptr)
     }
 
     sound(SoundKind::WIELD);
-    if (need_switch_wielding && !player_ptr->inventory_list[need_switch_wielding].is_cursed()) {
-        auto &slot_item = player_ptr->inventory_list[slot];
-        auto &switch_item = player_ptr->inventory_list[need_switch_wielding];
+    if (need_switch_wielding && !player_ptr->inventory[need_switch_wielding].is_cursed()) {
+        auto &slot_item = player_ptr->inventory[slot];
+        auto &switch_item = player_ptr->inventory[need_switch_wielding];
         const auto item_name = describe_flavor(player_ptr, switch_item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
         std::swap(switch_item, slot_item);
         msg_format(_("%sを%sに構えなおした。", "You wield %s at %s hand."), item_name.data(),
@@ -281,7 +281,7 @@ void do_cmd_wield(PlayerType *player_ptr)
         floor_item_optimize(player_ptr, 0 - i_idx);
     }
 
-    auto &wield_slot_item = player_ptr->inventory_list[slot];
+    auto &wield_slot_item = player_ptr->inventory[slot];
     if (wield_slot_item.is_valid()) {
         (void)inven_takeoff(player_ptr, slot, 255);
     }

--- a/src/cmd-item/cmd-item.cpp
+++ b/src/cmd-item/cmd-item.cpp
@@ -293,7 +293,7 @@ void do_cmd_use(PlayerType *player_ptr)
     case ItemKindType::SHOT:
     case ItemKindType::ARROW:
     case ItemKindType::BOLT:
-        exe_fire(player_ptr, i_idx, &player_ptr->inventory_list[INVEN_BOW], SP_NONE);
+        exe_fire(player_ptr, i_idx, &player_ptr->inventory[INVEN_BOW], SP_NONE);
         break;
     default:
         exe_activate(player_ptr, i_idx);

--- a/src/cmd-item/cmd-refill.cpp
+++ b/src/cmd-item/cmd-refill.cpp
@@ -37,7 +37,7 @@ static void do_cmd_refill_lamp(PlayerType *player_ptr)
     const auto flags = o_ptr->get_flags();
 
     PlayerEnergy(player_ptr).set_player_turn_energy(50);
-    auto *j_ptr = &player_ptr->inventory_list[INVEN_LITE];
+    auto *j_ptr = &player_ptr->inventory[INVEN_LITE];
     const auto flags2 = j_ptr->get_flags();
     j_ptr->fuel += o_ptr->fuel;
     msg_print(_("ランプに油を注いだ。", "You fuel your lamp."));
@@ -73,7 +73,7 @@ static void do_cmd_refill_torch(PlayerType *player_ptr)
     const auto flags = o_ptr->get_flags();
 
     PlayerEnergy(player_ptr).set_player_turn_energy(50);
-    auto *j_ptr = &player_ptr->inventory_list[INVEN_LITE];
+    auto *j_ptr = &player_ptr->inventory[INVEN_LITE];
     const auto flags2 = j_ptr->get_flags();
     j_ptr->fuel += o_ptr->fuel + 5;
     msg_print(_("松明を結合した。", "You combine the torches."));
@@ -101,7 +101,7 @@ static void do_cmd_refill_torch(PlayerType *player_ptr)
 void do_cmd_refill(PlayerType *player_ptr)
 {
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU });
-    const auto *o_ptr = &player_ptr->inventory_list[INVEN_LITE];
+    const auto *o_ptr = &player_ptr->inventory[INVEN_LITE];
     const auto &bi_key = o_ptr->bi_key;
     if (bi_key.tval() != ItemKindType::LITE) {
         msg_print(_("光源を装備していない。", "You are not wielding a light."));

--- a/src/combat/attack-accuracy.cpp
+++ b/src/combat/attack-accuracy.cpp
@@ -124,7 +124,7 @@ bool check_hit_from_monster_to_monster(int power, DEPTH level, ARMOUR_CLASS ac, 
 static bool decide_attack_hit(PlayerType *player_ptr, player_attack_type *pa_ptr, int chance)
 {
     bool success_hit = false;
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
     if ((o_ptr->bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) || (pa_ptr->mode == HISSATSU_KYUSHO)) {
         int n = 1;
@@ -160,7 +160,7 @@ static bool decide_attack_hit(PlayerType *player_ptr, player_attack_type *pa_ptr
  */
 bool process_attack_hit(PlayerType *player_ptr, player_attack_type *pa_ptr, int chance)
 {
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     if (decide_attack_hit(player_ptr, pa_ptr, chance)) {
         return true;
     }

--- a/src/combat/attack-criticality.cpp
+++ b/src/combat/attack-criticality.cpp
@@ -125,7 +125,7 @@ static void ninja_critical(PlayerType *player_ptr, player_attack_type *pa_ptr)
  */
 void critical_attack(PlayerType *player_ptr, player_attack_type *pa_ptr)
 {
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     auto &monrace = pa_ptr->m_ptr->get_monrace();
     const auto no_instantly_death = monrace.resistance_flags.has(MonsterResistanceType::NO_INSTANTLY_DEATH);
     if ((o_ptr->bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) || (pa_ptr->mode == HISSATSU_KYUSHO)) {

--- a/src/combat/aura-counterattack.cpp
+++ b/src/combat/aura-counterattack.cpp
@@ -196,7 +196,7 @@ static void aura_shadow_by_monster_attack(PlayerType *player_ptr, MonsterAttackP
     }
 
     int dam = 1;
-    ItemEntity *o_armed_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
+    ItemEntity *o_armed_ptr = &player_ptr->inventory[INVEN_MAIN_HAND];
     auto &monrace = monap_ptr->m_ptr->get_monrace();
     const EnumClassFlagGroup<MonsterResistanceType> resist_flags = { MonsterResistanceType::RESIST_ALL, MonsterResistanceType::RESIST_DARK };
 
@@ -214,7 +214,7 @@ static void aura_shadow_by_monster_attack(PlayerType *player_ptr, MonsterAttackP
         dam = Dice::floored_expected_value(num, sides) + o_armed_ptr->to_d + player_ptr->to_d[0];
     }
 
-    o_armed_ptr = &player_ptr->inventory_list[INVEN_BODY];
+    o_armed_ptr = &player_ptr->inventory[INVEN_BODY];
     if (o_armed_ptr->is_valid() && o_armed_ptr->is_cursed()) {
         dam *= 2;
     }
@@ -241,7 +241,7 @@ static void aura_shadow_by_monster_attack(PlayerType *player_ptr, MonsterAttackP
 
     /* Some cursed armours gives an extra effect */
     for (int j = 0; j < TABLE_SIZE; j++) {
-        o_armed_ptr = &player_ptr->inventory_list[table[j].slot];
+        o_armed_ptr = &player_ptr->inventory[table[j].slot];
         if (o_armed_ptr->is_valid() && o_armed_ptr->is_cursed() && o_armed_ptr->is_protector()) {
             project(player_ptr, 0, 0, monap_ptr->m_ptr->fy, monap_ptr->m_ptr->fx, (player_ptr->lev * 2), table[j].type, flg);
         }

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -337,7 +337,7 @@ static MULTIPLY calc_shot_damage_with_slay(
             }
 
             auto can_eliminate_smaug = arrow_ptr->is_specific_artifact(FixedArtifactId::BARD_ARROW);
-            can_eliminate_smaug &= player_ptr->inventory_list[INVEN_BOW].is_specific_artifact(FixedArtifactId::BARD);
+            can_eliminate_smaug &= player_ptr->inventory[INVEN_BOW].is_specific_artifact(FixedArtifactId::BARD);
             can_eliminate_smaug &= monster.r_idx == MonraceId::SMAUG;
             if (can_eliminate_smaug) {
                 mult *= 5;
@@ -469,7 +469,7 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
     /* Access the item (if in the pack) */
     auto &floor = *player_ptr->current_floor_ptr;
     if (i_idx >= 0) {
-        o_ptr = &player_ptr->inventory_list[i_idx];
+        o_ptr = &player_ptr->inventory[i_idx];
     } else {
         o_ptr = &floor.o_list[0 - i_idx];
     }
@@ -1026,7 +1026,7 @@ bool test_hit_fire(PlayerType *player_ptr, int chance, const MonsterEntity &mons
  */
 int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus_bow, int dam)
 {
-    const auto &item = player_ptr->inventory_list[INVEN_BOW];
+    const auto &item = player_ptr->inventory[INVEN_BOW];
     const auto bonus = player_ptr->to_h_b + plus_ammo;
     const auto tval = item.bi_key.tval();
     const auto median_skill_exp = PlayerSkill::weapon_exp_at(PlayerSkillRank::MASTER) / 2;
@@ -1087,7 +1087,7 @@ int critical_shot(PlayerType *player_ptr, WEIGHT weight, int plus_ammo, int plus
  */
 int calc_crit_ratio_shot(PlayerType *player_ptr, int plus_ammo, int plus_bow)
 {
-    auto *j_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    auto *j_ptr = &player_ptr->inventory[INVEN_BOW];
 
     /* Extract "shot" power */
     auto i = player_ptr->to_h_b + plus_ammo;

--- a/src/flavor/flavor-describer.cpp
+++ b/src/flavor/flavor-describer.cpp
@@ -592,7 +592,7 @@ std::string describe_flavor(PlayerType *player_ptr, const ItemEntity &item, BIT_
        << describe_accuracy_and_damage_bonus(item, opt);
 
     if (none_bits(mode, OD_DEBUG)) {
-        const auto &bow = player_ptr->inventory_list[INVEN_BOW];
+        const auto &bow = player_ptr->inventory[INVEN_BOW];
         const auto tval = item.bi_key.tval();
         if (bow.is_valid() && (tval == bow.get_arrow_kind())) {
             ss << describe_ammo_detail(player_ptr, item, bow, opt);

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -284,7 +284,7 @@ static void preserve_info(PlayerType *player_ptr)
     }
 
     for (short i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/hpmp/hp-mp-processor.cpp
+++ b/src/hpmp/hp-mp-processor.cpp
@@ -141,9 +141,9 @@ void process_player_hp_mp(PlayerType *player_ptr)
             }
         }
 
-        const auto &item = player_ptr->inventory_list[INVEN_LITE];
+        const auto &item = player_ptr->inventory[INVEN_LITE];
         const auto flags = item.get_flags();
-        if ((player_ptr->inventory_list[INVEN_LITE].bi_key.tval() != ItemKindType::NONE) && flags.has_not(TR_DARK_SOURCE) && !has_resist_lite(player_ptr)) {
+        if ((player_ptr->inventory[INVEN_LITE].bi_key.tval() != ItemKindType::NONE) && flags.has_not(TR_DARK_SOURCE) && !has_resist_lite(player_ptr)) {
             const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
             msg_format(_("%sがあなたのアンデッドの肉体を焼き焦がした！", "The %s scorches your undead flesh!"), item_name.data());
             cave_no_regen = true;

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -214,7 +214,7 @@ void regenerate_captured_monsters(PlayerType *player_ptr)
 {
     bool heal = false;
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -169,7 +169,7 @@ static void test_inventory_floor(PlayerType *player_ptr, fis_type *fis_ptr, cons
     }
 
     for (int i = 0; i < INVEN_PACK; i++) {
-        if (item_tester.okay(&player_ptr->inventory_list[i]) || (fis_ptr->mode & USE_FULL)) {
+        if (item_tester.okay(&player_ptr->inventory[i]) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_inven++;
         }
     }
@@ -193,7 +193,7 @@ static void test_equipment_floor(PlayerType *player_ptr, fis_type *fis_ptr, cons
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         if (player_ptr->select_ring_slot ? is_ring_slot(i)
-                                         : item_tester.okay(&player_ptr->inventory_list[i]) || (fis_ptr->mode & USE_FULL)) {
+                                         : item_tester.okay(&player_ptr->inventory[i]) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_equip++;
         }
     }

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -171,7 +171,7 @@ ItemEntity *choose_cursed_obj_name(PlayerType *player_ptr, CurseTraitType flag)
     }
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (o_ptr->curse_flags.has(flag)) {
             choices[number] = i;
             number++;
@@ -181,7 +181,7 @@ ItemEntity *choose_cursed_obj_name(PlayerType *player_ptr, CurseTraitType flag)
         choise_cursed_item(flag, o_ptr, choices, &number, i);
     }
 
-    return &player_ptr->inventory_list[choices[randint0(number)]];
+    return &player_ptr->inventory[choices[randint0(number)]];
 }
 
 /*!
@@ -196,7 +196,7 @@ static void curse_teleport(PlayerType *player_ptr)
 
     int i_keep = 0, count = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -217,7 +217,7 @@ static void curse_teleport(PlayerType *player_ptr)
         }
     }
 
-    const auto &item = player_ptr->inventory_list[i_keep];
+    const auto &item = player_ptr->inventory[i_keep];
     const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY));
     msg_format(_("%sがテレポートの能力を発動させようとしている。", "Your %s tries to teleport you."), item_name.data());
     if (input_check_strict(player_ptr, _("テレポートしますか？", "Teleport? "), UserCheck::OKAY_CANCEL)) {
@@ -487,7 +487,7 @@ void execute_cursed_items_effect(PlayerType *player_ptr)
         return;
     }
 
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_LITE];
+    auto *o_ptr = &player_ptr->inventory[INVEN_LITE];
     if (!o_ptr->is_specific_artifact(FixedArtifactId::JUDGE)) {
         return;
     }

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -34,7 +34,7 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
 
     /* Scan through the slots backwards */
     for (short i = 0; i < INVEN_PACK; i++) {
-        auto &item = player_ptr->inventory_list[i];
+        auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/inventory/inventory-describer.cpp
+++ b/src/inventory/inventory-describer.cpp
@@ -44,7 +44,7 @@ concptr mention_use(PlayerType *player_ptr, int i)
 #endif
 
     case INVEN_BOW:
-        p = (adj_str_hold[player_ptr->stat_index[A_STR]] < player_ptr->inventory_list[i].weight / 10) ? _("運搬中", "Just holding") : _("射撃用", "Shooting");
+        p = (adj_str_hold[player_ptr->stat_index[A_STR]] < player_ptr->inventory[i].weight / 10) ? _("運搬中", "Just holding") : _("射撃用", "Shooting");
         break;
     case INVEN_MAIN_RING:
         p = (left_hander ? _("左手指", "On left hand") : _("右手指", "On right hand"));
@@ -120,8 +120,8 @@ concptr describe_use(PlayerType *player_ptr, int i)
 #endif
 
     case INVEN_BOW:
-        p = (adj_str_hold[player_ptr->stat_index[A_STR]] < player_ptr->inventory_list[i].weight / 10) ? _("持つだけで精一杯の", "just holding")
-                                                                                                      : _("射撃用に装備している", "shooting missiles with");
+        p = (adj_str_hold[player_ptr->stat_index[A_STR]] < player_ptr->inventory[i].weight / 10) ? _("持つだけで精一杯の", "just holding")
+                                                                                                 : _("射撃用に装備している", "shooting missiles with");
         break;
     case INVEN_MAIN_RING:
         p = (left_hander ? _("左手の指にはめている", "wearing on your left hand") : _("右手の指にはめている", "wearing on your right hand"));

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -40,7 +40,7 @@ void vary_item(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER num)
  */
 void inven_item_increase(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER num)
 {
-    auto *o_ptr = &player_ptr->inventory_list[i_idx];
+    auto *o_ptr = &player_ptr->inventory[i_idx];
     num += o_ptr->number;
     if (num > 255) {
         num = 255;
@@ -89,7 +89,7 @@ void inven_item_increase(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBE
  */
 void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx)
 {
-    auto *o_ptr = &player_ptr->inventory_list[i_idx];
+    auto *o_ptr = &player_ptr->inventory[i_idx];
     if (!o_ptr->is_valid()) {
         return;
     }
@@ -100,7 +100,7 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx)
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     if (i_idx >= INVEN_MAIN_HAND) {
         player_ptr->equip_cnt--;
-        (&player_ptr->inventory_list[i_idx])->wipe();
+        (&player_ptr->inventory[i_idx])->wipe();
         static constexpr auto flags_srf = {
             StatusRecalculatingFlag::BONUS,
             StatusRecalculatingFlag::TORCH,
@@ -117,8 +117,8 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx)
 
     player_ptr->inven_cnt--;
 
-    auto first = &player_ptr->inventory_list[i_idx];
-    auto last = &player_ptr->inventory_list[INVEN_PACK];
+    auto first = &player_ptr->inventory[i_idx];
+    auto last = &player_ptr->inventory[INVEN_PACK];
     std::rotate(first, first + 1, last + 1);
     last->wipe();
 
@@ -137,7 +137,7 @@ void inven_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx)
  */
 void drop_from_inventory(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER amt)
 {
-    auto *o_ptr = &player_ptr->inventory_list[i_idx];
+    auto *o_ptr = &player_ptr->inventory[i_idx];
     if (amt <= 0) {
         return;
     }
@@ -148,7 +148,7 @@ void drop_from_inventory(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBE
 
     if (i_idx >= INVEN_MAIN_HAND) {
         i_idx = inven_takeoff(player_ptr, i_idx, amt);
-        o_ptr = &player_ptr->inventory_list[i_idx];
+        o_ptr = &player_ptr->inventory[i_idx];
     }
 
     auto item = o_ptr->clone();
@@ -177,13 +177,13 @@ void combine_pack(PlayerType *player_ptr)
         combined = false;
 
         for (auto i = enum2i(INVEN_PACK); i > 0; i--) {
-            auto &item1 = player_ptr->inventory_list[i];
+            auto &item1 = player_ptr->inventory[i];
             if (!item1.is_valid()) {
                 continue;
             }
 
             for (short j = 0; j < i; j++) {
-                auto &item2 = player_ptr->inventory_list[j];
+                auto &item2 = player_ptr->inventory[j];
                 if (!item2.is_valid()) {
                     continue;
                 }
@@ -198,8 +198,8 @@ void combine_pack(PlayerType *player_ptr)
                     flag = true;
                     item2.absorb(item1);
                     player_ptr->inven_cnt--;
-                    auto first = &player_ptr->inventory_list[i];
-                    auto last = &player_ptr->inventory_list[INVEN_PACK];
+                    auto first = &player_ptr->inventory[i];
+                    auto last = &player_ptr->inventory[INVEN_PACK];
                     std::rotate(first, first + 1, last + 1);
                     last->wipe();
                 } else {
@@ -245,8 +245,8 @@ void reorder_pack(PlayerType *player_ptr)
 
     const auto sort_count = std::min(enum2i(INVEN_PACK), player_ptr->inven_cnt);
 
-    auto first = &player_ptr->inventory_list[0];
-    auto last = &player_ptr->inventory_list[sort_count];
+    auto first = &player_ptr->inventory[0];
+    auto last = &player_ptr->inventory[sort_count];
 
     if (std::is_sorted(first, last, comp)) {
         return;
@@ -276,7 +276,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
         SubWindowRedrawingFlag::PLAYER,
     };
     for (j = 0; j < INVEN_PACK; j++) {
-        j_ptr = &player_ptr->inventory_list[j];
+        j_ptr = &player_ptr->inventory[j];
         if (!j_ptr->is_valid()) {
             continue;
         }
@@ -295,7 +295,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     for (j = 0; j <= INVEN_PACK; j++) {
-        j_ptr = &player_ptr->inventory_list[j];
+        j_ptr = &player_ptr->inventory[j];
         if (!j_ptr->is_valid()) {
             break;
         }
@@ -304,17 +304,17 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
     i = j;
     if (i < INVEN_PACK) {
         for (j = 0; j < INVEN_PACK; j++) {
-            if (object_sort_comp(player_ptr, *o_ptr, player_ptr->inventory_list[j])) {
+            if (object_sort_comp(player_ptr, *o_ptr, player_ptr->inventory[j])) {
                 break;
             }
         }
 
         i = j;
-        std::rotate(&player_ptr->inventory_list[i], &player_ptr->inventory_list[n + 1], &player_ptr->inventory_list[n + 2]);
+        std::rotate(&player_ptr->inventory[i], &player_ptr->inventory[n + 1], &player_ptr->inventory[n + 2]);
     }
 
-    player_ptr->inventory_list[i] = o_ptr->clone();
-    j_ptr = &player_ptr->inventory_list[i];
+    player_ptr->inventory[i] = o_ptr->clone();
+    j_ptr = &player_ptr->inventory[i];
     j_ptr->held_m_idx = 0;
     j_ptr->iy = j_ptr->ix = 0;
     j_ptr->marked.clear().set(OmType::TOUCHED);
@@ -344,7 +344,7 @@ bool check_store_item_to_inventory(PlayerType *player_ptr, const ItemEntity *o_p
     }
 
     for (int j = 0; j < INVEN_PACK; j++) {
-        auto *j_ptr = &player_ptr->inventory_list[j];
+        auto *j_ptr = &player_ptr->inventory[j];
         if (!j_ptr->is_valid()) {
             continue;
         }
@@ -366,7 +366,7 @@ bool check_store_item_to_inventory(PlayerType *player_ptr, const ItemEntity *o_p
  */
 INVENTORY_IDX inven_takeoff(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER amt)
 {
-    const auto &item_inventory = player_ptr->inventory_list[i_idx];
+    const auto &item_inventory = player_ptr->inventory[i_idx];
     if (amt <= 0) {
         return -1;
     }

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -124,7 +124,7 @@ bool get_tag(PlayerType *player_ptr, COMMAND_CODE *cp, char tag, BIT_FLAGS mode,
     }
 
     for (COMMAND_CODE i = start; i <= end; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid() || !o_ptr->is_inscribed()) {
             continue;
         }
@@ -149,7 +149,7 @@ bool get_tag(PlayerType *player_ptr, COMMAND_CODE *cp, char tag, BIT_FLAGS mode,
     }
 
     for (COMMAND_CODE i = start; i <= end; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid() || !o_ptr->is_inscribed()) {
             continue;
         }
@@ -188,7 +188,7 @@ bool get_item_okay(PlayerType *player_ptr, OBJECT_IDX i, const ItemTester &item_
         return is_ring_slot(i);
     }
 
-    return item_tester.okay(&player_ptr->inventory_list[i]);
+    return item_tester.okay(&player_ptr->inventory[i]);
 }
 
 /*!
@@ -205,7 +205,7 @@ bool get_item_allow(PlayerType *player_ptr, INVENTORY_IDX i_idx)
 
     ItemEntity *o_ptr;
     if (i_idx >= 0) {
-        o_ptr = &player_ptr->inventory_list[i_idx];
+        o_ptr = &player_ptr->inventory[i_idx];
     } else {
         o_ptr = &player_ptr->current_floor_ptr->o_list[0 - i_idx];
     }
@@ -246,7 +246,7 @@ INVENTORY_IDX label_to_equipment(PlayerType *player_ptr, int c)
         return is_ring_slot(i) ? i : -1;
     }
 
-    if (!player_ptr->inventory_list[i].bi_id) {
+    if (!player_ptr->inventory[i].bi_id) {
         return -1;
     }
 
@@ -265,7 +265,7 @@ INVENTORY_IDX label_to_inventory(PlayerType *player_ptr, int c)
 {
     INVENTORY_IDX i = (INVENTORY_IDX)(islower(c) ? A2I(c) : -1);
 
-    if ((i < 0) || (i > INVEN_PACK) || !player_ptr->inventory_list[i].is_valid()) {
+    if ((i < 0) || (i > INVEN_PACK) || !player_ptr->inventory[i].is_valid()) {
         return -1;
     }
 
@@ -281,7 +281,7 @@ INVENTORY_IDX label_to_inventory(PlayerType *player_ptr, int c)
  */
 bool verify(PlayerType *player_ptr, concptr prompt, INVENTORY_IDX i_idx)
 {
-    const auto &item = i_idx >= 0 ? player_ptr->inventory_list[i_idx] : player_ptr->current_floor_ptr->o_list[0 - i_idx];
+    const auto &item = i_idx >= 0 ? player_ptr->inventory[i_idx] : player_ptr->current_floor_ptr->o_list[0 - i_idx];
     const auto item_name = describe_flavor(player_ptr, item, 0);
     std::stringstream ss;
     ss << prompt;

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -161,7 +161,7 @@ static void test_inventory(PlayerType *player_ptr, item_selection_type *item_sel
     }
 
     for (int j = 0; j < INVEN_PACK; j++) {
-        if (item_tester.okay(&player_ptr->inventory_list[j]) || (item_selection_ptr->mode & USE_FULL)) {
+        if (item_tester.okay(&player_ptr->inventory[j]) || (item_selection_ptr->mode & USE_FULL)) {
             item_selection_ptr->max_inven++;
         }
     }
@@ -185,7 +185,7 @@ static void test_equipment(PlayerType *player_ptr, item_selection_type *item_sel
 
     for (int j = INVEN_MAIN_HAND; j < INVEN_TOTAL; j++) {
         if (player_ptr->select_ring_slot ? is_ring_slot(j)
-                                         : item_tester.okay(&player_ptr->inventory_list[j]) || (item_selection_ptr->mode & USE_FULL)) {
+                                         : item_tester.okay(&player_ptr->inventory[j]) || (item_selection_ptr->mode & USE_FULL)) {
             item_selection_ptr->max_equip++;
         }
     }

--- a/src/inventory/pack-overflow.cpp
+++ b/src/inventory/pack-overflow.cpp
@@ -16,16 +16,16 @@
  */
 void pack_overflow(PlayerType *player_ptr)
 {
-    if (!player_ptr->inventory_list[INVEN_PACK].is_valid()) {
+    if (!player_ptr->inventory[INVEN_PACK].is_valid()) {
         return;
     }
 
     update_creature(player_ptr);
-    if (!player_ptr->inventory_list[INVEN_PACK].is_valid()) {
+    if (!player_ptr->inventory[INVEN_PACK].is_valid()) {
         return;
     }
 
-    auto &item = player_ptr->inventory_list[INVEN_PACK];
+    auto &item = player_ptr->inventory[INVEN_PACK];
     disturb(player_ptr, false, true);
     msg_print(_("ザックからアイテムがあふれた！", "Your pack overflows!"));
 

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -48,7 +48,7 @@
 bool can_get_item(PlayerType *player_ptr, const ItemTester &item_tester)
 {
     for (int j = 0; j < INVEN_TOTAL; j++) {
-        if (item_tester.okay(&player_ptr->inventory_list[j])) {
+        if (item_tester.okay(&player_ptr->inventory[j])) {
             return true;
         }
     }
@@ -197,7 +197,7 @@ void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
 #endif
 
     auto slot = store_item_to_inventory(player_ptr, o_ptr);
-    o_ptr = &player_ptr->inventory_list[slot];
+    o_ptr = &player_ptr->inventory[slot];
     delete_object_idx(player_ptr, o_idx);
     if (player_ptr->ppersonality == PERSONALITY_MUNCHKIN) {
         bool old_known = identify_item(player_ptr, o_ptr);

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -56,7 +56,7 @@ void recharge_magic_items(PlayerType *player_ptr)
     bool changed;
 
     for (changed = false, i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto &item = player_ptr->inventory_list[i];
+        auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -82,7 +82,7 @@ void recharge_magic_items(PlayerType *player_ptr)
      * one per turn. -LM-
      */
     for (changed = false, i = 0; i < INVEN_PACK; i++) {
-        auto &item = player_ptr->inventory_list[i];
+        auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -481,7 +481,7 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
     if (player_ptr->equip_cnt) {
         fmt::println(fff, _("  [キャラクタの装備]\n", "  [Character Equipment]\n"));
         for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[i], 0);
+            auto item_name = describe_flavor(player_ptr, player_ptr->inventory[i], 0);
             auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr));
             is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr));
             if (is_two_handed && has_two_handed_weapons(player_ptr)) {
@@ -496,11 +496,11 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
 
     fmt::println(fff, _("  [キャラクタの持ち物]\n", "  [Character Inventory]\n"));
     for (auto i = 0; i < INVEN_PACK; i++) {
-        if (!player_ptr->inventory_list[i].is_valid()) {
+        if (!player_ptr->inventory[i].is_valid()) {
             break;
         }
 
-        const auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[i], 0);
+        const auto item_name = describe_flavor(player_ptr, player_ptr->inventory[i], 0);
         fmt::println(fff, "{}) {}", index_to_label(i), item_name);
     }
 

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -82,12 +82,12 @@ void spoil_random_artifact(PlayerType *player_ptr)
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
             for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-                auto &item = player_ptr->inventory_list[i];
+                auto &item = player_ptr->inventory[i];
                 spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }
 
             for (int i = 0; i < INVEN_PACK; i++) {
-                auto &item = player_ptr->inventory_list[i];
+                auto &item = player_ptr->inventory[i];
                 spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }
 

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -306,7 +306,7 @@ void InputKeyRequestor::sweep_confirmation_equipments()
 {
     auto caret_command = this->get_caret_command();
     for (auto i = enum2i(INVEN_MAIN_HAND); i < INVEN_TOTAL; i++) {
-        auto &item = this->player_ptr->inventory_list[i];
+        auto &item = this->player_ptr->inventory[i];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;
         }

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -215,7 +215,7 @@ static void show_wearing_equipment_resistances(PlayerType *player_ptr, ItemKindT
     char where[32];
     strcpy(where, _("装", "E "));
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!check_item_knowledge(item, tval)) {
             continue;
         }
@@ -237,7 +237,7 @@ static void show_holding_equipment_resistances(PlayerType *player_ptr, ItemKindT
     char where[32];
     strcpy(where, _("持", "I "));
     for (int i = 0; i < INVEN_PACK; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!check_item_knowledge(item, tval)) {
             continue;
         }

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -67,7 +67,7 @@ auto collect_known_fixed_artifacts(PlayerType *player_ptr)
     }
 
     for (auto i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/load/inventory-loader.cpp
+++ b/src/load/inventory-loader.cpp
@@ -25,7 +25,7 @@ static errr rd_inventory(PlayerType *player_ptr)
     player_ptr->equip_cnt = 0;
 
     //! @todo std::make_shared の配列対応版は C++20 から
-    player_ptr->inventory_list = std::shared_ptr<ItemEntity[]>{ new ItemEntity[INVEN_TOTAL] };
+    player_ptr->inventory = std::shared_ptr<ItemEntity[]>{ new ItemEntity[INVEN_TOTAL] };
 
     int slot = 0;
     auto item_loader = ItemLoaderFactory::create_loader();
@@ -44,7 +44,7 @@ static errr rd_inventory(PlayerType *player_ptr)
 
         if (n >= INVEN_MAIN_HAND) {
             item.marked.set(OmType::TOUCHED);
-            player_ptr->inventory_list[n] = std::move(item);
+            player_ptr->inventory[n] = std::move(item);
             player_ptr->equip_cnt++;
             continue;
         }
@@ -56,7 +56,7 @@ static errr rd_inventory(PlayerType *player_ptr)
 
         n = slot++;
         item.marked.set(OmType::TOUCHED);
-        player_ptr->inventory_list[n] = std::move(item);
+        player_ptr->inventory[n] = std::move(item);
         player_ptr->inven_cnt++;
     }
 

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -43,7 +43,7 @@ bool exchange_cash(PlayerType *player_ptr)
     constexpr auto fmt_convert = _("%s を換金しますか？", "Convert %s into money? ");
     constexpr auto fmt_reward = _("賞金 %d＄を手に入れた。", "You get %dgp.");
     for (INVENTORY_IDX i = 0; i <= INVEN_SUB_HAND; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (item.bi_key.tval() != ItemKindType::CAPTURE) {
             continue;
         }
@@ -66,7 +66,7 @@ bool exchange_cash(PlayerType *player_ptr)
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!item.is_corpse()) {
             continue;
         }
@@ -89,7 +89,7 @@ bool exchange_cash(PlayerType *player_ptr)
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) {
             continue;
         }
@@ -113,7 +113,7 @@ bool exchange_cash(PlayerType *player_ptr)
 
     auto &world = AngbandWorld::get_instance();
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         const auto &monrace = world.get_today_bounty();
         if (!item.is_corpse() || (item.get_monrace().name != monrace.name)) {
             continue;
@@ -133,7 +133,7 @@ bool exchange_cash(PlayerType *player_ptr)
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         const auto &monrace = world.get_today_bounty();
         if ((item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) || (item.get_monrace().name != monrace.name)) {
             continue;
@@ -158,7 +158,7 @@ bool exchange_cash(PlayerType *player_ptr)
         }
 
         for (INVENTORY_IDX i = INVEN_PACK - 1; i >= 0; i--) {
-            auto &item = player_ptr->inventory_list[i];
+            auto &item = player_ptr->inventory[i];
             if ((item.bi_key.tval() != ItemKindType::MONSTER_REMAINS) || (item.get_monrace().idx != monrace_id)) {
                 continue;
             }

--- a/src/market/building-craft-weapon.cpp
+++ b/src/market/building-craft-weapon.cpp
@@ -307,7 +307,7 @@ PRICE compare_weapons(PlayerType *player_ptr, PRICE bcost)
 
     screen_save();
     clear_bldg(0, 22);
-    auto *i_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
+    auto *i_ptr = &player_ptr->inventory[INVEN_MAIN_HAND];
     auto orig_weapon = i_ptr->clone();
 
     constexpr auto first_q = _("第一の武器は？", "What is your first weapon? ");

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -178,7 +178,7 @@ void building_recharge_all(PlayerType *player_ptr)
     auto price = 0;
     auto total_cost = 0;
     for (short i = 0; i < INVEN_PACK; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!item.can_recharge()) {
             continue;
         }
@@ -230,7 +230,7 @@ void building_recharge_all(PlayerType *player_ptr)
     }
 
     for (short i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->can_recharge()) {
             continue;
         }

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -413,7 +413,7 @@ bool cast_ninja_spell(PlayerType *player_ptr, MindNinjaType spell)
             OBJECT_IDX slot;
 
             for (slot = 0; slot < INVEN_PACK; slot++) {
-                if (player_ptr->inventory_list[slot].bi_key.tval() == ItemKindType::SPIKE) {
+                if (player_ptr->inventory[slot].bi_key.tval() == ItemKindType::SPIKE) {
                     break;
                 }
             }

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -451,7 +451,7 @@ bool choose_samurai_stance(PlayerType *player_ptr)
  */
 int calc_attack_quality(PlayerType *player_ptr, player_attack_type *pa_ptr)
 {
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + pa_ptr->hand];
     int bonus = player_ptr->to_h[pa_ptr->hand] + o_ptr->to_h;
     int chance = (player_ptr->skill_thn + (bonus * BTH_PLUS_ADJ));
     if (pa_ptr->mode == HISSATSU_IAI) {

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -526,7 +526,7 @@ MULTIPLY calc_snipe_damage_with_slay(PlayerType *player_ptr, MULTIPLY mult, cons
  */
 static bool cast_sniper_spell(PlayerType *player_ptr, int spell)
 {
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    auto *o_ptr = &player_ptr->inventory[INVEN_BOW];
     if (o_ptr->bi_key.tval() != ItemKindType::BOW) {
         msg_print(_("弓を装備していない！", "You wield no bow!"));
         return false;

--- a/src/monster-attack/monster-attack-player.cpp
+++ b/src/monster-attack/monster-attack-player.cpp
@@ -447,8 +447,8 @@ void MonsterAttackPlayer::describe_attack_evasion()
 
 void MonsterAttackPlayer::gain_armor_exp()
 {
-    const auto o_ptr_mh = &this->player_ptr->inventory_list[INVEN_MAIN_HAND];
-    const auto o_ptr_sh = &this->player_ptr->inventory_list[INVEN_SUB_HAND];
+    const auto o_ptr_mh = &this->player_ptr->inventory[INVEN_MAIN_HAND];
+    const auto o_ptr_sh = &this->player_ptr->inventory[INVEN_SUB_HAND];
     if (!o_ptr_mh->is_protector() && !o_ptr_sh->is_protector()) {
         return;
     }

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -112,7 +112,7 @@ static void calc_blow_un_power(PlayerType *player_ptr, MonsterAttackPlayer *mona
     int max_draining_item = is_magic_mastery ? 5 : 10;
     for (int i = 0; i < max_draining_item; i++) {
         auto i_idx = randnum0<short>(INVEN_PACK);
-        monap_ptr->o_ptr = &player_ptr->inventory_list[i_idx];
+        monap_ptr->o_ptr = &player_ptr->inventory[i_idx];
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;
         }
@@ -397,7 +397,7 @@ void switch_monster_blow_to_player(PlayerType *player_ptr, MonsterAttackPlayer *
         break;
     }
     case RaceBlowEffectType::EAT_LITE: {
-        monap_ptr->o_ptr = &player_ptr->inventory_list[INVEN_LITE];
+        monap_ptr->o_ptr = &player_ptr->inventory[INVEN_LITE];
         monap_ptr->get_damage += take_hit(player_ptr, DAMAGE_ATTACK, monap_ptr->damage, monap_ptr->ddesc);
         if (player_ptr->is_dead || check_multishadow(player_ptr)) {
             break;

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -132,7 +132,7 @@ void process_eat_item(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 {
     for (int i = 0; i < 10; i++) {
         auto i_idx = randnum0<short>(INVEN_PACK);
-        monap_ptr->o_ptr = &player_ptr->inventory_list[i_idx];
+        monap_ptr->o_ptr = &player_ptr->inventory[i_idx];
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;
         }
@@ -162,7 +162,7 @@ void process_eat_food(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 {
     for (int i = 0; i < 10; i++) {
         auto i_idx = randnum0<short>(INVEN_PACK);
-        monap_ptr->o_ptr = &player_ptr->inventory_list[i_idx];
+        monap_ptr->o_ptr = &player_ptr->inventory[i_idx];
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;
         }

--- a/src/mspell/mspell-damage-calculator.cpp
+++ b/src/mspell/mspell-damage-calculator.cpp
@@ -457,9 +457,9 @@ int monspell_bluemage_damage(PlayerType *player_ptr, MonsterAbilityType ms_type,
     ItemEntity *o_ptr = nullptr;
 
     if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND)) {
-        o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
+        o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND];
     } else if (has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
-        o_ptr = &player_ptr->inventory_list[INVEN_SUB_HAND];
+        o_ptr = &player_ptr->inventory[INVEN_SUB_HAND];
     }
 
     const auto shoot_base = o_ptr ? o_ptr->to_d : 0;

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -212,7 +212,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
             hp_player(player_ptr, 10);
         }
 
-        auto &item = player_ptr->inventory_list[INVEN_LITE];
+        auto &item = player_ptr->inventory[INVEN_LITE];
         if (item.bi_key.tval() == ItemKindType::LITE) {
             if (!item.is_fixed_artifact() && (item.fuel > 0)) {
                 hp_player(player_ptr, item.fuel / 20);
@@ -449,14 +449,14 @@ bool drop_weapons(PlayerType *player_ptr)
     msg_print(nullptr);
     if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND)) {
         slot = INVEN_MAIN_HAND;
-        o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
+        o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND];
 
         if (has_melee_weapon(player_ptr, INVEN_SUB_HAND) && one_in_(2)) {
-            o_ptr = &player_ptr->inventory_list[INVEN_SUB_HAND];
+            o_ptr = &player_ptr->inventory[INVEN_SUB_HAND];
             slot = INVEN_SUB_HAND;
         }
     } else if (has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
-        o_ptr = &player_ptr->inventory_list[INVEN_SUB_HAND];
+        o_ptr = &player_ptr->inventory[INVEN_SUB_HAND];
         slot = INVEN_SUB_HAND;
     }
 

--- a/src/object-enchant/object-curse.cpp
+++ b/src/object-enchant/object-curse.cpp
@@ -69,7 +69,7 @@ void curse_equipment(PlayerType *player_ptr, PERCENTAGE chance, PERCENTAGE heavy
         return;
     }
 
-    auto &item = player_ptr->inventory_list[INVEN_MAIN_HAND + randint0(12)];
+    auto &item = player_ptr->inventory[INVEN_MAIN_HAND + randint0(12)];
     if (!item.is_valid()) {
         return;
     }

--- a/src/object-enchant/vorpal-weapon.cpp
+++ b/src/object-enchant/vorpal-weapon.cpp
@@ -80,7 +80,7 @@ void process_vorpal_attack(PlayerType *player_ptr, player_attack_type *pa_ptr, c
         return;
     }
 
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     int vorpal_magnification = 2;
     print_chainsword_noise(o_ptr);
     if (o_ptr->is_specific_artifact(FixedArtifactId::VORPAL_BLADE)) {

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -39,7 +39,7 @@ bool item_tester_hook_use(PlayerType *player_ptr, const ItemEntity *o_ptr)
         }
 
         for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            if ((&player_ptr->inventory_list[i] == o_ptr) && o_ptr->get_flags().has(TR_ACTIVATE)) {
+            if ((&player_ptr->inventory[i] == o_ptr) && o_ptr->get_flags().has(TR_ACTIVATE)) {
                 return true;
             }
         }

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -93,7 +93,7 @@ bool ScrollReadExecutor::read()
             k = INVEN_SUB_HAND;
         }
 
-        if (k && curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[k])) {
+        if (k && curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory[k])) {
             this->ident = true;
         }
 

--- a/src/object-use/throw-execution.cpp
+++ b/src/object-use/throw-execution.cpp
@@ -283,7 +283,7 @@ void ObjectThrowEntity::process_boomerang_back()
             return;
         }
 
-        this->o_ptr = &player_ptr->inventory_list[this->i_idx];
+        this->o_ptr = &player_ptr->inventory[this->i_idx];
         *this->o_ptr = this->q_ptr->clone();
         this->player_ptr->equip_cnt++;
         auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -321,7 +321,7 @@ bool ObjectThrowEntity::check_what_throw()
 {
     if (this->shuriken >= 0) {
         this->i_idx = this->shuriken;
-        this->o_ptr = &this->player_ptr->inventory_list[this->i_idx];
+        this->o_ptr = &this->player_ptr->inventory[this->i_idx];
         return true;
     }
 
@@ -357,12 +357,12 @@ bool ObjectThrowEntity::check_throw_boomerang()
 
     if (has_melee_weapon(this->player_ptr, INVEN_SUB_HAND)) {
         this->i_idx = INVEN_SUB_HAND;
-        this->o_ptr = &this->player_ptr->inventory_list[this->i_idx];
+        this->o_ptr = &this->player_ptr->inventory[this->i_idx];
         return true;
     }
 
     this->i_idx = INVEN_MAIN_HAND;
-    this->o_ptr = &this->player_ptr->inventory_list[this->i_idx];
+    this->o_ptr = &this->player_ptr->inventory[this->i_idx];
     return true;
 }
 

--- a/src/object-use/use-execution.cpp
+++ b/src/object-use/use-execution.cpp
@@ -145,7 +145,7 @@ void ObjectUseEntity::execute()
     }
 
     if (this->i_idx >= 0) {
-        inven_item_charges(this->player_ptr->inventory_list[this->i_idx]);
+        inven_item_charges(this->player_ptr->inventory[this->i_idx]);
     } else {
         floor_item_charges(*this->player_ptr->current_floor_ptr, 0 - this->i_idx);
     }

--- a/src/object-use/zapwand-execution.cpp
+++ b/src/object-use/zapwand-execution.cpp
@@ -135,7 +135,7 @@ void ObjectZapWandEntity::execute(INVENTORY_IDX i_idx)
     rfu.set_flags(flags_srf);
     o_ptr->pval--;
     if (i_idx >= 0) {
-        inven_item_charges(this->player_ptr->inventory_list[i_idx]);
+        inven_item_charges(this->player_ptr->inventory[i_idx]);
         return;
     }
 

--- a/src/object/lite-processor.cpp
+++ b/src/object/lite-processor.cpp
@@ -19,7 +19,7 @@
  */
 void reduce_lite_life(PlayerType *player_ptr)
 {
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_LITE];
+    auto *o_ptr = &player_ptr->inventory[INVEN_LITE];
     if (o_ptr->bi_key.tval() != ItemKindType::LITE) {
         return;
     }

--- a/src/object/object-info.cpp
+++ b/src/object/object-info.cpp
@@ -43,11 +43,11 @@ int16_t wield_slot(PlayerType *player_ptr, const ItemEntity *o_ptr)
     case ItemKindType::HAFTED:
     case ItemKindType::POLEARM:
     case ItemKindType::SWORD:
-        if (!player_ptr->inventory_list[INVEN_MAIN_HAND].bi_id) {
+        if (!player_ptr->inventory[INVEN_MAIN_HAND].bi_id) {
             return INVEN_MAIN_HAND;
         }
 
-        if (player_ptr->inventory_list[INVEN_SUB_HAND].bi_id) {
+        if (player_ptr->inventory[INVEN_SUB_HAND].bi_id) {
             return INVEN_MAIN_HAND;
         }
 
@@ -55,11 +55,11 @@ int16_t wield_slot(PlayerType *player_ptr, const ItemEntity *o_ptr)
     case ItemKindType::CAPTURE:
     case ItemKindType::CARD:
     case ItemKindType::SHIELD:
-        if (!player_ptr->inventory_list[INVEN_SUB_HAND].bi_id) {
+        if (!player_ptr->inventory[INVEN_SUB_HAND].bi_id) {
             return INVEN_SUB_HAND;
         }
 
-        if (player_ptr->inventory_list[INVEN_MAIN_HAND].bi_id) {
+        if (player_ptr->inventory[INVEN_MAIN_HAND].bi_id) {
             return INVEN_SUB_HAND;
         }
 
@@ -67,7 +67,7 @@ int16_t wield_slot(PlayerType *player_ptr, const ItemEntity *o_ptr)
     case ItemKindType::BOW:
         return INVEN_BOW;
     case ItemKindType::RING:
-        if (!player_ptr->inventory_list[INVEN_MAIN_RING].bi_id) {
+        if (!player_ptr->inventory[INVEN_MAIN_RING].bi_id) {
             return INVEN_MAIN_RING;
         }
 
@@ -126,5 +126,5 @@ bool check_book_realm(PlayerType *player_ptr, const BaseitemKey &bi_key)
 ItemEntity *ref_item(PlayerType *player_ptr, INVENTORY_IDX i_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    return i_idx >= 0 ? &player_ptr->inventory_list[i_idx] : &(floor.o_list[0 - i_idx]);
+    return i_idx >= 0 ? &player_ptr->inventory[i_idx] : &(floor.o_list[0 - i_idx]);
 }

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -38,14 +38,14 @@ ItemEntity *choose_warning_item(PlayerType *player_ptr)
     /* Search Inventory */
     std::vector<int> candidates;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = &player_ptr->inventory_list[i];
+        const auto *o_ptr = &player_ptr->inventory[i];
         if (o_ptr->get_flags().has(TR_WARNING)) {
             candidates.push_back(i);
         }
     }
 
     /* Choice one of them */
-    return candidates.empty() ? nullptr : &player_ptr->inventory_list[rand_choice(candidates)];
+    return candidates.empty() ? nullptr : &player_ptr->inventory[rand_choice(candidates)];
 }
 
 /*!

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -35,7 +35,7 @@
  */
 static void sense_inventory_aux(PlayerType *player_ptr, INVENTORY_IDX slot, bool heavy)
 {
-    auto &item = player_ptr->inventory_list[slot];
+    auto &item = player_ptr->inventory[slot];
     if (any_bits(item.ident, IDENT_SENSE) || item.is_known()) {
         return;
     }
@@ -280,7 +280,7 @@ void sense_inventory1(PlayerType *player_ptr)
     }
 
     for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
 
         if (!o_ptr->is_valid()) {
             continue;
@@ -409,7 +409,7 @@ void sense_inventory2(PlayerType *player_ptr)
 
     for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
         bool okay = false;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -311,7 +311,7 @@ void change_monster_stat(PlayerType *player_ptr, player_attack_type *pa_ptr, con
         attack_polymorph(player_ptr, pa_ptr, y, x);
     }
 
-    const auto &item = player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    const auto &item = player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     if (item.is_specific_artifact(FixedArtifactId::G_HAMMER)) {
         attack_golden_hammer(player_ptr, pa_ptr);
     }

--- a/src/player-attack/blood-sucking-processor.cpp
+++ b/src/player-attack/blood-sucking-processor.cpp
@@ -61,7 +61,7 @@ static void drain_muramasa(PlayerType *player_ptr, player_attack_type *pa_ptr, c
         return;
     }
 
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     HIT_PROB to_h = o_ptr->to_h;
     int to_d = o_ptr->to_d;
     bool flag = true;
@@ -153,7 +153,7 @@ void process_drain(PlayerType *player_ptr, player_attack_type *pa_ptr, const boo
         return;
     }
 
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     if (o_ptr->is_specific_artifact(FixedArtifactId::MURAMASA)) {
         drain_muramasa(player_ptr, pa_ptr, is_human);
     } else {

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -114,7 +114,7 @@ static void get_bare_knuckle_exp(PlayerType *player_ptr, player_attack_type *pa_
  */
 static void get_weapon_exp(PlayerType *player_ptr, player_attack_type *pa_ptr)
 {
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
 
     PlayerSkill(player_ptr).gain_melee_weapon_exp(o_ptr);
 }
@@ -127,7 +127,7 @@ static void get_weapon_exp(PlayerType *player_ptr, player_attack_type *pa_ptr)
 static void get_attack_exp(PlayerType *player_ptr, player_attack_type *pa_ptr)
 {
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     if (!o_ptr->is_valid()) {
         get_bare_knuckle_exp(player_ptr, pa_ptr);
         return;
@@ -156,7 +156,7 @@ static void calc_num_blow(PlayerType *player_ptr, player_attack_type *pa_ptr)
         pa_ptr->num_blow = player_ptr->num_blow[pa_ptr->hand];
     }
 
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     if (o_ptr->bi_key == BaseitemKey(ItemKindType::SWORD, SV_POISON_NEEDLE)) {
         pa_ptr->num_blow = 1;
     }
@@ -313,7 +313,7 @@ static bool does_weapon_has_flag(BIT_FLAGS &attacker_flags, player_attack_type *
  */
 static void process_weapon_attack(PlayerType *player_ptr, player_attack_type *pa_ptr, bool *do_quake, const bool vorpal_cut, const int vorpal_chance)
 {
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     const auto num = o_ptr->damage_dice.num + player_ptr->damage_dice_bonus[pa_ptr->hand].num + magical_brand_extra_dice(pa_ptr);
     const auto sides = o_ptr->damage_dice.sides + player_ptr->damage_dice_bonus[pa_ptr->hand].sides;
     pa_ptr->attack_damage = calc_attack_damage_with_slay(player_ptr, o_ptr, Dice::roll(num, sides), *pa_ptr->m_ptr, pa_ptr->mode, false);
@@ -345,7 +345,7 @@ static void process_weapon_attack(PlayerType *player_ptr, player_attack_type *pa
  */
 static void calc_attack_damage(PlayerType *player_ptr, player_attack_type *pa_ptr, bool *do_quake, const bool vorpal_cut, const int vorpal_chance)
 {
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     pa_ptr->attack_damage = 1;
     if (pa_ptr->monk_attack) {
         process_monk_attack(player_ptr, pa_ptr);
@@ -446,7 +446,7 @@ static bool check_fear_death(PlayerType *player_ptr, player_attack_type *pa_ptr,
         }
     }
 
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     if ((o_ptr->is_specific_artifact(FixedArtifactId::ZANTETSU)) && is_lowlevel) {
         msg_print(_("またつまらぬものを斬ってしまった．．．", "Sigh... Another trifling thing I've cut...."));
     }
@@ -465,7 +465,7 @@ static bool check_fear_death(PlayerType *player_ptr, player_attack_type *pa_ptr,
 static void apply_actual_attack(
     PlayerType *player_ptr, player_attack_type *pa_ptr, bool *do_quake, const bool is_zantetsu_nullified, const bool is_ej_nullified)
 {
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     int vorpal_chance = (o_ptr->is_specific_artifact(FixedArtifactId::VORPAL_BLADE) || o_ptr->is_specific_artifact(FixedArtifactId::CHAINSWORD)) ? 2 : 4;
 
     sound(SoundKind::HIT);
@@ -541,7 +541,7 @@ void exe_player_attack_to_monster(PlayerType *player_ptr, POSITION y, POSITION x
     angband_strcpy(pa_ptr->m_name, monster_desc(player_ptr, *pa_ptr->m_ptr, 0), sizeof(pa_ptr->m_name));
 
     int chance = calc_attack_quality(player_ptr, pa_ptr);
-    auto *o_ptr = &player_ptr->inventory_list[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[enum2i(INVEN_MAIN_HAND) + pa_ptr->hand];
     const auto is_zantetsu_nullified = o_ptr->is_specific_artifact(FixedArtifactId::ZANTETSU) && pa_ptr->r_ptr->symbol_char_is_any_of("j");
     const auto is_ej_nullified = o_ptr->is_specific_artifact(FixedArtifactId::EXCALIBUR_J) && pa_ptr->r_ptr->symbol_char_is_any_of("S");
     calc_num_blow(player_ptr, pa_ptr);

--- a/src/player-base/player-class.cpp
+++ b/src/player-base/player-class.cpp
@@ -533,9 +533,9 @@ void PlayerClass::init_specific_data()
 
 bool PlayerClass::has_ninja_speed() const
 {
-    auto has_ninja_speed_main = !this->player_ptr->inventory_list[INVEN_MAIN_HAND].is_valid();
+    auto has_ninja_speed_main = !this->player_ptr->inventory[INVEN_MAIN_HAND].is_valid();
     has_ninja_speed_main |= can_attack_with_main_hand(this->player_ptr);
-    auto has_ninja_speed_sub = !this->player_ptr->inventory_list[INVEN_SUB_HAND].is_valid();
+    auto has_ninja_speed_sub = !this->player_ptr->inventory[INVEN_SUB_HAND].is_valid();
     has_ninja_speed_sub |= can_attack_with_sub_hand(this->player_ptr);
     return has_ninja_speed_main && has_ninja_speed_sub;
 }

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -92,7 +92,7 @@ void PlayerAlignment::update_alignment()
     }
 
     for (int i = 0; i < 2; i++) {
-        const auto &wielding_weapon = this->player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+        const auto &wielding_weapon = this->player_ptr->inventory[INVEN_MAIN_HAND + i];
         if (!has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND + i) || !wielding_weapon.is_specific_artifact(FixedArtifactId::IRON_BALL)) {
             continue;
         }

--- a/src/player-info/base-status-info.cpp
+++ b/src/player-info/base-status-info.cpp
@@ -9,7 +9,7 @@
 void set_equipment_influence(PlayerType *player_ptr, self_info_type *self_ptr)
 {
     for (int k = INVEN_MAIN_HAND; k < INVEN_TOTAL; k++) {
-        auto *o_ptr = &player_ptr->inventory_list[k];
+        auto *o_ptr = &player_ptr->inventory[k];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player-info/equipment-info.cpp
+++ b/src/player-info/equipment-info.cpp
@@ -16,7 +16,7 @@
  */
 bool has_melee_weapon(PlayerType *player_ptr, int slot)
 {
-    const auto o_ptr = &player_ptr->inventory_list[slot];
+    const auto o_ptr = &player_ptr->inventory[slot];
     return o_ptr->is_valid() && o_ptr->is_melee_weapon();
 }
 
@@ -28,10 +28,10 @@ bool has_melee_weapon(PlayerType *player_ptr, int slot)
 BIT_FLAGS16 empty_hands(PlayerType *player_ptr, bool riding_control)
 {
     BIT_FLAGS16 status = EMPTY_HAND_NONE;
-    if (!player_ptr->inventory_list[INVEN_MAIN_HAND].is_valid()) {
+    if (!player_ptr->inventory[INVEN_MAIN_HAND].is_valid()) {
         status |= EMPTY_HAND_MAIN;
     }
-    if (!player_ptr->inventory_list[INVEN_SUB_HAND].is_valid()) {
+    if (!player_ptr->inventory[INVEN_SUB_HAND].is_valid()) {
         status |= EMPTY_HAND_SUB;
     }
 
@@ -63,19 +63,19 @@ bool heavy_armor(PlayerType *player_ptr)
     }
 
     WEIGHT monk_arm_wgt = 0;
-    if (player_ptr->inventory_list[INVEN_MAIN_HAND].bi_key.tval() > ItemKindType::SWORD) {
-        monk_arm_wgt += player_ptr->inventory_list[INVEN_MAIN_HAND].weight;
+    if (player_ptr->inventory[INVEN_MAIN_HAND].bi_key.tval() > ItemKindType::SWORD) {
+        monk_arm_wgt += player_ptr->inventory[INVEN_MAIN_HAND].weight;
     }
 
-    if (player_ptr->inventory_list[INVEN_SUB_HAND].bi_key.tval() > ItemKindType::SWORD) {
-        monk_arm_wgt += player_ptr->inventory_list[INVEN_SUB_HAND].weight;
+    if (player_ptr->inventory[INVEN_SUB_HAND].bi_key.tval() > ItemKindType::SWORD) {
+        monk_arm_wgt += player_ptr->inventory[INVEN_SUB_HAND].weight;
     }
 
-    monk_arm_wgt += player_ptr->inventory_list[INVEN_BODY].weight;
-    monk_arm_wgt += player_ptr->inventory_list[INVEN_HEAD].weight;
-    monk_arm_wgt += player_ptr->inventory_list[INVEN_OUTER].weight;
-    monk_arm_wgt += player_ptr->inventory_list[INVEN_ARMS].weight;
-    monk_arm_wgt += player_ptr->inventory_list[INVEN_FEET].weight;
+    monk_arm_wgt += player_ptr->inventory[INVEN_BODY].weight;
+    monk_arm_wgt += player_ptr->inventory[INVEN_HEAD].weight;
+    monk_arm_wgt += player_ptr->inventory[INVEN_OUTER].weight;
+    monk_arm_wgt += player_ptr->inventory[INVEN_ARMS].weight;
+    monk_arm_wgt += player_ptr->inventory[INVEN_FEET].weight;
 
     return monk_arm_wgt > (100 + (player_ptr->lev * 4));
 }

--- a/src/player-info/weapon-effect-info.cpp
+++ b/src/player-info/weapon-effect-info.cpp
@@ -124,7 +124,7 @@ static void set_slay_info(self_info_type *self_ptr)
 
 void set_weapon_effect_info(PlayerType *player_ptr, self_info_type *self_ptr)
 {
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND];
+    auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND];
     if (!o_ptr->is_valid()) {
         return;
     }

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -211,7 +211,7 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -234,7 +234,7 @@ BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &this->player_ptr->inventory_list[i];
+        auto *o_ptr = &this->player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -259,7 +259,7 @@ int16_t PlayerStatusBase::equipments_bonus()
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     int16_t bonus = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = &player_ptr->inventory_list[i];
+        const auto *o_ptr = &player_ptr->inventory[i];
         const auto o_flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/player/patron.cpp
+++ b/src/player/patron.cpp
@@ -337,19 +337,19 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                 }
             }
 
-            const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
-            (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
+            const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory[slot], OD_NAME_ONLY);
+            (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory[slot]);
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
         }
         case REW_CURSE_AR: {
-            if (!this->player_ptr->inventory_list[INVEN_BODY].is_valid()) {
+            if (!this->player_ptr->inventory[INVEN_BODY].is_valid()) {
                 break;
             }
 
             msg_format(_("%sの声が響き渡った:", "The voice of %s booms out:"), this->name.data());
             msg_print(_("「汝、防具に頼ることなかれ。」", "'Thou reliest too much on thine equipment.'"));
-            const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+            const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory[INVEN_BODY], OD_NAME_ONLY);
             (void)curse_armor(this->player_ptr);
             reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
             break;
@@ -380,15 +380,15 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                         }
                     }
 
-                    const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[slot], OD_NAME_ONLY);
-                    (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
+                    const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory[slot], OD_NAME_ONLY);
+                    (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory[slot]);
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 } else {
-                    if (!this->player_ptr->inventory_list[INVEN_BODY].is_valid()) {
+                    if (!this->player_ptr->inventory[INVEN_BODY].is_valid()) {
                         break;
                     }
 
-                    const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory_list[INVEN_BODY], OD_NAME_ONLY);
+                    const auto item_name = describe_flavor(this->player_ptr, this->player_ptr->inventory[INVEN_BODY], OD_NAME_ONLY);
                     (void)curse_armor(this->player_ptr);
                     reward = format(_("%sが破壊された。", "destroying %s"), item_name.data());
                 }
@@ -425,7 +425,7 @@ void Patron::gain_level_reward(PlayerType *player_ptr_, int chosen_reward)
                 }
 
                 if (slot) {
-                    (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory_list[slot]);
+                    (void)curse_weapon_object(this->player_ptr, false, &this->player_ptr->inventory[slot]);
                 }
             }
 

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -94,7 +94,7 @@ static bool acid_minus_ac(PlayerType *player_ptr)
     };
 
     const auto slot = rand_choice(candidates);
-    auto &item = player_ptr->inventory_list[slot];
+    auto &item = player_ptr->inventory[slot];
     if (!item.is_valid() || !item.is_protector()) {
         return false;
     }

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -119,7 +119,7 @@ BIT_FLAGS check_equipment_flags(PlayerType *player_ptr, tr_type tr_flag)
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -719,7 +719,7 @@ void check_no_flowed(PlayerType *player_ptr)
     }
 
     for (int i = 0; i < INVEN_PACK; i++) {
-        const auto &bi_key = player_ptr->inventory_list[i].bi_key;
+        const auto &bi_key = player_ptr->inventory[i].bi_key;
         if (bi_key == BaseitemKey(ItemKindType::NATURE_BOOK, 2)) {
             has_sw = true;
         }
@@ -788,7 +788,7 @@ BIT_FLAGS has_warning(PlayerType *player_ptr)
     ItemEntity *o_ptr;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1055,7 +1055,7 @@ void update_curses(PlayerType *player_ptr)
     }
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1165,7 +1165,7 @@ void update_extra_blows(PlayerType *player_ptr)
     const bool two_handed = (melee_type == MELEE_TYPE_WEAPON_TWOHAND || melee_type == MELEE_TYPE_BAREHAND_TWO);
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1468,7 +1468,7 @@ BIT_FLAGS has_vuln_curse(PlayerType *player_ptr)
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1493,7 +1493,7 @@ BIT_FLAGS has_heavy_vuln_curse(PlayerType *player_ptr)
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1653,9 +1653,9 @@ bool can_attack_with_sub_hand(PlayerType *player_ptr)
 bool has_two_handed_weapons(PlayerType *player_ptr)
 {
     if (can_two_hands_wielding(player_ptr)) {
-        if (can_attack_with_main_hand(player_ptr) && (empty_hands(player_ptr, false) == EMPTY_HAND_SUB) && player_ptr->inventory_list[INVEN_MAIN_HAND].allow_two_hands_wielding()) {
+        if (can_attack_with_main_hand(player_ptr) && (empty_hands(player_ptr, false) == EMPTY_HAND_SUB) && player_ptr->inventory[INVEN_MAIN_HAND].allow_two_hands_wielding()) {
             return true;
-        } else if (can_attack_with_sub_hand(player_ptr) && (empty_hands(player_ptr, false) == EMPTY_HAND_MAIN) && player_ptr->inventory_list[INVEN_SUB_HAND].allow_two_hands_wielding()) {
+        } else if (can_attack_with_sub_hand(player_ptr) && (empty_hands(player_ptr, false) == EMPTY_HAND_MAIN) && player_ptr->inventory[INVEN_SUB_HAND].allow_two_hands_wielding()) {
             return true;
         }
     }
@@ -1695,7 +1695,7 @@ BIT_FLAGS has_lite(PlayerType *player_ptr)
 bool has_disable_two_handed_bonus(PlayerType *player_ptr, int i)
 {
     if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND + i) && has_two_handed_weapons(player_ptr)) {
-        auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+        auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
         int limit = calc_weapon_weight_limit(player_ptr);
 
         /* Enable when two hand wields an enough light weapon */
@@ -1714,7 +1714,7 @@ bool has_disable_two_handed_bonus(PlayerType *player_ptr, int i)
  */
 bool is_wielding_icky_weapon(PlayerType *player_ptr, int i)
 {
-    const auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+    const auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
     const auto flags = o_ptr->get_flags();
 
     const auto tval = o_ptr->bi_key.tval();
@@ -1742,7 +1742,7 @@ bool is_wielding_icky_weapon(PlayerType *player_ptr, int i)
  */
 bool is_wielding_icky_riding_weapon(PlayerType *player_ptr, int i)
 {
-    const auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+    const auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
     const auto flags = o_ptr->get_flags();
     const auto tval = o_ptr->bi_key.tval();
     const auto has_no_weapon = (tval == ItemKindType::NONE) || (tval == ItemKindType::SHIELD);
@@ -1756,12 +1756,12 @@ bool has_not_ninja_weapon(PlayerType *player_ptr, int i)
         return false;
     }
 
-    const auto &item = player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+    const auto &item = player_ptr->inventory[INVEN_MAIN_HAND + i];
     const auto tval = item.bi_key.tval();
     const auto sval = *item.bi_key.sval();
     return PlayerClass(player_ptr).equals(PlayerClassType::NINJA) &&
            !((player_ptr->weapon_exp_max[tval][sval] > PlayerSkill::weapon_exp_at(PlayerSkillRank::BEGINNER)) &&
-               (player_ptr->inventory_list[INVEN_SUB_HAND - i].bi_key.tval() != ItemKindType::SHIELD));
+               (player_ptr->inventory[INVEN_SUB_HAND - i].bi_key.tval() != ItemKindType::SHIELD));
 }
 
 bool has_not_monk_weapon(PlayerType *player_ptr, int i)
@@ -1770,7 +1770,7 @@ bool has_not_monk_weapon(PlayerType *player_ptr, int i)
         return false;
     }
 
-    const auto &item = player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+    const auto &item = player_ptr->inventory[INVEN_MAIN_HAND + i];
     const auto tval = item.bi_key.tval();
     const auto sval = *item.bi_key.sval();
     PlayerClass pc(player_ptr);

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -195,7 +195,7 @@ int calc_inventory_weight(PlayerType *player_ptr)
 {
     auto weight = 0;
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -318,7 +318,7 @@ static void update_bonuses(PlayerType *player_ptr)
     }
 
     update_ability_scores(player_ptr);
-    o_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    o_ptr = &player_ptr->inventory[INVEN_BOW];
     if (o_ptr->is_valid()) {
         player_ptr->tval_ammo = o_ptr->get_arrow_kind();
         player_ptr->num_fire = calc_num_fire(player_ptr, o_ptr);
@@ -742,7 +742,7 @@ static void update_max_mana(PlayerType *player_ptr)
 
     if (mp_ptr->has_glove_mp_penalty) {
         player_ptr->cumber_glove = false;
-        const auto *o_ptr = &player_ptr->inventory_list[INVEN_ARMS];
+        const auto *o_ptr = &player_ptr->inventory[INVEN_ARMS];
         const auto flags = o_ptr->get_flags();
         auto should_mp_decrease = o_ptr->is_valid();
         should_mp_decrease &= flags.has_not(TR_FREE_ACT);
@@ -759,23 +759,23 @@ static void update_max_mana(PlayerType *player_ptr)
     player_ptr->cumber_armor = false;
 
     auto cur_wgt = 0;
-    const auto &item_main_hand = player_ptr->inventory_list[INVEN_MAIN_HAND];
+    const auto &item_main_hand = player_ptr->inventory[INVEN_MAIN_HAND];
     const auto tval_main = item_main_hand.bi_key.tval();
     if (tval_main > ItemKindType::SWORD) {
         cur_wgt += item_main_hand.weight;
     }
 
-    const auto &item_sub_hand = player_ptr->inventory_list[INVEN_SUB_HAND];
+    const auto &item_sub_hand = player_ptr->inventory[INVEN_SUB_HAND];
     const auto tval_sub = item_sub_hand.bi_key.tval();
     if (item_sub_hand.bi_key.tval() > ItemKindType::SWORD) {
         cur_wgt += item_sub_hand.weight;
     }
 
-    cur_wgt += player_ptr->inventory_list[INVEN_BODY].weight;
-    cur_wgt += player_ptr->inventory_list[INVEN_HEAD].weight;
-    cur_wgt += player_ptr->inventory_list[INVEN_OUTER].weight;
-    cur_wgt += player_ptr->inventory_list[INVEN_ARMS].weight;
-    cur_wgt += player_ptr->inventory_list[INVEN_FEET].weight;
+    cur_wgt += player_ptr->inventory[INVEN_BODY].weight;
+    cur_wgt += player_ptr->inventory[INVEN_HEAD].weight;
+    cur_wgt += player_ptr->inventory[INVEN_OUTER].weight;
+    cur_wgt += player_ptr->inventory[INVEN_ARMS].weight;
+    cur_wgt += player_ptr->inventory[INVEN_FEET].weight;
 
     switch (player_ptr->pclass) {
     case PlayerClassType::MAGE:
@@ -959,7 +959,7 @@ short calc_num_fire(PlayerType *player_ptr, const ItemEntity *o_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *q_ptr;
-        q_ptr = &player_ptr->inventory_list[i];
+        q_ptr = &player_ptr->inventory[i];
         if (!q_ptr->is_valid()) {
             continue;
         }
@@ -1079,7 +1079,7 @@ static ACTION_SKILL_POWER calc_device_ability(PlayerType *player_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1207,7 +1207,7 @@ static ACTION_SKILL_POWER calc_search(PlayerType *player_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1256,7 +1256,7 @@ static ACTION_SKILL_POWER calc_search_freq(PlayerType *player_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1376,7 +1376,7 @@ static ACTION_SKILL_POWER calc_skill_dig(PlayerType *player_ptr)
 
     pow = 0;
 
-    if (PlayerRace(player_ptr).equals(PlayerRaceType::ENT) && !player_ptr->inventory_list[INVEN_MAIN_HAND].is_valid()) {
+    if (PlayerRace(player_ptr).equals(PlayerRaceType::ENT) && !player_ptr->inventory[INVEN_MAIN_HAND].is_valid()) {
         pow += player_ptr->lev * 10;
     }
 
@@ -1391,7 +1391,7 @@ static ACTION_SKILL_POWER calc_skill_dig(PlayerType *player_ptr)
     }
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1402,7 +1402,7 @@ static ACTION_SKILL_POWER calc_skill_dig(PlayerType *player_ptr)
     }
 
     for (int i = 0; i < 2; i++) {
-        o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+        o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
         if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND + i) && !player_ptr->heavy_wield[i]) {
             pow += (o_ptr->weight / 10);
         }
@@ -1430,7 +1430,7 @@ static bool is_martial_arts_mode(PlayerType *player_ptr)
 
 static bool is_heavy_wield(PlayerType *player_ptr, int i)
 {
-    const auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+    const auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
 
     return has_melee_weapon(player_ptr, INVEN_MAIN_HAND + i) && (calc_weapon_weight_limit(player_ptr) < o_ptr->weight / 10);
 }
@@ -1439,7 +1439,7 @@ static int16_t calc_num_blow(PlayerType *player_ptr, int i)
 {
     int16_t num_blow = 1;
 
-    const auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+    const auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
     PlayerClass pc(player_ptr);
     if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND + i)) {
         if (o_ptr->is_valid() && !player_ptr->heavy_wield[i]) {
@@ -1610,7 +1610,7 @@ static int16_t calc_to_magic_chance(PlayerType *player_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1635,15 +1635,15 @@ static ARMOUR_CLASS calc_base_ac(PlayerType *player_ptr)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
         ac += o_ptr->ac;
     }
 
-    const auto o_ptr_mh = &player_ptr->inventory_list[INVEN_MAIN_HAND];
-    const auto o_ptr_sh = &player_ptr->inventory_list[INVEN_SUB_HAND];
+    const auto o_ptr_mh = &player_ptr->inventory[INVEN_MAIN_HAND];
+    const auto o_ptr_sh = &player_ptr->inventory[INVEN_SUB_HAND];
     if (o_ptr_mh->is_protector() || o_ptr_sh->is_protector()) {
         ac += player_ptr->skill_exp[PlayerSkillKindType::SHIELD] * (1 + player_ptr->lev / 22) / 2000;
     }
@@ -1684,7 +1684,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
     }
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = &player_ptr->inventory_list[i];
+        const auto *o_ptr = &player_ptr->inventory[i];
         const auto flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1740,22 +1740,22 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
     }
 
     if (pc.is_martial_arts_pro() && !heavy_armor(player_ptr)) {
-        if (!player_ptr->inventory_list[INVEN_BODY].is_valid()) {
+        if (!player_ptr->inventory[INVEN_BODY].is_valid()) {
             ac += (player_ptr->lev * 3) / 2;
         }
-        if (!player_ptr->inventory_list[INVEN_OUTER].is_valid() && (player_ptr->lev > 15)) {
+        if (!player_ptr->inventory[INVEN_OUTER].is_valid() && (player_ptr->lev > 15)) {
             ac += ((player_ptr->lev - 13) / 3);
         }
-        if (!player_ptr->inventory_list[INVEN_SUB_HAND].is_valid() && (player_ptr->lev > 10)) {
+        if (!player_ptr->inventory[INVEN_SUB_HAND].is_valid() && (player_ptr->lev > 10)) {
             ac += ((player_ptr->lev - 8) / 3);
         }
-        if (!player_ptr->inventory_list[INVEN_HEAD].is_valid() && (player_ptr->lev > 4)) {
+        if (!player_ptr->inventory[INVEN_HEAD].is_valid() && (player_ptr->lev > 4)) {
             ac += (player_ptr->lev - 2) / 3;
         }
-        if (!player_ptr->inventory_list[INVEN_ARMS].is_valid()) {
+        if (!player_ptr->inventory[INVEN_ARMS].is_valid()) {
             ac += (player_ptr->lev / 2);
         }
-        if (!player_ptr->inventory_list[INVEN_FEET].is_valid()) {
+        if (!player_ptr->inventory[INVEN_FEET].is_valid()) {
             ac += (player_ptr->lev / 3);
         }
     }
@@ -1766,7 +1766,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
         }
 
         for (int i = INVEN_MAIN_HAND; i <= INVEN_FEET; i++) {
-            auto *o_ptr = &player_ptr->inventory_list[i];
+            auto *o_ptr = &player_ptr->inventory[i];
             if (!o_ptr->is_valid()) {
                 continue;
             }
@@ -1813,8 +1813,8 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
     }
 
     if (pc.equals(PlayerClassType::NINJA)) {
-        const auto bi_id_main = player_ptr->inventory_list[INVEN_MAIN_HAND].bi_id;
-        const auto bi_id_sub = player_ptr->inventory_list[INVEN_SUB_HAND].bi_id;
+        const auto bi_id_main = player_ptr->inventory[INVEN_MAIN_HAND].bi_id;
+        const auto bi_id_sub = player_ptr->inventory[INVEN_SUB_HAND].bi_id;
         if (((bi_id_main == 0) || can_attack_with_main_hand(player_ptr)) && ((bi_id_sub == 0) || can_attack_with_sub_hand(player_ptr))) {
             ac += player_ptr->lev / 2 + 5;
         }
@@ -1841,9 +1841,9 @@ int16_t calc_double_weapon_penalty(PlayerType *player_ptr, INVENTORY_IDX slot)
     int penalty = 0;
 
     if (has_melee_weapon(player_ptr, INVEN_MAIN_HAND) && has_melee_weapon(player_ptr, INVEN_SUB_HAND)) {
-        const auto flags = player_ptr->inventory_list[INVEN_SUB_HAND].get_flags();
+        const auto flags = player_ptr->inventory[INVEN_SUB_HAND].get_flags();
 
-        penalty = ((100 - player_ptr->skill_exp[PlayerSkillKindType::TWO_WEAPON] / 160) - (130 - player_ptr->inventory_list[slot].weight) / 8);
+        penalty = ((100 - player_ptr->skill_exp[PlayerSkillKindType::TWO_WEAPON] / 160) - (130 - player_ptr->inventory[slot].weight) / 8);
         if (set_quick_and_tiny(player_ptr) || set_icing_and_twinkle(player_ptr) || set_anubis_and_chariot(player_ptr)) {
             penalty = penalty / 2 - 5;
         }
@@ -1862,7 +1862,7 @@ int16_t calc_double_weapon_penalty(PlayerType *player_ptr, INVENTORY_IDX slot)
             penalty = std::min(0, penalty);
         }
 
-        if (player_ptr->inventory_list[slot].bi_key.tval() == ItemKindType::POLEARM) {
+        if (player_ptr->inventory[slot].bi_key.tval() == ItemKindType::POLEARM) {
             penalty += 10;
         }
     }
@@ -1923,11 +1923,11 @@ static int16_t calc_riding_bow_penalty(PlayerType *player_ptr)
 
 void put_equipment_warning(PlayerType *player_ptr)
 {
-    bool heavy_shoot = is_heavy_shoot(player_ptr, &player_ptr->inventory_list[INVEN_BOW]);
+    bool heavy_shoot = is_heavy_shoot(player_ptr, &player_ptr->inventory[INVEN_BOW]);
     if (player_ptr->old_heavy_shoot != heavy_shoot) {
         if (heavy_shoot) {
             msg_print(_("こんな重い弓を装備しているのは大変だ。", "You have trouble wielding such a heavy bow."));
-        } else if (player_ptr->inventory_list[INVEN_BOW].is_valid()) {
+        } else if (player_ptr->inventory[INVEN_BOW].is_valid()) {
             msg_print(_("この弓なら装備していても辛くない。", "You have no trouble wielding your bow."));
         } else {
             msg_print(_("重い弓を装備からはずして体が楽になった。", "You feel relieved to put down your heavy bow."));
@@ -2022,7 +2022,7 @@ static bool is_bare_knuckle(PlayerType *player_ptr)
 
 static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_real_value)
 {
-    const auto *o_ptr = &player_ptr->inventory_list[slot];
+    const auto *o_ptr = &player_ptr->inventory[slot];
     player_hand calc_hand = PLAYER_HAND_OTHER;
     if (slot == INVEN_MAIN_HAND) {
         calc_hand = PLAYER_HAND_MAIN;
@@ -2079,7 +2079,7 @@ static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         int bonus_to_d = 0;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         const auto has_melee = has_melee_weapon(player_ptr, i);
         if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
             continue;
@@ -2235,7 +2235,7 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
     /* Bonuses and penalties by weapon */
     PlayerClass pc(player_ptr);
     if (has_melee_weapon(player_ptr, slot)) {
-        const auto *o_ptr = &player_ptr->inventory_list[slot];
+        const auto *o_ptr = &player_ptr->inventory[slot];
 
         /* Traind bonuses */
         const auto tval = o_ptr->bi_key.tval();
@@ -2318,7 +2318,7 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
 
     /* Bonuses from inventory */
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
 
         /* Ignore empty hands, handed weapons, bows and capture balls */
         const auto has_melee = has_melee_weapon(player_ptr, i);
@@ -2418,7 +2418,7 @@ static int16_t calc_to_hit_bow(PlayerType *player_ptr, bool is_real_value)
 
     {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[INVEN_BOW];
+        o_ptr = &player_ptr->inventory[INVEN_BOW];
         if (o_ptr->is_valid()) {
             if (o_ptr->curse_flags.has(CurseTraitType::LOW_MELEE)) {
                 if (o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE)) {
@@ -2443,14 +2443,14 @@ static int16_t calc_to_hit_bow(PlayerType *player_ptr, bool is_real_value)
         pow -= 12;
     }
 
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    auto *o_ptr = &player_ptr->inventory[INVEN_BOW];
 
     if (is_heavy_shoot(player_ptr, o_ptr)) {
         pow += 2 * (calc_bow_weight_limit(player_ptr) - o_ptr->weight / 10);
     }
 
     if (o_ptr->is_valid()) {
-        if (!is_heavy_shoot(player_ptr, &player_ptr->inventory_list[INVEN_BOW])) {
+        if (!is_heavy_shoot(player_ptr, &player_ptr->inventory[INVEN_BOW])) {
             if (PlayerClass(player_ptr).equals(PlayerClassType::SNIPER) && (player_ptr->tval_ammo == ItemKindType::BOLT)) {
                 pow += (10 + (player_ptr->lev / 5));
             }
@@ -2460,7 +2460,7 @@ static int16_t calc_to_hit_bow(PlayerType *player_ptr, bool is_real_value)
     // 武器以外の装備による修正
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         int bonus_to_h;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         const auto has_melee = has_melee_weapon(player_ptr, i);
         if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
             continue;
@@ -2495,7 +2495,7 @@ static int16_t calc_to_damage_misc(PlayerType *player_ptr)
     int16_t to_dam = 0;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -2525,7 +2525,7 @@ static int16_t calc_to_hit_misc(PlayerType *player_ptr)
     int16_t to_hit = 0;
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -2560,7 +2560,7 @@ static int16_t calc_to_hit_misc(PlayerType *player_ptr)
 
 static int calc_to_weapon_dice_num(PlayerType *player_ptr, INVENTORY_IDX slot)
 {
-    auto *o_ptr = &player_ptr->inventory_list[slot];
+    auto *o_ptr = &player_ptr->inventory[slot];
     return (player_ptr->riding > 0) && o_ptr->is_lance() ? 2 : 0;
 }
 
@@ -2693,7 +2693,7 @@ void update_creature(PlayerType *player_ptr)
 bool player_has_no_spellbooks(PlayerType *player_ptr)
 {
     for (int i = 0; i < INVEN_PACK; i++) {
-        const auto *o_ptr = &player_ptr->inventory_list[i];
+        const auto *o_ptr = &player_ptr->inventory[i];
         if (o_ptr->is_valid() && check_book_realm(player_ptr, o_ptr->bi_key)) {
             return false;
         }
@@ -3123,7 +3123,7 @@ bool is_shero(PlayerType *player_ptr)
 
 bool is_echizen(PlayerType *player_ptr)
 {
-    return (player_ptr->ppersonality == PERSONALITY_COMBAT) || (player_ptr->inventory_list[INVEN_BOW].is_specific_artifact(FixedArtifactId::CRIMSON));
+    return (player_ptr->ppersonality == PERSONALITY_COMBAT) || (player_ptr->inventory[INVEN_BOW].is_specific_artifact(FixedArtifactId::CRIMSON));
 }
 
 bool is_chargeman(PlayerType *player_ptr)
@@ -3172,28 +3172,28 @@ static player_hand main_attack_hand(PlayerType *player_ptr)
 
 bool set_quick_and_tiny(PlayerType *player_ptr)
 {
-    auto is_quickly_tiny = player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::QUICKTHORN);
-    is_quickly_tiny &= player_ptr->inventory_list[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::TINYTHORN);
+    auto is_quickly_tiny = player_ptr->inventory[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::QUICKTHORN);
+    is_quickly_tiny &= player_ptr->inventory[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::TINYTHORN);
     return is_quickly_tiny;
 }
 
 bool set_musasi(PlayerType *player_ptr)
 {
-    auto is_musasi = player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::MUSASI_KATANA);
-    is_musasi &= player_ptr->inventory_list[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::MUSASI_WAKIZASI);
+    auto is_musasi = player_ptr->inventory[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::MUSASI_KATANA);
+    is_musasi &= player_ptr->inventory[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::MUSASI_WAKIZASI);
     return is_musasi;
 }
 
 bool set_icing_and_twinkle(PlayerType *player_ptr)
 {
-    auto can_call_ice_wind_saga = player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::ICINGDEATH);
-    can_call_ice_wind_saga &= player_ptr->inventory_list[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::TWINKLE);
+    auto can_call_ice_wind_saga = player_ptr->inventory[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::ICINGDEATH);
+    can_call_ice_wind_saga &= player_ptr->inventory[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::TWINKLE);
     return can_call_ice_wind_saga;
 }
 
 bool set_anubis_and_chariot(PlayerType *player_ptr)
 {
-    auto is_anubis_chariot = player_ptr->inventory_list[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::ANUBIS);
-    is_anubis_chariot &= player_ptr->inventory_list[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::SILVER_CHARIOT);
+    auto is_anubis_chariot = player_ptr->inventory[INVEN_MAIN_HAND].is_specific_artifact(FixedArtifactId::ANUBIS);
+    is_anubis_chariot &= player_ptr->inventory[INVEN_SUB_HAND].is_specific_artifact(FixedArtifactId::SILVER_CHARIOT);
     return is_anubis_chariot;
 }

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -236,7 +236,7 @@ static void inventory_aware(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -81,7 +81,7 @@ void known_obj_immunity(PlayerType *player_ptr, TrFlags &flags)
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -64,7 +64,7 @@ void calc_android_exp(PlayerType *player_ptr)
     }
 
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         uint32_t value, exp;
         DEPTH level = std::max(o_ptr->get_baseitem_level() - 8, 1);
 

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -392,7 +392,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
                 return "";
             }
 
-            o_ptr = &player_ptr->inventory_list[i_idx];
+            o_ptr = &player_ptr->inventory[i_idx];
             const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);
             if (!input_check(format(_("本当に %s を呪いますか？", "Do you curse %s, really?"), item_name.data()))) {
                 return "";
@@ -456,7 +456,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
     }
     case HEX_SHADOW_CLOAK: {
         if (cast) {
-            auto *o_ptr = &player_ptr->inventory_list[INVEN_OUTER];
+            auto *o_ptr = &player_ptr->inventory[INVEN_OUTER];
 
             if (!o_ptr->is_valid()) {
                 msg_print(_("クロークを身につけていない！", "You are not wearing a cloak."));
@@ -469,7 +469,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
             }
         }
         if (continuation) {
-            auto *o_ptr = &player_ptr->inventory_list[INVEN_OUTER];
+            auto *o_ptr = &player_ptr->inventory[INVEN_OUTER];
 
             if ((!o_ptr->is_valid()) || (!o_ptr->is_cursed())) {
                 exe_spell(player_ptr, RealmType::HEX, spell, SpellProcessType::STOP);

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -473,7 +473,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 if (!has_melee_weapon(player_ptr, INVEN_MAIN_HAND + i)) {
                     break;
                 }
-                o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+                o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
                 basedam = o_ptr->damage_dice.floored_expected_value_multiplied_by(100);
                 damage = o_ptr->to_d * 100;
 
@@ -706,7 +706,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     break;
                 }
 
-                const auto &item = player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+                const auto &item = player_ptr->inventory[INVEN_MAIN_HAND + i];
                 auto basedam = item.damage_dice.floored_expected_value_multiplied_by(100);
                 auto damage = item.to_d * 100;
 

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -197,7 +197,7 @@ static bool wr_savefile_new(PlayerType *player_ptr)
     }
 
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/specific-object/death-scythe.cpp
+++ b/src/specific-object/death-scythe.cpp
@@ -147,7 +147,7 @@ void process_death_scythe_reflection(PlayerType *player_ptr, player_attack_type 
     msg_format(_("ミス！ %sにかわされた。", "You miss %s."), pa_ptr->m_name);
     msg_print(_("振り回した大鎌が自分自身に返ってきた！", "Your scythe returns to you!"));
 
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + pa_ptr->hand];
+    auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + pa_ptr->hand];
     const auto death_scythe_flags = o_ptr->get_flags();
     const auto num = o_ptr->damage_dice.num + player_ptr->damage_dice_bonus[pa_ptr->hand].num;
     const auto sides = o_ptr->damage_dice.sides + player_ptr->damage_dice_bonus[pa_ptr->hand].sides;

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -72,7 +72,7 @@ void update_lite_radius(PlayerType *player_ptr)
 {
     player_ptr->cur_lite = 0;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto *o_ptr = &player_ptr->inventory_list[i];
+        const auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/spell-kind/spells-curse-removal.cpp
+++ b/src/spell-kind/spells-curse-removal.cpp
@@ -21,7 +21,7 @@ static int exe_curse_removal(PlayerType *player_ptr, int all)
     auto count = 0;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
             continue;
         }

--- a/src/spell-kind/spells-equipment.cpp
+++ b/src/spell-kind/spells-equipment.cpp
@@ -34,7 +34,7 @@ bool apply_disenchant(PlayerType *player_ptr, BIT_FLAGS mode)
     };
 
     const auto t = rand_choice(candidates);
-    auto &item = player_ptr->inventory_list[t];
+    auto &item = player_ptr->inventory[t];
     if (!item.is_valid()) {
         return false;
     }

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -39,7 +39,7 @@
 void identify_pack(PlayerType *player_ptr)
 {
     for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -537,7 +537,7 @@ void teleport_away_followable(PlayerType *player_ptr, MONSTER_IDX m_idx)
         INVENTORY_IDX i;
 
         for (i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            o_ptr = &player_ptr->inventory_list[i];
+            o_ptr = &player_ptr->inventory[i];
             if (o_ptr->is_valid() && !o_ptr->is_cursed() && o_ptr->get_flags().has(TR_TELEPORT)) {
                 follow = true;
                 break;

--- a/src/spell-realm/spells-arcane.cpp
+++ b/src/spell-realm/spells-arcane.cpp
@@ -14,7 +14,7 @@
 void phlogiston(PlayerType *player_ptr)
 {
     short max_flog = 0;
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_LITE];
+    auto *o_ptr = &player_ptr->inventory[INVEN_LITE];
     const auto &bi_key = o_ptr->bi_key;
     if (bi_key == BaseitemKey(ItemKindType::LITE, SV_LITE_LANTERN)) {
         max_flog = FUEL_LAMP;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -202,7 +202,7 @@ void acquirement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool
 bool curse_armor(PlayerType *player_ptr)
 {
     /* Curse the body armor */
-    auto &item = player_ptr->inventory_list[INVEN_BODY];
+    auto &item = player_ptr->inventory[INVEN_BODY];
     if (!item.is_valid()) {
         return false;
     }
@@ -308,7 +308,7 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity *o_ptr)
 void brand_bolts(PlayerType *player_ptr)
 {
     for (auto i = 0; i < INVEN_PACK; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (o_ptr->bi_key.tval() != ItemKindType::BOLT) {
             continue;
         }

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -574,7 +574,7 @@ bool cosmic_cast_off(PlayerType *player_ptr, ItemEntity **o_ptr_ptr)
     /* Cast off activated item */
     INVENTORY_IDX slot;
     for (slot = INVEN_MAIN_HAND; slot <= INVEN_FEET; slot++) {
-        if (o_ptr == &player_ptr->inventory_list[slot]) {
+        if (o_ptr == &player_ptr->inventory[slot]) {
             break;
         }
     }

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -305,7 +305,7 @@ bool lose_all_info(PlayerType *player_ptr)
     chg_virtue(player_ptr, Virtue::KNOWLEDGE, -5);
     chg_virtue(player_ptr, Virtue::ENLIGHTEN, -5);
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid() || o_ptr->is_fully_known()) {
             continue;
         }

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -157,9 +157,9 @@ void do_cmd_store(PlayerType *player_ptr)
         const auto should_redraw_store_inventory = rfu.has(StatusRecalculatingFlag::BONUS);
         world.character_icky_depth = 1;
         handle_stuff(player_ptr);
-        if (player_ptr->inventory_list[INVEN_PACK].bi_id) {
+        if (player_ptr->inventory[INVEN_PACK].bi_id) {
             INVENTORY_IDX i_idx = INVEN_PACK;
-            const auto &item_inventory = player_ptr->inventory_list[i_idx];
+            const auto &item_inventory = player_ptr->inventory[i_idx];
             if (store_num != StoreSaleType::HOME) {
                 if (store_num == StoreSaleType::MUSEUM) {
                     msg_print(_("ザックからアイテムがあふれそうなので、あわてて博物館から出た...", "Your pack is so full that you flee the Museum..."));

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -93,7 +93,7 @@ static void take_item_from_home(PlayerType *player_ptr, ItemEntity &item_home, I
     distribute_charges(&item_home, &item_inventory, amt);
 
     const auto item_new = store_item_to_inventory(player_ptr, &item_inventory);
-    const auto item_name = describe_flavor(player_ptr, player_ptr->inventory_list[item_new], 0);
+    const auto item_name = describe_flavor(player_ptr, player_ptr->inventory[item_new], 0);
     handle_stuff(player_ptr);
     msg_format(_("%s(%c)を取った。", "You have %s (%c)."), item_name.data(), index_to_label(item_new));
 
@@ -294,7 +294,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     item_new = store_item_to_inventory(player_ptr, &item);
     handle_stuff(player_ptr);
 
-    const auto got_item_name = describe_flavor(player_ptr, player_ptr->inventory_list[item_new], 0);
+    const auto got_item_name = describe_flavor(player_ptr, player_ptr->inventory[item_new], 0);
     msg_format(_("%s(%c)を手に入れた。", "You have %s (%c)."), got_item_name.data(), index_to_label(item_new));
 
     if (item_store.is_wand_rod()) {

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -207,7 +207,7 @@ public:
 
     bool autopick_autoregister{}; /* auto register is in-use or not */
 
-    std::shared_ptr<ItemEntity[]> inventory_list{}; /* The player's inventory */
+    std::shared_ptr<ItemEntity[]> inventory{}; /* The player's inventory */
     int16_t inven_cnt{}; /* Number of items in inventory */
     int16_t equip_cnt{}; /* Number of items in equipment */
 

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -106,7 +106,7 @@ static void process_cursed_equipment_characteristics(PlayerType *player_ptr, uin
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         auto is_known = o_ptr->is_known();
         auto is_sensed = is_known || o_ptr->ident & IDENT_SENSE;
         auto flags = o_ptr->get_flags_known();
@@ -155,7 +155,7 @@ static void process_light_equipment_characteristics(PlayerType *player_ptr, all_
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         auto flags = o_ptr->get_flags_known();
 
         auto b = false;
@@ -204,7 +204,7 @@ static void process_inventory_characteristic(PlayerType *player_ptr, tr_type fla
 {
     int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         auto flags = o_ptr->get_flags_known();
 
         auto f_imm = flag_to_greater_flag.find(flag);

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -40,7 +40,7 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
     for (i = 0; i < INVEN_PACK; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }
@@ -50,7 +50,7 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
 
     prepare_label_string(player_ptr, inven_label, USE_INVEN, item_tester);
     for (k = 0, i = 0; i < z; i++) {
-        auto &item = player_ptr->inventory_list[i];
+        auto &item = player_ptr->inventory[i];
         if (!item_tester.okay(&item) && !(mode & USE_FULL)) {
             continue;
         }
@@ -86,7 +86,7 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     int j;
     for (j = 0; j < k; j++) {
         i = out_index[j];
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         prt("", j + 1, col ? col - 2 : col);
         std::string head;
         if (use_menu && target_item) {
@@ -137,13 +137,13 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 {
     int i, z = 0;
     TERM_COLOR attr = TERM_WHITE;
-    if (!player_ptr || !player_ptr->inventory_list) {
+    if (!player_ptr || !player_ptr->inventory) {
         return;
     }
 
     const auto &[wid, hgt] = term_get_size();
     for (i = 0; i < INVEN_PACK; i++) {
-        auto o_ptr = &player_ptr->inventory_list[i];
+        auto o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -155,7 +155,7 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
             break;
         }
 
-        auto &item = player_ptr->inventory_list[i];
+        auto &item = player_ptr->inventory[i];
         auto do_disp = item_tester.okay(&item);
         std::string label = "   ";
         if (do_disp) {

--- a/src/view/display-player-middle.cpp
+++ b/src/view/display-player-middle.cpp
@@ -42,7 +42,7 @@ static void display_player_melee_bonus(PlayerType *player_ptr, int hand, int han
 {
     HIT_PROB show_tohit = player_ptr->dis_to_h[hand];
     int show_todam = player_ptr->dis_to_d[hand];
-    auto *o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + hand];
+    auto *o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + hand];
 
     if (o_ptr->is_known()) {
         show_tohit += o_ptr->to_h;
@@ -97,7 +97,7 @@ static void display_sub_hand(PlayerType *player_ptr)
  */
 static void display_bow_hit_damage(PlayerType *player_ptr)
 {
-    const auto &item = player_ptr->inventory_list[INVEN_BOW];
+    const auto &item = player_ptr->inventory[INVEN_BOW];
     auto show_tohit = player_ptr->dis_to_h_b;
     auto show_todam = 0;
     if (item.is_known()) {
@@ -133,8 +133,8 @@ static void display_bow_hit_damage(PlayerType *player_ptr)
 static void display_shoot_magnification(PlayerType *player_ptr)
 {
     int tmul = 0;
-    if (player_ptr->inventory_list[INVEN_BOW].is_valid()) {
-        tmul = player_ptr->inventory_list[INVEN_BOW].get_arrow_magnification();
+    if (player_ptr->inventory[INVEN_BOW].is_valid()) {
+        tmul = player_ptr->inventory[INVEN_BOW].get_arrow_magnification();
         if (player_ptr->xtra_might) {
             tmul++;
         }

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -209,7 +209,7 @@ static void display_equipments_compensation(PlayerType *player_ptr, int row, int
 {
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         ItemEntity *o_ptr;
-        o_ptr = &player_ptr->inventory_list[i];
+        o_ptr = &player_ptr->inventory[i];
         auto flags = o_ptr->get_flags_known();
         for (int stat = 0; stat < A_MAX; stat++) {
             DisplaySymbol symbol(TERM_SLATE, '.');

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -332,7 +332,7 @@ void display_player_equippy(PlayerType *player_ptr, TERM_LEN y, TERM_LEN x, BIT_
 {
     const auto max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
     for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         auto symbol = item.get_symbol();
         if (!equippy_chars || !item.is_valid()) {
             symbol.color = TERM_DARK;

--- a/src/view/object-describer.cpp
+++ b/src/view/object-describer.cpp
@@ -47,7 +47,7 @@ void inven_item_charges(const ItemEntity &item)
  */
 void inven_item_describe(PlayerType *player_ptr, short i_idx)
 {
-    const auto &item = player_ptr->inventory_list[i_idx];
+    const auto &item = player_ptr->inventory[i_idx];
     const auto item_name = describe_flavor(player_ptr, item, 0);
 #ifdef JP
     if (item.number <= 0) {

--- a/src/view/status-first-page.cpp
+++ b/src/view/status-first-page.cpp
@@ -216,7 +216,7 @@ static std::pair<std::string, TERM_COLOR> likert(int x, int y)
 static void calc_two_hands(PlayerType *player_ptr, int *damage, int *to_h)
 {
     ItemEntity *o_ptr;
-    o_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    o_ptr = &player_ptr->inventory[INVEN_BOW];
 
     for (int i = 0; i < 2; i++) {
         int basedam;
@@ -230,7 +230,7 @@ static void calc_two_hands(PlayerType *player_ptr, int *damage, int *to_h)
             continue;
         }
 
-        o_ptr = &player_ptr->inventory_list[INVEN_MAIN_HAND + i];
+        o_ptr = &player_ptr->inventory[INVEN_MAIN_HAND + i];
         if (!calc_weapon_one_hand(o_ptr, i, damage, &basedam)) {
             continue;
         }
@@ -355,7 +355,7 @@ static void display_first_page(PlayerType *player_ptr, int xthb, int *damage, in
 void display_player_various(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
-    o_ptr = &player_ptr->inventory_list[INVEN_BOW];
+    o_ptr = &player_ptr->inventory[INVEN_BOW];
     int tmp = player_ptr->to_h_b + o_ptr->to_h;
     int xthb = player_ptr->skill_thb + (tmp * BTH_PLUS_ADJ);
     int shots = 0;

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -303,7 +303,7 @@ void fix_pet_list(PlayerType *player_ptr)
  */
 static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tester)
 {
-    if (!player_ptr || !player_ptr->inventory_list) {
+    if (!player_ptr || !player_ptr->inventory) {
         return;
     }
 
@@ -315,7 +315,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
             break;
         }
 
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         auto do_disp = player_ptr->select_ring_slot ? is_ring_slot(i) : item_tester.okay(&item);
         std::string tmp_val = "   ";
 

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -42,7 +42,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
     for (k = 0, i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         auto only_slot = !(player_ptr->select_ring_slot ? is_ring_slot(i) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
         auto is_any_hand = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr);
         is_any_hand |= (i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr);
@@ -90,7 +90,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     prepare_label_string(player_ptr, equip_label, USE_EQUIP, item_tester);
     for (j = 0; j < k; j++) {
         i = out_index[j];
-        const auto &item = player_ptr->inventory_list[i];
+        const auto &item = player_ptr->inventory[i];
         prt("", j + 1, col ? col - 2 : col);
         std::string head;
         if (use_menu && target_item) {

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -256,7 +256,7 @@ bool exe_cmd_debug(PlayerType *player_ptr, char cmd)
         return true;
     case 'X':
         for (INVENTORY_IDX i = INVEN_TOTAL - 1; i >= 0; i--) {
-            if (player_ptr->inventory_list[i].is_valid()) {
+            if (player_ptr->inventory[i].is_valid()) {
                 drop_from_inventory(player_ptr, i, 999);
             }
         }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -271,7 +271,7 @@ void wiz_modify_item_activation(PlayerType *player_ptr)
 void wiz_identify_full_inventory(PlayerType *player_ptr)
 {
     for (int i = 0; i < INVEN_TOTAL; i++) {
-        auto *o_ptr = &player_ptr->inventory_list[i];
+        auto *o_ptr = &player_ptr->inventory[i];
         if (!o_ptr->is_valid()) {
             continue;
         }


### PR DESCRIPTION
プレイヤーの持ち物を管理する配列変数の名称が PlayerType::inventory_listとなっているが、「inventory」自体に複数の物を指す意味が含まれるためlist をつけるのは冗長なので PlayerType::inventory に改名する。

VSCodeのC++拡張機能のリファクタリング機能による変数名の単純置換による変更です。

Resolves #5027