### PR TITLE
[Refactor] フロア全マスのループにFloorType::get_area()を使用する 

### DIFF
--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -15,6 +15,7 @@
 #include "system/terrain/terrain-definition.h"
 #include "view/display-messages.h"
 #include <algorithm>
+#include <range/v3/algorithm.hpp>
 
 QuestCompletionChecker::QuestCompletionChecker(PlayerType *player_ptr, const MonsterEntity &monster)
     : player_ptr(player_ptr)
@@ -201,17 +202,12 @@ void QuestCompletionChecker::complete_tower()
 int QuestCompletionChecker::count_all_hostile_monsters()
 {
     const auto &floor = *this->player_ptr->current_floor_ptr;
-    auto number_mon = 0;
-    for (auto x = 0; x < floor.width; ++x) {
-        for (auto y = 0; y < floor.height; ++y) {
-            auto m_idx = floor.grid_array[y][x].m_idx;
-            if ((m_idx > 0) && floor.m_list[m_idx].is_hostile()) {
-                ++number_mon;
-            }
-        }
-    }
+    const auto hostile_monster_exists = [&floor](const Pos2D &pos) {
+        const auto &grid = floor.get_grid(pos);
+        return grid.has_monster() && floor.m_list[grid.m_idx].is_hostile();
+    };
 
-    return number_mon;
+    return ranges::count_if(floor.get_area(), hostile_monster_exists);
 }
 
 Pos2D QuestCompletionChecker::make_stairs(const bool create_stairs)

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -43,30 +43,20 @@ static void check_arena_floor(PlayerType *player_ptr, DungeonData *dd_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     if (!dd_ptr->empty_level) {
-        for (POSITION y = 0; y < floor.height; y++) {
-            for (POSITION x = 0; x < floor.width; x++) {
-                place_bold(player_ptr, y, x, GB_EXTRA);
-            }
+        for (const auto &pos : floor.get_area()) {
+            place_bold(player_ptr, pos.y, pos.x, GB_EXTRA);
         }
 
         return;
     }
 
-    for (POSITION y = 0; y < floor.height; y++) {
-        for (POSITION x = 0; x < floor.width; x++) {
-            place_bold(player_ptr, y, x, GB_FLOOR);
-        }
+    for (const auto &pos : floor.get_area()) {
+        place_bold(player_ptr, pos.y, pos.x, GB_FLOOR);
     }
 
-    for (POSITION x = 0; x < floor.width; x++) {
-        place_bold(player_ptr, 0, x, GB_EXTRA);
-        place_bold(player_ptr, floor.height - 1, x, GB_EXTRA);
-    }
-
-    for (POSITION y = 1; y < (floor.height - 1); y++) {
-        place_bold(player_ptr, y, 0, GB_EXTRA);
-        place_bold(player_ptr, y, floor.width - 1, GB_EXTRA);
-    }
+    floor.get_area().each_edge([&](const Pos2D &pos) {
+        place_bold(player_ptr, pos.y, pos.x, GB_EXTRA);
+    });
 }
 
 static void place_cave_contents(PlayerType *player_ptr, DungeonData *dd_ptr, const DungeonDefinition &dungeon)
@@ -284,15 +274,9 @@ static void place_bound_perm_wall(PlayerType *player_ptr, Grid &grid)
 static void make_perm_walls(PlayerType *player_ptr)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    for (POSITION x = 0; x < floor.width; x++) {
-        place_bound_perm_wall(player_ptr, floor.get_grid({ 0, x }));
-        place_bound_perm_wall(player_ptr, floor.get_grid({ floor.height - 1, x }));
-    }
-
-    for (POSITION y = 1; y < (floor.height - 1); y++) {
-        place_bound_perm_wall(player_ptr, floor.get_grid({ y, 0 }));
-        place_bound_perm_wall(player_ptr, floor.get_grid({ y, floor.width - 1 }));
-    }
+    floor.get_area().each_edge([&](const Pos2D &pos) {
+        place_bound_perm_wall(player_ptr, floor.get_grid(pos));
+    });
 }
 
 static bool check_place_necessary_objects(PlayerType *player_ptr, DungeonData *dd_ptr)
@@ -383,10 +367,8 @@ static void decide_grid_glowing(FloorType &floor, DungeonData *dd_ptr, const Dun
         return;
     }
 
-    for (POSITION y = 0; y < floor.height; y++) {
-        for (POSITION x = 0; x < floor.width; x++) {
-            floor.grid_array[y][x].info |= CAVE_GLOW;
-        }
+    for (const auto &pos : floor.get_area()) {
+        floor.get_grid(pos).add_info(CAVE_GLOW);
     }
 }
 

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -277,10 +277,8 @@ static void generate_gambling_arena(PlayerType *player_ptr)
 static void generate_fixed_floor(PlayerType *player_ptr)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    for (auto y = 0; y < floor.height; y++) {
-        for (auto x = 0; x < floor.width; x++) {
-            place_bold(player_ptr, y, x, GB_SOLID_PERM);
-        }
+    for (const auto &pos : floor.get_area()) {
+        place_bold(player_ptr, pos.y, pos.x, GB_SOLID_PERM);
     }
 
     const auto &quests = QuestList::get_instance();
@@ -356,17 +354,13 @@ static std::optional<std::string> level_gen(PlayerType *player_ptr)
  */
 void wipe_generate_random_floor_flags(FloorType &floor)
 {
-    for (auto y = 0; y < floor.height; y++) {
-        for (auto x = 0; x < floor.width; x++) {
-            floor.get_grid({ y, x }).info &= ~(CAVE_MASK);
-        }
+    for (const auto &pos : floor.get_area()) {
+        floor.get_grid(pos).info &= ~(CAVE_MASK);
     }
 
     if (floor.is_underground()) {
-        for (auto y = 1; y < floor.height - 1; y++) {
-            for (auto x = 1; x < floor.width - 1; x++) {
-                floor.get_grid({ y, x }).info |= CAVE_UNSAFE;
-            }
+        for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+            floor.get_grid(pos).info |= CAVE_UNSAFE;
         }
     }
 }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -152,38 +152,36 @@ static void locate_connected_stairs(PlayerType *player_ptr, FloorType &floor, sa
     int y_table[20]{};
     auto num = 0;
     const auto &fcms = FloorChangeModesStore::get_instace();
-    for (POSITION y = 0; y < floor.height; y++) {
-        for (POSITION x = 0; x < floor.width; x++) {
-            const auto &grid = floor.get_grid({ y, x });
-            const auto &terrain = grid.get_terrain();
-            auto ok = false;
-            if (fcms->has(FloorChangeMode::UP)) {
-                if (terrain.flags.has_all_of({ TerrainCharacteristics::LESS, TerrainCharacteristics::STAIRS }) && terrain.flags.has_not(TerrainCharacteristics::SPECIAL)) {
-                    ok = true;
-                    if (grid.special && grid.special == sf_ptr->upper_floor_id) {
-                        sx = x;
-                        sy = y;
-                    }
-                }
-            } else if (fcms->has(FloorChangeMode::DOWN)) {
-                if (terrain.flags.has_all_of({ TerrainCharacteristics::MORE, TerrainCharacteristics::STAIRS }) && terrain.flags.has_not(TerrainCharacteristics::SPECIAL)) {
-                    ok = true;
-                    if (grid.special && grid.special == sf_ptr->lower_floor_id) {
-                        sx = x;
-                        sy = y;
-                    }
-                }
-            } else {
-                if (terrain.flags.has(TerrainCharacteristics::BLDG)) {
-                    ok = true;
+    for (const auto &pos : floor.get_area()) {
+        const auto &grid = floor.get_grid(pos);
+        const auto &terrain = grid.get_terrain();
+        auto ok = false;
+        if (fcms->has(FloorChangeMode::UP)) {
+            if (terrain.flags.has_all_of({ TerrainCharacteristics::LESS, TerrainCharacteristics::STAIRS }) && terrain.flags.has_not(TerrainCharacteristics::SPECIAL)) {
+                ok = true;
+                if (grid.special && grid.special == sf_ptr->upper_floor_id) {
+                    sx = pos.x;
+                    sy = pos.y;
                 }
             }
+        } else if (fcms->has(FloorChangeMode::DOWN)) {
+            if (terrain.flags.has_all_of({ TerrainCharacteristics::MORE, TerrainCharacteristics::STAIRS }) && terrain.flags.has_not(TerrainCharacteristics::SPECIAL)) {
+                ok = true;
+                if (grid.special && grid.special == sf_ptr->lower_floor_id) {
+                    sx = pos.x;
+                    sy = pos.y;
+                }
+            }
+        } else {
+            if (terrain.flags.has(TerrainCharacteristics::BLDG)) {
+                ok = true;
+            }
+        }
 
-            if (ok && (num < 20)) {
-                x_table[num] = x;
-                y_table[num] = y;
-                num++;
-            }
+        if (ok && (num < 20)) {
+            x_table[num] = pos.x;
+            y_table[num] = pos.y;
+            num++;
         }
     }
 

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -61,13 +61,10 @@ void update_smell(FloorType &floor, const Pos2D &p_pos)
     };
 
     if (++scent_when == 254) {
-        for (auto y = 0; y < floor.height; y++) {
-            for (auto x = 0; x < floor.width; x++) {
-                const Pos2D pos(y, x);
-                auto &grid = floor.get_grid(pos);
-                int w = grid.when;
-                grid.when = (w > 128) ? (w - 128) : 0;
-            }
+        for (const auto &pos : floor.get_area()) {
+            auto &grid = floor.get_grid(pos);
+            int w = grid.when;
+            grid.when = (w > 128) ? (w - 128) : 0;
         }
 
         scent_when = 126;
@@ -98,13 +95,11 @@ void update_smell(FloorType &floor, const Pos2D &p_pos)
  */
 void forget_flow(FloorType &floor)
 {
-    for (POSITION y = 0; y < floor.height; y++) {
-        for (POSITION x = 0; x < floor.width; x++) {
-            auto &grid = floor.grid_array[y][x];
-            grid.reset_costs();
-            grid.reset_dists();
-            floor.grid_array[y][x].when = 0;
-        }
+    for (const auto &pos : floor.get_area()) {
+        auto &grid = floor.get_grid(pos);
+        grid.reset_costs();
+        grid.reset_dists();
+        grid.when = 0;
     }
 }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -457,79 +457,73 @@ void wilderness_gen(PlayerType *player_ptr)
     floor.get_grid({ MAX_HGT - 1, 0 }).mimic = border.bottom_left;
     floor.get_grid({ MAX_HGT - 1, MAX_WID - 1 }).mimic = border.bottom_right;
     const auto &world = AngbandWorld::get_instance();
-    for (auto y = 0; y < floor.height; y++) {
-        for (auto x = 0; x < floor.width; x++) {
-            auto &grid = floor.get_grid({ y, x });
-            if (world.is_daytime()) {
-                grid.info |= CAVE_GLOW;
-                if (view_perma_grids) {
-                    grid.info |= CAVE_MARK;
-                }
-
-                continue;
-            }
-
-            const auto &terrain = grid.get_terrain(TerrainKind::MIMIC);
-            auto can_darken = !grid.is_mirror();
-            can_darken &= terrain.flags.has_none_of({ TerrainCharacteristics::QUEST_ENTER, TerrainCharacteristics::ENTRANCE });
-            if (can_darken) {
-                grid.info &= ~(CAVE_GLOW);
-                if (terrain.flags.has_not(TerrainCharacteristics::REMEMBER)) {
-                    grid.info &= ~(CAVE_MARK);
-                }
-
-                continue;
-            }
-
-            if (terrain.flags.has_not(TerrainCharacteristics::ENTRANCE)) {
-                continue;
-            }
-
+    for (const auto &pos : floor.get_area()) {
+        auto &grid = floor.get_grid(pos);
+        if (world.is_daytime()) {
             grid.info |= CAVE_GLOW;
             if (view_perma_grids) {
                 grid.info |= CAVE_MARK;
             }
+
+            continue;
+        }
+
+        const auto &terrain = grid.get_terrain(TerrainKind::MIMIC);
+        auto can_darken = !grid.is_mirror();
+        can_darken &= terrain.flags.has_none_of({ TerrainCharacteristics::QUEST_ENTER, TerrainCharacteristics::ENTRANCE });
+        if (can_darken) {
+            grid.info &= ~(CAVE_GLOW);
+            if (terrain.flags.has_not(TerrainCharacteristics::REMEMBER)) {
+                grid.info &= ~(CAVE_MARK);
+            }
+
+            continue;
+        }
+
+        if (terrain.flags.has_not(TerrainCharacteristics::ENTRANCE)) {
+            continue;
+        }
+
+        grid.info |= CAVE_GLOW;
+        if (view_perma_grids) {
+            grid.info |= CAVE_MARK;
         }
     }
 
     if (player_ptr->teleport_town) {
-        for (auto y = 0; y < floor.height; y++) {
-            for (auto x = 0; x < floor.width; x++) {
-                auto &grid = floor.get_grid({ y, x });
-                const auto &terrain = grid.get_terrain();
-                if (terrain.flags.has_not(TerrainCharacteristics::BLDG)) {
-                    continue;
-                }
-
-                if ((terrain.subtype != 4) && !((player_ptr->town_num == 1) && (terrain.subtype == 0))) {
-                    continue;
-                }
-
-                if (grid.has_monster()) {
-                    delete_monster_idx(player_ptr, grid.m_idx);
-                }
-
-                player_ptr->oldpy = y;
-                player_ptr->oldpx = x;
+        for (const auto &pos : floor.get_area()) {
+            auto &grid = floor.get_grid(pos);
+            const auto &terrain = grid.get_terrain();
+            if (terrain.flags.has_not(TerrainCharacteristics::BLDG)) {
+                continue;
             }
+
+            if ((terrain.subtype != 4) && !((player_ptr->town_num == 1) && (terrain.subtype == 0))) {
+                continue;
+            }
+
+            if (grid.has_monster()) {
+                delete_monster_idx(player_ptr, grid.m_idx);
+            }
+
+            player_ptr->oldpy = pos.y;
+            player_ptr->oldpx = pos.x;
         }
 
         player_ptr->teleport_town = false;
     } else if (floor.is_leaving_dungeon()) {
-        for (auto y = 0; y < floor.height; y++) {
-            for (auto x = 0; x < floor.width; x++) {
-                auto &grid = floor.get_grid({ y, x });
-                if (!grid.has(TerrainCharacteristics::ENTRANCE)) {
-                    continue;
-                }
-
-                if (grid.has_monster()) {
-                    delete_monster_idx(player_ptr, grid.m_idx);
-                }
-
-                player_ptr->oldpy = y;
-                player_ptr->oldpx = x;
+        for (const auto &pos : floor.get_area()) {
+            auto &grid = floor.get_grid(pos);
+            if (!grid.has(TerrainCharacteristics::ENTRANCE)) {
+                continue;
             }
+
+            if (grid.has_monster()) {
+                delete_monster_idx(player_ptr, grid.m_idx);
+            }
+
+            player_ptr->oldpy = pos.y;
+            player_ptr->oldpx = pos.x;
         }
 
         player_ptr->teleport_town = false;

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -717,12 +717,10 @@ void update_flow(PlayerType *player_ptr)
     }
 
     /* Erase all of the current flow information */
-    for (auto y = 0; y < floor.height; y++) {
-        for (auto x = 0; x < floor.width; x++) {
-            auto &grid = floor.grid_array[y][x];
-            grid.reset_costs();
-            grid.reset_dists();
-        }
+    for (const auto &pos : floor.get_area()) {
+        auto &grid = floor.get_grid(pos);
+        grid.reset_costs();
+        grid.reset_dists();
     }
 
     /* Save player position */

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -52,17 +52,15 @@ auto collect_known_fixed_artifacts(PlayerType *player_ptr)
     }
 
     const auto &floor = *player_ptr->current_floor_ptr;
-    for (auto y = 0; y < floor.height; y++) {
-        for (auto x = 0; x < floor.width; x++) {
-            const auto &grid = floor.get_grid({ y, x });
-            for (const auto this_o_idx : grid.o_idx_list) {
-                const auto &item = *floor.o_list[this_o_idx];
-                if (!item.is_fixed_artifact() || item.is_known()) {
-                    continue;
-                }
-
-                fa_ids.erase(item.fa_id);
+    for (const auto &pos : floor.get_area()) {
+        const auto &grid = floor.get_grid(pos);
+        for (const auto this_o_idx : grid.o_idx_list) {
+            const auto &item = *floor.o_list[this_o_idx];
+            if (!item.is_fixed_artifact() || item.is_known()) {
+                continue;
             }
+
+            fa_ids.erase(item.fa_id);
         }
     }
 

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -35,6 +35,7 @@
 #include "view/display-messages.h"
 #include "wizard/wizard-messages.h"
 #include "world/world.h"
+#include <range/v3/algorithm.hpp>
 
 /*!
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -124,16 +125,11 @@ static bool check_quest_placeable(const FloorType &floor, MonraceId r_idx)
     if (r_idx != quest.r_idx) {
         return true;
     }
-    int number_mon = 0;
-    for (int i2 = 0; i2 < floor.width; ++i2) {
-        for (int j2 = 0; j2 < floor.height; j2++) {
-            auto quest_monster = floor.grid_array[j2][i2].has_monster();
-            quest_monster &= (floor.m_list[floor.grid_array[j2][i2].m_idx].r_idx == quest.r_idx);
-            if (quest_monster) {
-                number_mon++;
-            }
-        }
-    }
+    const auto has_quest_monrace = [&](const Pos2D &pos) {
+        const auto &grid = floor.get_grid(pos);
+        return grid.has_monster() && (floor.m_list[grid.m_idx].r_idx == quest.r_idx);
+    };
+    const auto number_mon = ranges::count_if(floor.get_area(), has_quest_monrace);
 
     if (number_mon + quest.cur_num >= quest.max_num) {
         return false;

--- a/src/spell-kind/spells-detection.cpp
+++ b/src/spell-kind/spells-detection.cpp
@@ -34,34 +34,31 @@ static bool detect_feat_flag(PlayerType *player_ptr, POSITION range, TerrainChar
     }
 
     auto detect = false;
-    for (auto y = 1; y < floor.height - 1; y++) {
-        for (auto x = 1; x <= floor.width - 1; x++) {
-            const Pos2D pos(y, x);
-            auto dist = Grid::calc_distance(player_ptr->get_position(), pos);
-            if (dist > range) {
-                continue;
-            }
+    for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+        auto dist = Grid::calc_distance(player_ptr->get_position(), pos);
+        if (dist > range) {
+            continue;
+        }
 
-            auto &grid = floor.get_grid(pos);
-            if (flag == TerrainCharacteristics::TRAP) {
-                /* Mark as detected */
-                if (dist <= range && known) {
-                    if (dist <= range - 1) {
-                        grid.info |= (CAVE_IN_DETECT);
-                    }
-
-                    grid.info &= ~(CAVE_UNSAFE);
-
-                    lite_spot(player_ptr, pos);
+        auto &grid = floor.get_grid(pos);
+        if (flag == TerrainCharacteristics::TRAP) {
+            /* Mark as detected */
+            if (dist <= range && known) {
+                if (dist <= range - 1) {
+                    grid.info |= (CAVE_IN_DETECT);
                 }
-            }
 
-            if (grid.has(flag)) {
-                disclose_grid(player_ptr, pos);
-                grid.info |= (CAVE_MARK);
+                grid.info &= ~(CAVE_UNSAFE);
+
                 lite_spot(player_ptr, pos);
-                detect = true;
             }
+        }
+
+        if (grid.has(flag)) {
+            disclose_grid(player_ptr, pos);
+            grid.info |= (CAVE_MARK);
+            lite_spot(player_ptr, pos);
+            detect = true;
         }
     }
 

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -60,41 +60,38 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
 
     /* Scan all normal grids */
     const auto &terrains = TerrainList::get_instance();
-    for (auto y = 1; y < floor.height - 1; y++) {
+    for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         /* Scan all normal grids */
-        for (auto x = 1; x < floor.width - 1; x++) {
-            const Pos2D pos(y, x);
-            auto &grid = floor.get_grid(pos);
+        auto &grid = floor.get_grid(pos);
 
-            /* Memorize terrain of the grid */
-            grid.info |= (CAVE_KNOWN);
+        /* Memorize terrain of the grid */
+        grid.info |= (CAVE_KNOWN);
 
-            /* Scan all neighbors */
-            for (const auto &d : Direction::directions()) {
-                const auto pos_neighbor = pos + d.vec();
-                auto &grid_neighbor = floor.get_grid(pos_neighbor);
+        /* Scan all neighbors */
+        for (const auto &d : Direction::directions()) {
+            const auto pos_neighbor = pos + d.vec();
+            auto &grid_neighbor = floor.get_grid(pos_neighbor);
 
-                /* Feature code (applying "mimic" field) */
-                const auto &terrain = terrains.get_terrain(grid_neighbor.get_terrain_id(TerrainKind::MIMIC));
+            /* Feature code (applying "mimic" field) */
+            const auto &terrain = terrains.get_terrain(grid_neighbor.get_terrain_id(TerrainKind::MIMIC));
 
-                /* Perma-lite the grid */
-                if (floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS) && !ninja) {
-                    grid_neighbor.info |= (CAVE_GLOW);
-                }
+            /* Perma-lite the grid */
+            if (floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS) && !ninja) {
+                grid_neighbor.info |= (CAVE_GLOW);
+            }
 
-                /* Memorize normal features */
-                if (terrain.flags.has(TerrainCharacteristics::REMEMBER)) {
+            /* Memorize normal features */
+            if (terrain.flags.has(TerrainCharacteristics::REMEMBER)) {
+                /* Memorize the grid */
+                grid_neighbor.info |= (CAVE_MARK);
+            }
+
+            /* Perma-lit grids (newly and previously) */
+            else if (grid_neighbor.info & CAVE_GLOW) {
+                /* Normally, memorize floors (see above) */
+                if (view_perma_grids && !view_torch_grids) {
                     /* Memorize the grid */
                     grid_neighbor.info |= (CAVE_MARK);
-                }
-
-                /* Perma-lit grids (newly and previously) */
-                else if (grid_neighbor.info & CAVE_GLOW) {
-                    /* Normally, memorize floors (see above) */
-                    if (view_perma_grids && !view_torch_grids) {
-                        /* Memorize the grid */
-                        grid_neighbor.info |= (CAVE_MARK);
-                    }
                 }
             }
         }
@@ -119,28 +116,20 @@ void wiz_lite(PlayerType *player_ptr, bool ninja)
  */
 void wiz_dark(PlayerType *player_ptr)
 {
+    auto &floor = *player_ptr->current_floor_ptr;
     /* Forget every grid */
-    for (POSITION y = 1; y < player_ptr->current_floor_ptr->height - 1; y++) {
-        for (POSITION x = 1; x < player_ptr->current_floor_ptr->width - 1; x++) {
-            auto &grid = player_ptr->current_floor_ptr->grid_array[y][x];
+    for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+        auto &grid = floor.get_grid(pos);
 
-            /* Process the grid */
-            grid.info &= ~(CAVE_MARK | CAVE_IN_DETECT | CAVE_KNOWN);
-            grid.info |= (CAVE_UNSAFE);
-        }
+        /* Process the grid */
+        grid.info &= ~(CAVE_MARK | CAVE_IN_DETECT | CAVE_KNOWN);
+        grid.info |= (CAVE_UNSAFE);
     }
 
-    /* Forget every grid on horizontal edge */
-    for (POSITION x = 0; x < player_ptr->current_floor_ptr->width; x++) {
-        player_ptr->current_floor_ptr->grid_array[0][x].info &= ~(CAVE_MARK);
-        player_ptr->current_floor_ptr->grid_array[player_ptr->current_floor_ptr->height - 1][x].info &= ~(CAVE_MARK);
-    }
-
-    /* Forget every grid on vertical edge */
-    for (POSITION y = 1; y < (player_ptr->current_floor_ptr->height - 1); y++) {
-        player_ptr->current_floor_ptr->grid_array[y][0].info &= ~(CAVE_MARK);
-        player_ptr->current_floor_ptr->grid_array[y][player_ptr->current_floor_ptr->width - 1].info &= ~(CAVE_MARK);
-    }
+    /* Forget every grid on edge */
+    floor.get_area().each_edge([&](const Pos2D &pos) {
+        floor.get_grid(pos).info &= ~(CAVE_MARK);
+    });
 
     /* Forget all objects */
     for (auto &item_ptr : player_ptr->current_floor_ptr->o_list) {
@@ -190,41 +179,38 @@ void map_area(PlayerType *player_ptr, POSITION range)
 
     /* Scan that area */
     const auto &terrains = TerrainList::get_instance();
-    for (auto y = 1; y < floor.height - 1; y++) {
-        for (auto x = 1; x < floor.width - 1; x++) {
-            const Pos2D pos(y, x);
-            if (Grid::calc_distance(player_ptr->get_position(), pos) > range) {
-                continue;
-            }
+    for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+        if (Grid::calc_distance(player_ptr->get_position(), pos) > range) {
+            continue;
+        }
 
-            auto &grid = floor.get_grid(pos);
+        auto &grid = floor.get_grid(pos);
 
-            /* Memorize terrain of the grid */
-            grid.info |= (CAVE_KNOWN);
+        /* Memorize terrain of the grid */
+        grid.info |= (CAVE_KNOWN);
+
+        /* Feature code (applying "mimic" field) */
+        const auto mimic_terrain_id = grid.get_terrain_id(TerrainKind::MIMIC);
+        const auto &terrain_mimic = terrains.get_terrain(mimic_terrain_id);
+
+        /* Memorize normal features */
+        if (terrain_mimic.flags.has(TerrainCharacteristics::REMEMBER)) {
+            /* Memorize the object */
+            grid.info |= (CAVE_MARK);
+        }
+
+        /* Memorize known walls */
+        for (const auto &d : Direction::directions_8()) {
+            auto &grid_neighbor = floor.get_grid(pos + d.vec());
 
             /* Feature code (applying "mimic" field) */
-            const auto mimic_terrain_id = grid.get_terrain_id(TerrainKind::MIMIC);
-            const auto &terrain_mimic = terrains.get_terrain(mimic_terrain_id);
+            const auto terrain_id = grid_neighbor.get_terrain_id(TerrainKind::MIMIC);
+            const auto &terrain = terrains.get_terrain(terrain_id);
 
-            /* Memorize normal features */
-            if (terrain_mimic.flags.has(TerrainCharacteristics::REMEMBER)) {
-                /* Memorize the object */
-                grid.info |= (CAVE_MARK);
-            }
-
-            /* Memorize known walls */
-            for (const auto &d : Direction::directions_8()) {
-                auto &grid_neighbor = floor.get_grid(pos + d.vec());
-
-                /* Feature code (applying "mimic" field) */
-                const auto terrain_id = grid_neighbor.get_terrain_id(TerrainKind::MIMIC);
-                const auto &terrain = terrains.get_terrain(terrain_id);
-
-                /* Memorize walls (etc) */
-                if (terrain.flags.has(TerrainCharacteristics::REMEMBER)) {
-                    /* Memorize the walls */
-                    grid_neighbor.info |= (CAVE_MARK);
-                }
+            /* Memorize walls (etc) */
+            if (terrain.flags.has(TerrainCharacteristics::REMEMBER)) {
+                /* Memorize the walls */
+                grid_neighbor.info |= (CAVE_MARK);
             }
         }
     }

--- a/src/spell-kind/spells-grid.cpp
+++ b/src/spell-kind/spells-grid.cpp
@@ -110,26 +110,23 @@ void stair_creation(PlayerType *player_ptr)
 
     const auto &dungeon = floor.get_dungeon_definition();
     if (dest_floor_id) {
-        for (auto y = 0; y < floor.height; y++) {
-            for (auto x = 0; x < floor.width; x++) {
-                const Pos2D pos(y, x);
-                auto &grid = floor.get_grid(pos);
-                if (!grid.special) {
-                    continue;
-                }
-
-                if (grid.has_special_terrain()) {
-                    continue;
-                }
-
-                if (grid.special != dest_floor_id) {
-                    continue;
-                }
-
-                /* Remove old stairs */
-                grid.special = 0;
-                set_terrain_id_to_grid(player_ptr, pos, dungeon.select_floor_terrain_id());
+        for (const auto &pos : floor.get_area()) {
+            auto &grid = floor.get_grid(pos);
+            if (!grid.special) {
+                continue;
             }
+
+            if (grid.has_special_terrain()) {
+                continue;
+            }
+
+            if (grid.special != dest_floor_id) {
+                continue;
+            }
+
+            /* Remove old stairs */
+            grid.special = 0;
+            set_terrain_id_to_grid(player_ptr, pos, dungeon.select_floor_terrain_id());
         }
     } else {
         dest_floor_id = get_unused_floor_id(player_ptr);

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -29,6 +29,7 @@
 #include "system/terrain/terrain-list.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-range.h"
+#include "util/point-2d.h"
 #include "world/world.h"
 #include <range/v3/algorithm.hpp>
 
@@ -59,6 +60,18 @@ Grid &FloorType::get_grid(const Pos2D pos)
 const Grid &FloorType::get_grid(const Pos2D pos) const
 {
     return this->grid_array[pos.y][pos.x];
+}
+
+Rect2D FloorType::get_area(FloorBoundary fb) const
+{
+    switch (fb) {
+    case FloorBoundary::OUTER_WALL_EXCLUSIVE:
+        return Rect2D(1, 1, this->height - 2, this->width - 2);
+    case FloorBoundary::OUTER_WALL_INCLUSIVE:
+        return Rect2D(0, 0, this->height - 1, this->width - 1);
+    default:
+        THROW_EXCEPTION(std::logic_error, fmt::format("Invalid FloorBoundary is specified!: {}", enum2i(fb)));
+    }
 }
 
 bool FloorType::is_entering_dungeon() const

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -104,6 +104,7 @@ public:
     int get_level() const;
     Grid &get_grid(const Pos2D pos);
     const Grid &get_grid(const Pos2D pos) const;
+    Rect2D get_area(FloorBoundary fb = FloorBoundary::OUTER_WALL_INCLUSIVE) const;
     bool is_entering_dungeon() const;
     bool is_leaving_dungeon() const;
     bool is_underground() const;

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -41,30 +41,27 @@ static std::vector<Pos2D> tgt_pt_prepare(PlayerType *player_ptr)
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto p_pos = player_ptr->get_position();
     const auto is_hallucinated = player_ptr->effects()->hallucination().is_hallucinated();
-    for (auto y = 1; y < floor.height; y++) {
-        for (auto x = 1; x < floor.width; x++) {
-            const Pos2D pos(y, x);
-            if (!floor.contains(pos)) {
-                continue;
-            }
+    for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+        if (!floor.contains(pos)) {
+            continue;
+        }
 
-            if (pos == p_pos) {
-                positions.push_back(pos);
-                continue;
-            }
+        if (pos == p_pos) {
+            positions.push_back(pos);
+            continue;
+        }
 
-            if (is_hallucinated) {
-                continue;
-            }
+        if (is_hallucinated) {
+            continue;
+        }
 
-            const auto &grid = floor.get_grid(pos);
-            if (!grid.is_mark()) {
-                continue;
-            }
+        const auto &grid = floor.get_grid(pos);
+        if (!grid.is_mark()) {
+            continue;
+        }
 
-            if (grid.is_acceptable_target()) {
-                positions.push_back(pos);
-            }
+        if (grid.is_acceptable_target()) {
+            positions.push_back(pos);
         }
     }
 
@@ -73,13 +70,13 @@ static std::vector<Pos2D> tgt_pt_prepare(PlayerType *player_ptr)
     return positions;
 }
 
-static std::optional<Pos2D> select_building_pos(const auto &floor)
+static std::optional<Pos2D> select_building_pos(const FloorType &floor)
 {
     const auto is_building_pos = [&](const Pos2D &pos) {
         return floor.get_grid(pos).has(TerrainCharacteristics::BLDG);
     };
     const auto pos_buildings =
-        Rect2D(0, 0, floor.height - 1, floor.width - 1) |
+        floor.get_area() |
         ranges::views::filter(is_building_pos) |
         ranges::to<std::vector>();
 

--- a/src/util/point-2d.h
+++ b/src/util/point-2d.h
@@ -209,13 +209,13 @@ struct Rectangle2D {
     template <std::invocable<Point2D<T>> F>
     void each_edge(F &&f) const
     {
-        for (auto y = this->top_left.y; y <= this->bottom_right.y; ++y) {
-            f(Point2D<T>(y, top_left.x));
-            f(Point2D<T>(y, bottom_right.x));
-        }
         for (auto x = this->top_left.x; x <= this->bottom_right.x; ++x) {
             f(Point2D<T>(top_left.y, x));
             f(Point2D<T>(bottom_right.y, x));
+        }
+        for (auto y = this->top_left.y + 1; y <= this->bottom_right.y - 1; ++y) {
+            f(Point2D<T>(y, top_left.x));
+            f(Point2D<T>(y, bottom_right.x));
         }
     }
 

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -239,15 +239,15 @@ bool exe_cmd_debug(PlayerType *player_ptr, char cmd)
     case 't':
         teleport_player(player_ptr, 100, TELEPORT_SPONTANEOUS);
         return true;
-    case 'u':
-        for (int y = 0; y < player_ptr->current_floor_ptr->height; y++) {
-            for (int x = 0; x < player_ptr->current_floor_ptr->width; x++) {
-                player_ptr->current_floor_ptr->grid_array[y][x].info |= CAVE_GLOW | CAVE_MARK;
-            }
+    case 'u': {
+        auto &floor = *player_ptr->current_floor_ptr;
+        for (const auto &pos : floor.get_area()) {
+            floor.get_grid(pos).info |= CAVE_GLOW | CAVE_MARK;
         }
 
         wiz_lite(player_ptr, false);
         return true;
+    }
     case 'w':
         wiz_lite(player_ptr, PlayerClass(player_ptr).equals(PlayerClassType::NINJA));
         return true;


### PR DESCRIPTION
Resolves #5043

変更行数が多そうに見えるかもしれませんが、y, xの二重ループが一重ループになってネストが減った分インデントが変わっただけの行が多いので、実質的にはそんなに多くはありません。（賢い差分エディタならわかりやすいはず）