### PR TITLE
ccache用キャッシュ生成ワークフロー実行エラーの対策

### DIFF
--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -35,7 +35,7 @@ jobs:
     with:
       runner: ubuntu-22.04
       cxx: clang++-15
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable -stdlib=libc++"
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -stdlib=libc++"
       configure-opts: "--disable-pch"
       use-ccache: true
 
@@ -45,7 +45,7 @@ jobs:
     with:
       runner: ubuntu-22.04
       cxx: clang++-14
-      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra -Wno-unused-const-variable"
+      cxx-flags: "-pipe -O3 -Werror -Wall -Wextra"
       configure-opts: "--disable-pch"
       use-ccache: true
 

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,10 @@ AC_SUBST(DEFAULT_VAR_PATH)
 dnl Checks for programs.
 AC_LANG(C++)
 AC_PROG_CXX
+saved_CXXFLAGS="$CXXFLAGS"
+CXXFLAGS=$(echo "$CXXFLAGS" | sed 's/-Werror//g')
 AX_CXX_COMPILE_STDCXX(20, [noext], [mandatory])
+CXXFLAGS="$saved_CXXFLAGS"
 PKG_PROG_PKG_CONFIG
 
 AC_MSG_CHECKING([whether the compiler is Clang])


### PR DESCRIPTION
https://github.com/hengband/hengband/commit/5efb20507bbe024d1c18ad0af3ee7c5b924229f9 のコミットより[ccache用のキャッシュ生成ワークフロー](https://github.com/hengband/hengband/actions/workflows/create-cache-for-ccache.yml) がエラーで失敗するようになっていたので、その対策を行う。
