### PR TITLE
PlayerType::element の型をElementRealmTypeにし、element_realmに改名する

### DIFF
--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -15,7 +15,6 @@
 #include <string>
 
 constexpr auto TOTAL_REALM_NUM = std::ssize(MAGIC_REALM_RANGE) + std::ssize(TECHNIC_REALM_RANGE);
-constexpr byte REALM_SELECT_CANCEL = 255;
 
 struct birth_realm_type {
     birth_realm_type();
@@ -290,10 +289,11 @@ bool get_player_realms(PlayerType *player_ptr)
     pr.reset();
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        player_ptr->element = select_element_realm(player_ptr);
-        if (player_ptr->element == REALM_SELECT_CANCEL) {
+        const auto realm = select_element_realm(player_ptr);
+        if (!realm) {
             return false;
         }
+        player_ptr->element = *realm;
 
         put_str(_("魔法        :", "Magic       :"), 6, 1);
         c_put_str(TERM_L_BLUE, get_element_title(player_ptr->element), 6, 15);

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -293,10 +293,10 @@ bool get_player_realms(PlayerType *player_ptr)
         if (!realm) {
             return false;
         }
-        player_ptr->element = *realm;
+        player_ptr->element_realm = *realm;
 
         put_str(_("魔法        :", "Magic       :"), 6, 1);
-        c_put_str(TERM_L_BLUE, get_element_title(player_ptr->element), 6, 15);
+        c_put_str(TERM_L_BLUE, get_element_title(player_ptr->element_realm), 6, 15);
         return true;
     }
 

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -74,7 +74,7 @@ static void write_birth_diary(PlayerType *player_ptr)
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_realm);
     }
 
-    if (player_ptr->element) {
+    if (player_ptr->element != ElementRealmType::NONE) {
         const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element).data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_element);
     }

--- a/src/birth/character-builder.cpp
+++ b/src/birth/character-builder.cpp
@@ -74,8 +74,8 @@ static void write_birth_diary(PlayerType *player_ptr)
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_realm);
     }
 
-    if (player_ptr->element != ElementRealmType::NONE) {
-        const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element).data());
+    if (player_ptr->element_realm != ElementRealmType::NONE) {
+        const auto mes_element = format(_("%s元素系統に%sを選択した。", "%schose %s system."), indent, get_element_title(player_ptr->element_realm).data());
         exe_write_diary(floor, DiaryKind::DESCRIPTION, 1, mes_element);
     }
 

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -3,6 +3,7 @@
 #include "birth/birth-util.h"
 #include "birth/game-play-initializer.h"
 #include "io/input-key-acceptor.h"
+#include "mind/mind-elementalist.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
 #include "player-info/race-info.h"
@@ -142,7 +143,7 @@ void load_prev_data(PlayerType *player_ptr, bool swap)
     PlayerRealm pr(player_ptr);
     pr.reset();
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        player_ptr->element = previous_char.realm1;
+        player_ptr->element = i2enum<ElementRealmType>(previous_char.realm1);
     } else {
         const auto realm1 = i2enum<RealmType>(previous_char.realm1);
         const auto realm2 = i2enum<RealmType>(previous_char.realm2);

--- a/src/birth/quick-start.cpp
+++ b/src/birth/quick-start.cpp
@@ -90,7 +90,7 @@ void save_prev_data(PlayerType *player_ptr, birther *birther_ptr)
     birther_ptr->ppersonality = player_ptr->ppersonality;
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        birther_ptr->realm1 = static_cast<int16_t>(player_ptr->element);
+        birther_ptr->realm1 = static_cast<int16_t>(player_ptr->element_realm);
         birther_ptr->realm2 = 0;
     } else {
         PlayerRealm pr(player_ptr);
@@ -143,7 +143,7 @@ void load_prev_data(PlayerType *player_ptr, bool swap)
     PlayerRealm pr(player_ptr);
     pr.reset();
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        player_ptr->element = i2enum<ElementRealmType>(previous_char.realm1);
+        player_ptr->element_realm = i2enum<ElementRealmType>(previous_char.realm1);
     } else {
         const auto realm1 = i2enum<RealmType>(previous_char.realm1);
         const auto realm2 = i2enum<RealmType>(previous_char.realm2);

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -270,7 +270,7 @@ bool report_score(PlayerType *player_ptr)
     personality_desc.append(_(ap_ptr->no ? "の" : "", " "));
 
     PlayerRealm pr(player_ptr);
-    const auto &realm1_name = PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(player_ptr->element) : pr.realm1().get_name().string();
+    const auto &realm1_name = PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST) ? get_element_title(player_ptr->element_realm) : pr.realm1().get_name().string();
     score_ss << fmt::format("name: {}\n", player_ptr->name)
              << fmt::format("version: {}\n", AngbandSystem::get_instance().build_version_expression(VersionExpression::FULL))
              << fmt::format("score: {}\n", calc_score(player_ptr))

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -10,6 +10,7 @@
 #include "load/savedata-old-flag-types.h"
 #include "load/world-loader.h"
 #include "market/arena-entry.h"
+#include "mind/mind-elementalist.h"
 #include "monster-race/race-ability-flags.h"
 #include "mutation/mutation-calculator.h"
 #include "object/tval-types.h"
@@ -40,7 +41,7 @@ static void rd_realms(PlayerType *player_ptr)
     pr.reset();
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        player_ptr->element = rd_byte();
+        player_ptr->element = i2enum<ElementRealmType>(rd_byte());
         (void)rd_byte();
         return;
     }

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -41,7 +41,7 @@ static void rd_realms(PlayerType *player_ptr)
     pr.reset();
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        player_ptr->element = i2enum<ElementRealmType>(rd_byte());
+        player_ptr->element_realm = i2enum<ElementRealmType>(rd_byte());
         (void)rd_byte();
         return;
     }

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -315,7 +315,7 @@ AttributeType get_element_type(ElementRealmType realm, int n)
  */
 static AttributeType get_element_spells_type(PlayerType *player_ptr, int n)
 {
-    const auto &realm = element_types.at(player_ptr->element);
+    const auto &realm = element_types.at(player_ptr->element_realm);
     const auto t = realm.type.at(n);
     if (realm.extra.find(t) != realm.extra.end()) {
         if (evaluate_percent(player_ptr->lev * 2)) {
@@ -354,7 +354,7 @@ const std::string &get_element_name(ElementRealmType realm, int n)
  */
 static std::string get_element_tip(PlayerType *player_ptr, int spell_idx)
 {
-    auto realm = player_ptr->element;
+    auto realm = player_ptr->element_realm;
     auto spell = i2enum<ElementSpells>(spell_idx);
     auto elem = element_powers.at(spell).elem;
     return format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
@@ -876,7 +876,7 @@ static bool try_cast_element_spell(PlayerType *player_ptr, SPELL_IDX spell_idx, 
     if (randint1(100) < chance / 2) {
         int plev = player_ptr->lev;
         msg_print(_("元素の力が制御できない氾流となって解放された！", "The elemental power surges from you in an uncontrollable torrent!"));
-        const auto element = get_element_types(player_ptr->element)[0];
+        const auto element = get_element_types(player_ptr->element_realm)[0];
         constexpr auto flags = PROJECT_JUMP | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM;
         project(player_ptr, PROJECT_WHO_UNCTRL_POWER, 2 + plev / 10, player_ptr->y, player_ptr->x, plev * 2, element, flags);
         player_ptr->csp = std::max(0, player_ptr->csp - player_ptr->msp * 10 / (20 + randint1(10)));
@@ -990,7 +990,7 @@ void display_element_spell_list(PlayerType *player_ptr, int y, int x)
         }
 
         const auto elem = get_elemental_elem(player_ptr, i);
-        const auto name = format(spell.name, get_element_name(player_ptr->element, elem).data());
+        const auto name = format(spell.name, get_element_name(player_ptr->element_realm, elem).data());
 
         const auto mana_cost = decide_element_mana_cost(player_ptr, spell);
         const auto chance = decide_element_chance(player_ptr, spell);
@@ -1068,7 +1068,7 @@ static bool is_elemental_genocide_effective(const MonraceDefinition &monrace, At
  */
 ProcessResult effect_monster_elemental_genocide(PlayerType *player_ptr, EffectMonster *em_ptr)
 {
-    const auto &name = get_element_name(player_ptr->element, 0);
+    const auto &name = get_element_name(player_ptr->element_realm, 0);
     if (em_ptr->seen_msg) {
         msg_format(_("%sが%sを包み込んだ。", "The %s surrounds %s."), name.data(), em_ptr->m_name);
     }
@@ -1077,7 +1077,7 @@ ProcessResult effect_monster_elemental_genocide(PlayerType *player_ptr, EffectMo
         em_ptr->obvious = true;
     }
 
-    const auto type = get_element_type(player_ptr->element, 0);
+    const auto type = get_element_type(player_ptr->element_realm, 0);
     const auto is_effective = is_elemental_genocide_effective(*em_ptr->r_ptr, type);
     if (!is_effective) {
         if (em_ptr->seen_msg) {
@@ -1115,7 +1115,7 @@ bool has_element_resist(PlayerType *player_ptr, ElementRealmType realm, PLAYER_L
         return false;
     }
 
-    return (player_ptr->element == realm) && (player_ptr->lev >= lev);
+    return (player_ptr->element_realm == realm) && (player_ptr->lev >= lev);
 }
 
 /*!
@@ -1296,7 +1296,7 @@ void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 {
     auto plev = player_ptr->lev;
     rpi_type rpi;
-    switch (player_ptr->element) {
+    switch (player_ptr->element_realm) {
     case ElementRealmType::FIRE:
         rpi = rpi_type(_("ライト・エリア", "Light area"));
         rpi.text = _("光源が照らしている範囲か部屋全体を永久に明るくする。", "Lights up nearby area and the inside of a room permanently.");
@@ -1477,7 +1477,7 @@ bool switch_element_execution(PlayerType *player_ptr)
 {
     PLAYER_LEVEL plev = player_ptr->lev;
 
-    switch (player_ptr->element) {
+    switch (player_ptr->element_realm) {
     case ElementRealmType::FIRE:
         (void)lite_area(player_ptr, Dice::roll(2, plev / 2), plev / 10);
         return true;

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -279,46 +279,43 @@ static element_text_list element_texts = {
 
 /*!
  * @brief 元素魔法の領域名を返す
- * @param realm_idx 領域番号
+ * @param realm 領域
  * @return 領域名
  */
-const std::string &get_element_title(int realm_idx)
+const std::string &get_element_title(ElementRealmType realm)
 {
-    auto realm = i2enum<ElementRealmType>(realm_idx);
     return element_types.at(realm).title;
 }
 
 /*!
  * @brief 元素魔法領域の属性リストを返す
- * @param realm_idx 領域番号
+ * @param realm 領域
  * @return 領域で使用できる属性リスト
  */
-static const std::array<AttributeType, 3> &get_element_types(int realm_idx)
+static const std::array<AttributeType, 3> &get_element_types(ElementRealmType realm)
 {
-    auto realm = i2enum<ElementRealmType>(realm_idx);
     return element_types.at(realm).type;
 }
 
 /*!
  * @brief 元素魔法領域のn番目の属性を返す
- * @param realm_idx 領域番号
+ * @param realm 領域
  * @param n 属性の何番目か
  * @return 属性タイプ
  */
-AttributeType get_element_type(int realm_idx, int n)
+AttributeType get_element_type(ElementRealmType realm, int n)
 {
-    return get_element_types(realm_idx).at(n);
+    return get_element_types(realm).at(n);
 }
 
 /*!
  * @brief 元素魔法領域のn番目の呪文用の属性を返す
- * @param realm_idx 領域番号
  * @param n 属性の何番目か
  * @return 属性タイプ
  */
 static AttributeType get_element_spells_type(PlayerType *player_ptr, int n)
 {
-    const auto &realm = element_types.at(i2enum<ElementRealmType>(player_ptr->element));
+    const auto &realm = element_types.at(player_ptr->element);
     const auto t = realm.type.at(n);
     if (realm.extra.find(t) != realm.extra.end()) {
         if (evaluate_percent(player_ptr->lev * 2)) {
@@ -330,24 +327,23 @@ static AttributeType get_element_spells_type(PlayerType *player_ptr, int n)
 
 /*!
  * @brief 元素魔法領域の属性名リストを返す
- * @param realm_idx 領域番号
+ * @param realm 領域
  * @return 領域で使用できる属性の名称リスト
  */
-static const std::array<std::string, 3> &get_element_names(int realm_idx)
+static const std::array<std::string, 3> &get_element_names(ElementRealmType realm)
 {
-    const auto realm = i2enum<ElementRealmType>(realm_idx);
     return element_types.at(realm).name;
 }
 
 /*!
  * @brief 元素魔法領域のn番目の属性名を返す
- * @param realm_idx 領域番号
+ * @param realm 領域
  * @param n 属性の何番目か
  * @return 属性名
  */
-const std::string &get_element_name(int realm_idx, int n)
+const std::string &get_element_name(ElementRealmType realm, int n)
 {
-    return get_element_names(realm_idx).at(n);
+    return get_element_names(realm).at(n);
 }
 
 /*!
@@ -358,7 +354,7 @@ const std::string &get_element_name(int realm_idx, int n)
  */
 static std::string get_element_tip(PlayerType *player_ptr, int spell_idx)
 {
-    auto realm = i2enum<ElementRealmType>(player_ptr->element);
+    auto realm = player_ptr->element;
     auto spell = i2enum<ElementSpells>(spell_idx);
     auto elem = element_powers.at(spell).elem;
     return format(element_tips.at(spell).data(), element_types.at(realm).name[elem].data());
@@ -1119,8 +1115,7 @@ bool has_element_resist(PlayerType *player_ptr, ElementRealmType realm, PLAYER_L
         return false;
     }
 
-    auto prealm = i2enum<ElementRealmType>(player_ptr->element);
-    return (prealm == realm) && (player_ptr->lev >= lev);
+    return (player_ptr->element == realm) && (player_ptr->lev >= lev);
 }
 
 /*!
@@ -1187,12 +1182,13 @@ static int interpret_realm_select_key(int cs, int n, char c)
 /*!
  * @brief 領域選択ループ処理
  * @param player_ptr プレイヤー情報への参照ポインタ
+ * @param realm 選択中の領域
  * @param n 最後尾の位置
  * @return 領域番号
  */
-static int get_element_realm(PlayerType *player_ptr, int is, int n)
+static std::optional<ElementRealmType> get_element_realm(PlayerType *player_ptr, ElementRealmType realm, int n)
 {
-    int cs = std::max(0, is);
+    int cs = std::max(0, enum2i(realm) - 1);
     int os = cs;
     int k;
 
@@ -1208,7 +1204,7 @@ static int get_element_realm(PlayerType *player_ptr, int is, int n)
         cs = interpret_realm_select_key(cs, n, c);
 
         if (c == 'S') {
-            return 255;
+            return std::nullopt;
         }
 
         if (c == ' ' || c == '\r' || c == '\n') {
@@ -1249,7 +1245,7 @@ static int get_element_realm(PlayerType *player_ptr, int is, int n)
     }
 
     display_realm_cursor(cs, n, TERM_YELLOW);
-    return cs + 1;
+    return i2enum<ElementRealmType>(cs + 1);
 }
 
 /*!
@@ -1257,12 +1253,12 @@ static int get_element_realm(PlayerType *player_ptr, int is, int n)
  * @param player_ptr プレイヤー情報への参照ポインタ
  * @return 領域番号
  */
-byte select_element_realm(PlayerType *player_ptr)
+std::optional<ElementRealmType> select_element_realm(PlayerType *player_ptr)
 {
     clear_from(10);
 
     constexpr auto realm_max = enum2i(ElementRealmType::MAX);
-    int realm_idx = 1;
+    auto realm = std::make_optional(ElementRealmType::FIRE);
     int row = 16;
     while (1) {
         put_str(
@@ -1273,13 +1269,12 @@ byte select_element_realm(PlayerType *player_ptr)
             display_realm_cursor(i, realm_max - 1, TERM_WHITE);
         }
 
-        realm_idx = get_element_realm(player_ptr, realm_idx - 1, realm_max - 1);
-        if (realm_idx == 255) {
+        realm = get_element_realm(player_ptr, *realm, realm_max - 1);
+        if (!realm) {
             break;
         }
 
-        auto realm = i2enum<ElementRealmType>(realm_idx);
-        display_wrap_around(element_texts.at(realm), 74, row, 3);
+        display_wrap_around(element_texts.at(*realm), 74, row, 3);
 
         if (input_check_strict(player_ptr, _("よろしいですか？", "Are you sure? "), UserCheck::DEFAULT_Y)) {
             break;
@@ -1289,7 +1284,7 @@ byte select_element_realm(PlayerType *player_ptr)
     }
 
     clear_from(10);
-    return (byte)realm_idx;
+    return realm;
 }
 
 /*!
@@ -1300,9 +1295,8 @@ byte select_element_realm(PlayerType *player_ptr)
 void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr)
 {
     auto plev = player_ptr->lev;
-    auto realm = i2enum<ElementRealmType>(player_ptr->element);
     rpi_type rpi;
-    switch (realm) {
+    switch (player_ptr->element) {
     case ElementRealmType::FIRE:
         rpi = rpi_type(_("ライト・エリア", "Light area"));
         rpi.text = _("光源が照らしている範囲か部屋全体を永久に明るくする。", "Lights up nearby area and the inside of a room permanently.");
@@ -1481,10 +1475,9 @@ static bool door_to_darkness(PlayerType *player_ptr, int distance)
  */
 bool switch_element_execution(PlayerType *player_ptr)
 {
-    auto realm = i2enum<ElementRealmType>(player_ptr->element);
     PLAYER_LEVEL plev = player_ptr->lev;
 
-    switch (realm) {
+    switch (player_ptr->element) {
     case ElementRealmType::FIRE:
         (void)lite_area(player_ptr, Dice::roll(2, plev / 2), plev / 10);
         return true;

--- a/src/mind/mind-elementalist.h
+++ b/src/mind/mind-elementalist.h
@@ -2,7 +2,8 @@
 
 #include "effect/attribute-types.h"
 #include "system/angband.h"
-#include <string_view>
+#include <optional>
+#include <string>
 
 enum class ElementRealmType {
     NONE = 0,
@@ -21,14 +22,14 @@ class PlayerType;
 class EffectMonster;
 struct rc_type;
 
-const std::string &get_element_title(int realm_idx);
-AttributeType get_element_type(int realm_idx, int n);
-const std::string &get_element_name(int realm_idx, int n);
+const std::string &get_element_title(ElementRealmType realm);
+AttributeType get_element_type(ElementRealmType realm, int n);
+const std::string &get_element_name(ElementRealmType realm, int n);
 void do_cmd_element(PlayerType *player_ptr);
 void do_cmd_element_browse(PlayerType *player_ptr);
 void display_element_spell_list(PlayerType *player_ptr, int y = 1, int x = 1);
 ProcessResult effect_monster_elemental_genocide(PlayerType *player_ptr, EffectMonster *em_ptr);
 bool has_element_resist(PlayerType *player_ptr, ElementRealmType realm, PLAYER_LEVEL lev);
-byte select_element_realm(PlayerType *player_ptr);
+std::optional<ElementRealmType> select_element_realm(PlayerType *player_ptr);
 void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr);
 bool switch_element_execution(PlayerType *player_ptr);

--- a/src/racial/racial-draconian.cpp
+++ b/src/racial/racial-draconian.cpp
@@ -83,8 +83,8 @@ static std::optional<std::pair<AttributeType, std::string>> decide_breath_kind(P
 
         return std::pair(AttributeType::SOUND, _("轟音", "sound"));
     case PlayerClassType::ELEMENTALIST: {
-        const auto type = get_element_type(player_ptr->element, 0);
-        const std::string name(get_element_name(player_ptr->element, 0));
+        const auto type = get_element_type(player_ptr->element_realm, 0);
+        const std::string name(get_element_name(player_ptr->element_realm, 0));
         return std::pair(type, name);
     }
     default:

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -29,7 +29,7 @@ static void wr_relams(PlayerType *player_ptr)
 {
     PlayerRealm pr(player_ptr);
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        wr_byte((byte)player_ptr->element);
+        wr_byte((byte)player_ptr->element_realm);
     } else {
         wr_byte((byte)pr.realm1().to_enum());
     }

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -44,7 +44,7 @@ public:
     player_personality_type ppersonality{}; /* Personality index */
     RealmType realm1{}; /* First magic realm */
     RealmType realm2{}; /* Second magic realm */
-    ElementRealmType element{}; //!< 元素使い領域
+    ElementRealmType element_realm{}; //!< 元素使い領域
 
     Dice hit_dice{}; /* Hit dice */
     uint16_t expfact{}; /* Experience factor

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -18,6 +18,7 @@
 #include <string>
 
 enum class DungeonId;
+enum class ElementRealmType;
 enum class ItemKindType : short;
 enum class MimicKindType;
 enum class MonraceId : short;
@@ -43,7 +44,7 @@ public:
     player_personality_type ppersonality{}; /* Personality index */
     RealmType realm1{}; /* First magic realm */
     RealmType realm2{}; /* Second magic realm */
-    int element{}; //!< 元素使い領域番号 / Elementalist system index
+    ElementRealmType element{}; //!< 元素使い領域
 
     Dice hit_dice{}; /* Hit dice */
     uint16_t expfact{}; /* Experience factor

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -98,7 +98,7 @@ static void display_player_basic_info(PlayerType *player_ptr)
 static void display_magic_realms(PlayerType *player_ptr)
 {
     PlayerRealm pr(player_ptr);
-    if (!pr.realm1().is_available() && player_ptr->element == 0) {
+    if (!pr.realm1().is_available() && player_ptr->element == ElementRealmType::NONE) {
         return;
     }
 

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -98,12 +98,12 @@ static void display_player_basic_info(PlayerType *player_ptr)
 static void display_magic_realms(PlayerType *player_ptr)
 {
     PlayerRealm pr(player_ptr);
-    if (!pr.realm1().is_available() && player_ptr->element == ElementRealmType::NONE) {
+    if (!pr.realm1().is_available() && player_ptr->element_realm == ElementRealmType::NONE) {
         return;
     }
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::ELEMENTALIST)) {
-        display_player_one_line(ENTRY_REALM, get_element_title(player_ptr->element), TERM_L_BLUE);
+        display_player_one_line(ENTRY_REALM, get_element_title(player_ptr->element_realm), TERM_L_BLUE);
         return;
     }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -668,7 +668,7 @@ void wiz_reset_class(PlayerType *player_ptr)
     if (realm1 != RealmType::NONE) {
         pr.set(realm1, realm2);
     }
-    player_ptr->element = element_realm;
+    player_ptr->element_realm = element_realm;
     PlayerSpellStatus pss(player_ptr);
     pss.realm1().initialize();
     pss.realm2().initialize();
@@ -694,7 +694,7 @@ void wiz_reset_realms(PlayerType *player_ptr)
     if (realm1 != RealmType::NONE) {
         pr.set(realm1, realm2);
     }
-    player_ptr->element = element_realm;
+    player_ptr->element_realm = element_realm;
     PlayerSpellStatus pss(player_ptr);
     pss.realm1().initialize();
     pss.realm2().initialize();

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -565,9 +565,8 @@ static std::optional<ElementRealmType> wiz_select_element_realm()
 {
     constexpr EnumRange element_realms(ElementRealmType::FIRE, ElementRealmType::MAX);
     CandidateSelector cs("Which realm: ", 15);
-    const auto describe_realm = [](auto realm) { return get_element_title(enum2i(realm)); };
 
-    const auto chosen_realm = cs.select(element_realms, describe_realm);
+    const auto chosen_realm = cs.select(element_realms, get_element_title);
     return (chosen_realm != element_realms.end()) ? std::make_optional(*chosen_realm) : std::nullopt;
 }
 
@@ -669,7 +668,7 @@ void wiz_reset_class(PlayerType *player_ptr)
     if (realm1 != RealmType::NONE) {
         pr.set(realm1, realm2);
     }
-    player_ptr->element = enum2i(element_realm);
+    player_ptr->element = element_realm;
     PlayerSpellStatus pss(player_ptr);
     pss.realm1().initialize();
     pss.realm2().initialize();
@@ -695,7 +694,7 @@ void wiz_reset_realms(PlayerType *player_ptr)
     if (realm1 != RealmType::NONE) {
         pr.set(realm1, realm2);
     }
-    player_ptr->element = enum2i(element_realm);
+    player_ptr->element = element_realm;
     PlayerSpellStatus pss(player_ptr);
     pss.realm1().initialize();
     pss.realm2().initialize();


### PR DESCRIPTION
Resolves #5061
