### PR TITLE
is_cave_empty_bold2() をFloorType::can_generate_monster_at() に繰り込んだ

### DIFF
--- a/src/floor/cave.cpp
+++ b/src/floor/cave.cpp
@@ -11,27 +11,10 @@
 #include "system/angband-system.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
-#include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"
 #include "world/world.h"
-
-/*
- * Determine if a "legal" grid is an "empty" floor grid
- * Determine if monster generation is allowed in a grid
- *
- * Line 1 -- forbid non-empty grids
- * Line 2 -- forbid trees while dungeon generation
- */
-bool is_cave_empty_bold2(PlayerType *player_ptr, int y, int x)
-{
-    const auto &floor = *player_ptr->current_floor_ptr;
-    const Pos2D pos(y, x);
-    auto is_empty_grid = floor.is_empty_at(pos) && (pos != player_ptr->get_position());
-    is_empty_grid &= AngbandWorld::get_instance().character_dungeon || !floor.has_terrain_characteristics(pos, TerrainCharacteristics::TREE);
-    return is_empty_grid;
-}
 
 /*
  * Does the grid stop disintegration?

--- a/src/floor/cave.h
+++ b/src/floor/cave.h
@@ -1,8 +1,6 @@
 #pragma once
 
 class FloorType;
-class PlayerType;
-bool is_cave_empty_bold2(PlayerType *player_ptr, int x, int y);
 bool cave_stop_disintegration(const FloorType &floor, int y, int x);
 bool cave_los_bold(const FloorType &floor, int y, int x);
 bool cave_clean_bold(const FloorType &floor, int y, int x);

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -71,13 +71,17 @@ static void summon_self(PlayerType *player_ptr, MonsterDeath *md_ptr, summon_typ
         return;
     }
 
+    const auto p_pos = player_ptr->get_position();
     auto m_pos = md_ptr->get_position();
-    auto attempts = 100;
-    do {
+    auto attempts = 0;
+    for (; attempts < 100; attempts++) {
         m_pos = scatter(player_ptr, md_ptr->get_position(), radius, PROJECT_NONE);
-    } while (!(floor.contains(m_pos) && is_cave_empty_bold2(player_ptr, m_pos.y, m_pos.x)) && --attempts);
+        if (floor.contains(m_pos) && floor.can_generate_monster_at(m_pos) && (p_pos != m_pos)) {
+            break;
+        }
+    }
 
-    if (attempts <= 0) {
+    if (attempts == 100) {
         return;
     }
 

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -27,6 +27,7 @@
 #include "status/body-improvement.h"
 #include "status/buff-setter.h"
 #include "status/sight-setter.h"
+#include "system/floor/floor-info.h"
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "util/dice.h"
@@ -465,13 +466,14 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
             auto sp_sides = 20 + plev;
             auto sp_base = plev;
             crusade(player_ptr);
+            const auto &floor = *player_ptr->current_floor_ptr;
             const auto p_pos = player_ptr->get_position();
             for (auto i = 0; i < 12; i++) {
                 auto attempt = 10;
                 Pos2D pos(0, 0);
                 while (attempt--) {
                     pos = scatter(player_ptr, p_pos, 4, PROJECT_NONE);
-                    if (is_cave_empty_bold2(player_ptr, pos.y, pos.x)) {
+                    if (floor.can_generate_monster_at(pos) && (p_pos != pos)) {
                         break;
                     }
                 }

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -319,6 +319,13 @@ bool FloorType::is_empty_at(const Pos2D &pos) const
     return is_empty_grid;
 }
 
+bool FloorType::can_generate_monster_at(const Pos2D &pos) const
+{
+    auto is_empty_grid = this->is_empty_at(pos);
+    is_empty_grid &= AngbandWorld::get_instance().character_dungeon || !this->has_terrain_characteristics(pos, TerrainCharacteristics::TREE);
+    return is_empty_grid;
+}
+
 /*!
  * @brief 特定の財宝を生成する。指定がない場合、生成階に応じたランダムな財宝を生成する。
  * @param bi_key 財宝を固定生成する場合のBaseitemKey

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -128,6 +128,7 @@ public:
     bool order_pet_dismission(short index1, short index2, short riding_index) const;
     bool contains(const Pos2D &pos, FloorBoundary fb = FloorBoundary::OUTER_WALL_EXCLUSIVE) const;
     bool is_empty_at(const Pos2D &pos) const;
+    bool can_generate_monster_at(const Pos2D &pos) const;
 
     ItemEntity make_gold(std::optional<BaseitemKey> bi_key = std::nullopt) const;
     std::optional<ItemEntity> try_make_instant_artifact() const;


### PR DESCRIPTION
PlayerType::get\_position() をなるべくループの外に出しているのは、ループの中からPlayerType を掃き出すためです (カプセル化しやすくなるはず……)
ご確認下さい