### PR TITLE
[Refactor] FloorType::o_cnt,o_maxを廃止する

### DIFF
--- a/src/core/object-compressor.cpp
+++ b/src/core/object-compressor.cpp
@@ -10,27 +10,8 @@
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
 #include <algorithm>
+#include <range/v3/view.hpp>
 #include <utility>
-
-/*!
- * @brief グローバルオブジェクト配列の要素番号i1のオブジェクトを要素番号i2に移動する /
- * Move an object from index i1 to index i2 in the object list
- * @param i1 オブジェクト移動元の要素番号
- * @param i2 オブジェクト移動先の要素番号
- */
-static void compact_objects_aux(FloorType &floor, OBJECT_IDX i1, OBJECT_IDX i2)
-{
-    if (i1 == i2) {
-        return;
-    }
-
-    // モンスター所為アイテムリストもしくは床上アイテムリストの要素番号i1をi2に書き換える
-    auto &list = get_o_idx_list_contains(floor, i1);
-    std::replace(list.begin(), list.end(), i1, i2);
-
-    floor.o_list[i2].swap(floor.o_list[i1]);
-    floor.o_list[i1]->wipe();
-}
 
 /*!
  * @brief グローバルオブジェクト配列から優先度の低いものを削除し、データを圧縮する。 /
@@ -50,7 +31,6 @@ static void compact_objects_aux(FloorType &floor, OBJECT_IDX i1, OBJECT_IDX i2)
  */
 void compact_objects(PlayerType *player_ptr, int size)
 {
-    ItemEntity *o_ptr;
     if (size) {
         msg_print(_("アイテム情報を圧縮しています...", "Compacting objects..."));
         auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -66,16 +46,15 @@ void compact_objects(PlayerType *player_ptr, int size)
     for (int num = 0, cnt = 1; num < size; cnt++) {
         int cur_lev = 5 * cnt;
         int cur_dis = 5 * (20 - cnt);
-        for (OBJECT_IDX i = 1; i < floor.o_max; i++) {
-            o_ptr = floor.o_list[i].get();
-
-            if (!o_ptr->is_valid() || (o_ptr->get_baseitem_level() > cur_lev)) {
+        std::vector<OBJECT_IDX> delete_i_idx_list;
+        for (const auto &[i_idx, item_ptr] : floor.o_list | ranges::views::enumerate) {
+            if (!item_ptr->is_valid() || (item_ptr->get_baseitem_level() > cur_lev)) {
                 continue;
             }
 
             POSITION y, x;
-            if (o_ptr->is_held_by_monster()) {
-                const auto &monster = floor.m_list[o_ptr->held_m_idx];
+            if (item_ptr->is_held_by_monster()) {
+                const auto &monster = floor.m_list[item_ptr->held_m_idx];
                 y = monster.fy;
                 x = monster.fx;
 
@@ -83,8 +62,8 @@ void compact_objects(PlayerType *player_ptr, int size)
                     continue;
                 }
             } else {
-                y = o_ptr->iy;
-                x = o_ptr->ix;
+                y = item_ptr->iy;
+                x = item_ptr->ix;
             }
 
             if ((cur_dis > 0) && (Grid::calc_distance(player_ptr->get_position(), { y, x }) < cur_dis)) {
@@ -92,7 +71,7 @@ void compact_objects(PlayerType *player_ptr, int size)
             }
 
             int chance = 90;
-            if (o_ptr->is_fixed_or_random_artifact() && (cnt < 1000)) {
+            if (item_ptr->is_fixed_or_random_artifact() && (cnt < 1000)) {
                 chance = 100;
             }
 
@@ -100,18 +79,10 @@ void compact_objects(PlayerType *player_ptr, int size)
                 continue;
             }
 
-            delete_object_idx(player_ptr, i);
+            delete_i_idx_list.push_back(static_cast<OBJECT_IDX>(i_idx));
             num++;
         }
-    }
 
-    for (OBJECT_IDX i = floor.o_max - 1; i >= 1; i--) {
-        o_ptr = floor.o_list[i].get();
-        if (o_ptr->is_valid()) {
-            continue;
-        }
-
-        compact_objects_aux(floor, floor.o_max - 1, i);
-        floor.o_max--;
+        delete_items(player_ptr, std::move(delete_i_idx_list));
     }
 }

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -214,12 +214,8 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
             compact_monsters(player_ptr, 0);
         }
 
-        if (floor.o_cnt + 32 > MAX_FLOOR_ITEMS) {
+        if (floor.o_list.size() + 32 > MAX_FLOOR_ITEMS) {
             compact_objects(player_ptr, 64);
-        }
-
-        if (floor.o_cnt + 32 < floor.o_max) {
-            compact_objects(player_ptr, 0);
         }
 
         process_player(player_ptr);

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -48,6 +48,7 @@
 #include "window/main-window-util.h"
 #include "world/world.h"
 #include <algorithm>
+#include <range/v3/view.hpp>
 
 /*!
  * @brief 階段移動先のフロアが生成できない時に簡単な行き止まりマップを作成する / Builds the dead end
@@ -194,14 +195,13 @@ static void update_unique_artifact(const FloorType &floor, int16_t cur_floor_id)
         }
     }
 
-    for (int i = 1; i < floor.o_max; i++) {
-        const auto &o_ref = *floor.o_list[i];
-        if (!o_ref.is_valid()) {
+    for (const auto &item_ptr : floor.o_list) {
+        if (!item_ptr->is_valid()) {
             continue;
         }
 
-        if (o_ref.is_fixed_artifact()) {
-            o_ref.get_fixed_artifact().floor_id = cur_floor_id;
+        if (item_ptr->is_fixed_artifact()) {
+            item_ptr->get_fixed_artifact().floor_id = cur_floor_id;
         }
     }
 }
@@ -307,19 +307,20 @@ static void allocate_loaded_floor(PlayerType *player_ptr, saved_floor_type *sf_p
 
     GAME_TURN absence_ticks = (world.game_turn - tmp_last_visit) / TURNS_PER_TICK;
     reset_unique_by_floor_change(player_ptr);
-    for (MONSTER_IDX i = 1; i < floor.o_max; i++) {
-        const auto *o_ptr = floor.o_list[i].get();
-        if (!o_ptr->is_valid() || !o_ptr->is_fixed_artifact()) {
+    std::vector<OBJECT_IDX> delete_i_idx_list;
+    for (const auto &[i_idx, item_ptr] : floor.o_list | ranges::views::enumerate) {
+        if (!item_ptr->is_valid() || !item_ptr->is_fixed_artifact()) {
             continue;
         }
 
-        auto &artifact = o_ptr->get_fixed_artifact();
+        auto &artifact = item_ptr->get_fixed_artifact();
         if (artifact.floor_id == new_floor_id) {
             artifact.is_generated = true;
         } else {
-            delete_object_idx(player_ptr, i);
+            delete_i_idx_list.push_back(static_cast<OBJECT_IDX>(i_idx));
         }
     }
+    delete_items(player_ptr, std::move(delete_i_idx_list));
 
     (void)place_quest_monsters(player_ptr);
     GAME_TURN alloc_times = absence_ticks / alloc_chance;

--- a/src/floor/floor-events.cpp
+++ b/src/floor/floor-events.cpp
@@ -162,20 +162,19 @@ static int get_dungeon_feeling(const auto &floor)
         rating += rating_boost(delta);
     }
 
-    for (short i = 1; i < floor.o_max; i++) {
-        const auto &item = *floor.o_list[i];
+    for (const auto &item_ptr : floor.o_list) {
         auto delta = 0;
-        if (!item.is_valid() || (item.is_known() && item.marked.has(OmType::TOUCHED)) || ((item.ident & IDENT_SENSE) != 0)) {
+        if (!item_ptr->is_valid() || (item_ptr->is_known() && item_ptr->marked.has(OmType::TOUCHED)) || ((item_ptr->ident & IDENT_SENSE) != 0)) {
             continue;
         }
 
-        if (item.is_ego()) {
-            const auto &ego = item.get_ego();
+        if (item_ptr->is_ego()) {
+            const auto &ego = item_ptr->get_ego();
             delta += ego.rating * base;
         }
 
-        if (item.is_fixed_or_random_artifact()) {
-            const auto cost = object_value_real(&item);
+        if (item_ptr->is_fixed_or_random_artifact()) {
+            const auto cost = object_value_real(item_ptr.get());
             delta += 10 * base;
             if (cost > 10000L) {
                 delta += 10 * base;
@@ -194,40 +193,40 @@ static int get_dungeon_feeling(const auto &floor)
             }
         }
 
-        if (item.bi_key.tval() == ItemKindType::DRAG_ARMOR) {
+        if (item_ptr->bi_key.tval() == ItemKindType::DRAG_ARMOR) {
             delta += 30 * base;
         }
 
-        if (item.bi_key == BaseitemKey(ItemKindType::SHIELD, SV_DRAGON_SHIELD)) {
+        if (item_ptr->bi_key == BaseitemKey(ItemKindType::SHIELD, SV_DRAGON_SHIELD)) {
             delta += 5 * base;
         }
 
-        if (item.bi_key == BaseitemKey(ItemKindType::GLOVES, SV_SET_OF_DRAGON_GLOVES)) {
+        if (item_ptr->bi_key == BaseitemKey(ItemKindType::GLOVES, SV_SET_OF_DRAGON_GLOVES)) {
             delta += 5 * base;
         }
 
-        if (item.bi_key == BaseitemKey(ItemKindType::BOOTS, SV_PAIR_OF_DRAGON_GREAVE)) {
+        if (item_ptr->bi_key == BaseitemKey(ItemKindType::BOOTS, SV_PAIR_OF_DRAGON_GREAVE)) {
             delta += 5 * base;
         }
 
-        if (item.bi_key == BaseitemKey(ItemKindType::HELM, SV_DRAGON_HELM)) {
+        if (item_ptr->bi_key == BaseitemKey(ItemKindType::HELM, SV_DRAGON_HELM)) {
             delta += 5 * base;
         }
 
-        if (item.bi_key == BaseitemKey(ItemKindType::RING, SV_RING_SPEED) && !item.is_cursed()) {
+        if (item_ptr->bi_key == BaseitemKey(ItemKindType::RING, SV_RING_SPEED) && !item_ptr->is_cursed()) {
             delta += 25 * base;
         }
 
-        if (item.bi_key == BaseitemKey(ItemKindType::RING, SV_RING_LORDLY) && !item.is_cursed()) {
+        if (item_ptr->bi_key == BaseitemKey(ItemKindType::RING, SV_RING_LORDLY) && !item_ptr->is_cursed()) {
             delta += 15 * base;
         }
 
-        if (item.bi_key == BaseitemKey(ItemKindType::AMULET, SV_AMULET_THE_MAGI) && !item.is_cursed()) {
+        if (item_ptr->bi_key == BaseitemKey(ItemKindType::AMULET, SV_AMULET_THE_MAGI) && !item_ptr->is_cursed()) {
             delta += 15 * base;
         }
 
-        const auto item_level = item.get_baseitem_level();
-        if (!item.is_cursed() && !item.is_broken() && item_level > floor.dun_level) {
+        const auto item_level = item_ptr->get_baseitem_level();
+        if (!item_ptr->is_cursed() && !item_ptr->is_broken() && item_level > floor.dun_level) {
             delta += (item_level - floor.dun_level) * base;
         }
 

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -378,12 +378,9 @@ void wipe_generate_random_floor_flags(FloorType &floor)
 void clear_cave(PlayerType *player_ptr)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    for (auto &item_ptr : floor.o_list) {
-        item_ptr->wipe();
-    }
+    floor.o_list.clear();
+    floor.o_list.push_back(std::make_shared<ItemEntity>()); // 0番にダミーアイテムを用意
 
-    floor.o_max = 1;
-    floor.o_cnt = 0;
     MonraceList::get_instance().reset_current_numbers();
     for (auto &monster : floor.m_list) {
         monster.wipe();
@@ -532,7 +529,7 @@ void generate_floor(PlayerType *player_ptr)
             why = level_gen(player_ptr);
         }
 
-        if (floor.o_max >= MAX_FLOOR_ITEMS) {
+        if (floor.o_list.size() >= MAX_FLOOR_ITEMS) {
             why = _("アイテムが多すぎる", "too many objects");
         } else if (floor.m_max >= MAX_FLOOR_MONSTERS) {
             why = _("モンスターが多すぎる", "too many monsters");

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -4,6 +4,7 @@
 #include "system/angband.h"
 #include "util/point-2d.h"
 #include <optional>
+#include <vector>
 
 class ObjectIndexList;
 
@@ -17,6 +18,7 @@ void floor_item_increase(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBE
 void floor_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx);
 void delete_object_idx(PlayerType *player_ptr, OBJECT_IDX o_idx);
 void excise_object_idx(FloorType &floor, OBJECT_IDX o_idx);
+void delete_items(PlayerType *player_ptr, std::vector<OBJECT_IDX> delete_i_idx_list);
 ObjectIndexList &get_o_idx_list_contains(FloorType &floor, OBJECT_IDX o_idx);
 short drop_near(PlayerType *player_ptr, ItemEntity *o_ptr, const Pos2D &pos, std::optional<int> chance = std::nullopt);
 void floor_item_charges(const FloorType &floor, INVENTORY_IDX i_idx);

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -115,16 +115,15 @@ void recharge_magic_items(PlayerType *player_ptr)
         wild_regen = 20;
     }
 
-    for (i = 1; i < player_ptr->current_floor_ptr->o_max; i++) {
-        auto *o_ptr = player_ptr->current_floor_ptr->o_list[i].get();
-        if (!o_ptr->is_valid()) {
+    for (const auto &item_ptr : player_ptr->current_floor_ptr->o_list) {
+        if (!item_ptr->is_valid()) {
             continue;
         }
 
-        if ((o_ptr->bi_key.tval() == ItemKindType::ROD) && (o_ptr->timeout)) {
-            o_ptr->timeout -= (TIME_EFFECT)o_ptr->number;
-            if (o_ptr->timeout < 0) {
-                o_ptr->timeout = 0;
+        if ((item_ptr->bi_key.tval() == ItemKindType::ROD) && (item_ptr->timeout)) {
+            item_ptr->timeout -= (TIME_EFFECT)item_ptr->number;
+            if (item_ptr->timeout < 0) {
+                item_ptr->timeout = 0;
             }
         }
     }

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -214,13 +214,14 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
  */
 void monster_drop_carried_objects(PlayerType *player_ptr, MonsterEntity &monster)
 {
-    for (auto it = monster.hold_o_idx_list.begin(); it != monster.hold_o_idx_list.end();) {
-        const OBJECT_IDX this_o_idx = *it++;
+    std::vector<OBJECT_IDX> delete_i_idx_list;
+    for (const auto this_o_idx : monster.hold_o_idx_list) {
         auto drop_item = player_ptr->current_floor_ptr->o_list[this_o_idx]->clone();
         drop_item.held_m_idx = 0;
-        delete_object_idx(player_ptr, this_o_idx);
+        delete_i_idx_list.push_back(this_o_idx);
         (void)drop_near(player_ptr, &drop_item, monster.get_position());
     }
+    delete_items(player_ptr, std::move(delete_i_idx_list));
 
     monster.hold_o_idx_list.clear();
 }

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -14,6 +14,7 @@
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"
 #include "tracking/health-bar-tracker.h"
+#include <range/v3/view.hpp>
 
 /*!
  * @brief モンスター配列からモンスターを消去する
@@ -73,10 +74,7 @@ void delete_monster_idx(PlayerType *player_ptr, short m_idx)
     }
 
     floor.get_grid(m_pos).m_idx = 0;
-    for (auto it = monster.hold_o_idx_list.begin(); it != monster.hold_o_idx_list.end();) {
-        const OBJECT_IDX this_o_idx = *it++;
-        delete_object_idx(player_ptr, this_o_idx);
-    }
+    delete_items(player_ptr, monster.hold_o_idx_list | ranges::to_vector);
 
     // 召喚元のモンスターが消滅した時は、召喚されたモンスターのparent_m_idxが
     // 召喚されたモンスター自身のm_idxを指すようにする

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -225,7 +225,6 @@ bool wr_dungeon(PlayerType *player_ptr)
  */
 static bool save_floor_aux(PlayerType *player_ptr, saved_floor_type *sf_ptr)
 {
-    compact_objects(player_ptr, 0);
     compact_monsters(player_ptr, 0);
 
     auto tmp8u = static_cast<uint8_t>(Rand_external(256));

--- a/src/save/floor-writer.cpp
+++ b/src/save/floor-writer.cpp
@@ -20,6 +20,7 @@
 #include "system/redrawing-flags-updater.h"
 #include "term/z-form.h"
 #include "util/angband-files.h"
+#include <range/v3/view.hpp>
 
 namespace {
 /*
@@ -140,10 +141,9 @@ void wr_saved_floor(PlayerType *player_ptr, saved_floor_type *sf_ptr)
     }
 
     /*** Dump objects ***/
-    wr_u16b(floor.o_max);
-    for (int i = 1; i < floor.o_max; i++) {
-        const auto &item = *floor.o_list[i];
-        wr_item(item);
+    wr_u16b(static_cast<uint16_t>(floor.o_list.size()));
+    for (const auto &item_ptr : floor.o_list | ranges::views::drop(1)) {
+        wr_item(*item_ptr);
     }
 
     /*** Dump the monsters ***/

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -49,7 +49,6 @@
  */
 static bool wr_savefile_new(PlayerType *player_ptr)
 {
-    compact_objects(player_ptr, 0);
     compact_monsters(player_ptr, 0);
 
     uint32_t now = (uint32_t)time((time_t *)0);

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -174,23 +174,22 @@ bool detect_objects_gold(PlayerType *player_ptr, POSITION range)
 
     /* Scan objects */
     auto detect = false;
-    for (short i = 1; i < floor.o_max; i++) {
-        auto &item = *floor.o_list[i];
-        if (!item.is_valid()) {
+    for (const auto &item_ptr : floor.o_list) {
+        if (!item_ptr->is_valid()) {
             continue;
         }
 
-        if (item.is_held_by_monster()) {
+        if (item_ptr->is_held_by_monster()) {
             continue;
         }
 
-        const auto i_pos = item.get_position();
+        const auto i_pos = item_ptr->get_position();
         if (Grid::calc_distance(player_ptr->get_position(), i_pos) > range2) {
             continue;
         }
 
-        if (item.bi_key.tval() == ItemKindType::GOLD) {
-            item.marked.set(OmType::FOUND);
+        if (item_ptr->bi_key.tval() == ItemKindType::GOLD) {
+            item_ptr->marked.set(OmType::FOUND);
             lite_spot(player_ptr, i_pos);
             detect = true;
         }
@@ -225,22 +224,21 @@ bool detect_objects_normal(PlayerType *player_ptr, POSITION range)
     }
 
     auto detect = false;
-    for (short i = 1; i < floor.o_max; i++) {
-        auto &item = *floor.o_list[i];
-        if (!item.is_valid()) {
+    for (const auto &item_ptr : floor.o_list) {
+        if (!item_ptr->is_valid()) {
             continue;
         }
-        if (item.is_held_by_monster()) {
+        if (item_ptr->is_held_by_monster()) {
             continue;
         }
 
-        const auto i_pos = item.get_position();
+        const auto i_pos = item_ptr->get_position();
         if (Grid::calc_distance(player_ptr->get_position(), i_pos) > range2) {
             continue;
         }
 
-        if (item.bi_key.tval() != ItemKindType::GOLD) {
-            item.marked.set(OmType::FOUND);
+        if (item_ptr->bi_key.tval() != ItemKindType::GOLD) {
+            item_ptr->marked.set(OmType::FOUND);
             lite_spot(player_ptr, i_pos);
             detect = true;
         }
@@ -292,21 +290,20 @@ bool detect_objects_magic(PlayerType *player_ptr, POSITION range)
     }
 
     auto detect = false;
-    for (short i = 1; i < floor.o_max; i++) {
-        auto &item = *floor.o_list[i];
-        if (!item.is_valid() || item.is_held_by_monster()) {
+    for (const auto &item_ptr : floor.o_list) {
+        if (!item_ptr->is_valid() || item_ptr->is_held_by_monster()) {
             continue;
         }
 
-        const auto i_pos = item.get_position();
+        const auto i_pos = item_ptr->get_position();
         if (Grid::calc_distance(player_ptr->get_position(), i_pos) > range) {
             continue;
         }
 
-        auto has_bonus = item.to_a > 0;
-        has_bonus |= item.to_h + item.to_d > 0;
-        if (item.is_fixed_or_random_artifact() || item.is_ego() || is_object_magically(item.bi_key.tval()) || item.is_spell_book() || has_bonus) {
-            item.marked.set(OmType::FOUND);
+        auto has_bonus = item_ptr->to_a > 0;
+        has_bonus |= item_ptr->to_h + item_ptr->to_d > 0;
+        if (item_ptr->is_fixed_or_random_artifact() || item_ptr->is_ego() || is_object_magically(item_ptr->bi_key.tval()) || item_ptr->is_spell_book() || has_bonus) {
+            item_ptr->marked.set(OmType::FOUND);
             lite_spot(player_ptr, i_pos);
             detect = true;
         }

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -48,15 +48,14 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
 {
     /* Memorize objects */
     auto &floor = *player_ptr->current_floor_ptr;
-    for (OBJECT_IDX i = 1; i < floor.o_max; i++) {
-        auto *o_ptr = floor.o_list[i].get();
-        if (!o_ptr->is_valid()) {
+    for (auto &item_ptr : floor.o_list) {
+        if (!item_ptr->is_valid()) {
             continue;
         }
-        if (o_ptr->is_held_by_monster()) {
+        if (item_ptr->is_held_by_monster()) {
             continue;
         }
-        o_ptr->marked.set(OmType::FOUND);
+        item_ptr->marked.set(OmType::FOUND);
     }
 
     /* Scan all normal grids */
@@ -144,19 +143,17 @@ void wiz_dark(PlayerType *player_ptr)
     }
 
     /* Forget all objects */
-    for (OBJECT_IDX i = 1; i < player_ptr->current_floor_ptr->o_max; i++) {
-        auto *o_ptr = player_ptr->current_floor_ptr->o_list[i].get();
-
-        if (!o_ptr->is_valid()) {
+    for (auto &item_ptr : player_ptr->current_floor_ptr->o_list) {
+        if (!item_ptr->is_valid()) {
             continue;
         }
-        if (o_ptr->is_held_by_monster()) {
+        if (item_ptr->is_held_by_monster()) {
             continue;
         }
 
         /* Forget the object */
         // 意図としては OmType::TOUCHED を維持しつつ OmType::FOUND を消す事と思われるが一応元のロジックを維持しておく
-        o_ptr->marked &= { OmType::TOUCHED };
+        item_ptr->marked &= { OmType::TOUCHED };
     }
 
     /* Forget travel route when we have forgotten map */

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -19,6 +19,7 @@
 #include "target/target-checker.h"
 #include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
+#include <range/v3/view.hpp>
 
 /*!
  * @brief 変身処理向けにモンスターの近隣レベル帯モンスターを返す
@@ -128,10 +129,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
             o_ptr->held_m_idx = *m_idx;
         }
     } else {
-        for (auto it = back_m.hold_o_idx_list.begin(); it != back_m.hold_o_idx_list.end();) {
-            OBJECT_IDX this_o_idx = *it++;
-            delete_object_idx(player_ptr, this_o_idx);
-        }
+        delete_items(player_ptr, back_m.hold_o_idx_list | ranges::to_vector);
     }
 
     if (targeted) {

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -579,20 +579,9 @@ short FloorType::pop_empty_index_monster()
  */
 short FloorType::pop_empty_index_item()
 {
-    if (this->o_max < MAX_FLOOR_ITEMS) {
-        const auto i = this->o_max;
-        this->o_max++;
-        this->o_cnt++;
-        return i;
-    }
-
-    for (short i = 1; i < this->o_max; i++) {
-        if (this->o_list[i]->is_valid()) {
-            continue;
-        }
-
-        this->o_cnt++;
-        return i;
+    if (this->o_list.size() < MAX_FLOOR_ITEMS) {
+        this->o_list.push_back(std::make_shared<ItemEntity>());
+        return static_cast<short>(this->o_list.size() - 1);
     }
 
     if (AngbandWorld::get_instance().character_dungeon) {

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -73,8 +73,6 @@ public:
     GAME_TURN generated_turn = 0; /* Turn when level began */
 
     std::vector<std::shared_ptr<ItemEntity>> o_list; /*!< The array of dungeon items [max_o_idx] */
-    OBJECT_IDX o_max = 0; /* Number of allocated objects */
-    OBJECT_IDX o_cnt = 0; /* Number of live objects */
 
     std::vector<MonsterEntity> m_list; /*!< The array of dungeon monsters [max_m_idx] */
     MONSTER_IDX m_max = 0; /* Number of allocated monsters */


### PR DESCRIPTION
Resolves #5045 

FloorType::o_list を正しく可変長配列として扱うことで、FloorType::o_cntと FloorType::o_maxを廃止する。