### PR TITLE
[Fix] デバッグコマンドで元素使いに職業を変更して魔法を使用するとクラッシュする

### DIFF
--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -89,7 +89,7 @@ void save_prev_data(PlayerType *player_ptr, birther *birther_ptr)
     birther_ptr->ppersonality = player_ptr->ppersonality;
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        birther_ptr->realm1 = player_ptr->element;
+        birther_ptr->realm1 = static_cast<int16_t>(player_ptr->element);
         birther_ptr->realm2 = 0;
     } else {
         PlayerRealm pr(player_ptr);

--- a/src/mind/mind-elementalist.h
+++ b/src/mind/mind-elementalist.h
@@ -5,6 +5,7 @@
 #include <string_view>
 
 enum class ElementRealmType {
+    NONE = 0,
     FIRE = 1,
     ICE = 2,
     SKY = 3,

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -43,7 +43,7 @@ public:
     player_personality_type ppersonality{}; /* Personality index */
     RealmType realm1{}; /* First magic realm */
     RealmType realm2{}; /* Second magic realm */
-    int16_t element{}; //!< 元素使い領域番号 / Elementalist system index
+    int element{}; //!< 元素使い領域番号 / Elementalist system index
 
     Dice hit_dice{}; /* Hit dice */
     uint16_t expfact{}; /* Experience factor


### PR DESCRIPTION
Fix #5057

元素使いの魔法領域は通常の領域と別扱いなのでデバッグコマンドで領域選択が行われず正しい領域が選択されていない状態のままとなるので魔法を使用するとクラッシュする。
元素使い用の領域選択処理を実装し職業変更時に領域を選択できるようにする。
また領域変更コマンドにも対応する。