### PR TITLE
repeat_pull() の引数からポインタを外し、戻り値をoptional に変えた

### DIFF
--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -42,12 +42,12 @@
  */
 static std::optional<MonsterAbilityType> check_blue_magic_repeat()
 {
-    COMMAND_CODE code;
-    if (!repeat_pull(&code)) {
+    const auto code = repeat_pull();
+    if (!code) {
         return std::nullopt;
     }
 
-    if (auto spell = static_cast<MonsterAbilityType>(code);
+    if (auto spell = i2enum<MonsterAbilityType>(*code);
         monster_powers.find(spell) != monster_powers.end()) {
         return spell;
     }

--- a/src/cmd-action/cmd-hissatsu.cpp
+++ b/src/cmd-action/cmd-hissatsu.cpp
@@ -61,15 +61,14 @@ static int get_hissatsu_power(PlayerType *player_ptr, SPELL_IDX *sn)
     PLAYER_LEVEL plev = player_ptr->lev;
     char choice;
     concptr p = _("必殺剣", "special attack");
-    COMMAND_CODE code;
     int menu_line = (use_menu ? 1 : 0);
 
     /* Assume cancelled */
     *sn = (-1);
 
     /* Get the spell, if available */
-    if (repeat_pull(&code)) {
-        *sn = (SPELL_IDX)code;
+    if (const auto code = repeat_pull(); code) {
+        *sn = *code;
         /* Verify the spell */
         if (0 <= *sn && *sn < 32 && PlayerRealm::get_spell_info(RealmType::HISSATSU, *sn).slevel <= plev) {
             /* Success */

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -363,7 +363,6 @@ static void do_name_pet(PlayerType *player_ptr)
  */
 void do_cmd_pet(PlayerType *player_ptr)
 {
-    COMMAND_CODE i = 0;
     int powers[36]{};
     std::string power_desc[36];
     bool flag, redraw;
@@ -523,7 +522,8 @@ void do_cmd_pet(PlayerType *player_ptr)
         }
     }
 
-    if (!(repeat_pull(&i) && (i >= 0) && (i < num))) {
+    auto code_repeat = repeat_pull();
+    if (!code_repeat || (code_repeat < 0) || (code_repeat >= num)) {
         flag = false;
         redraw = false;
 
@@ -587,7 +587,7 @@ void do_cmd_pet(PlayerType *player_ptr)
                 case 'X':
                 case '\r':
                 case '\n':
-                    i = menu_line - 1;
+                    code_repeat = static_cast<short>(menu_line - 1);
                     should_redraw_cursor = false;
                     break;
                 }
@@ -638,11 +638,11 @@ void do_cmd_pet(PlayerType *player_ptr)
             }
 
             if (!use_menu) {
-                i = A2I(choice);
+                code_repeat = A2I(choice);
             }
 
             /* Totally Illegal */
-            if ((i < 0) || (i >= num)) {
+            if (!code_repeat || (code_repeat < 0) || (code_repeat >= num)) {
                 bell();
                 continue;
             }
@@ -660,9 +660,10 @@ void do_cmd_pet(PlayerType *player_ptr)
             return;
         }
 
-        repeat_push(i);
+        repeat_push(*code_repeat);
     }
-    switch (powers[i]) {
+
+    switch (powers[code_repeat.value_or(0)]) {
     case PET_DISMISS: /* Dismiss pets */
     {
         /* Check pets (backwards) */

--- a/src/cmd-action/cmd-racial.cpp
+++ b/src/cmd-action/cmd-racial.cpp
@@ -372,8 +372,12 @@ static bool racial_power_process_input(PlayerType *player_ptr, rc_type *rc_ptr)
  */
 static bool racial_power_select_power(PlayerType *player_ptr, rc_type *rc_ptr)
 {
-    if (repeat_pull(&rc_ptr->command_code) && rc_ptr->command_code >= 0 && rc_ptr->command_code < rc_ptr->power_count()) {
-        return true;
+    const auto code = repeat_pull();
+    if (code) {
+        rc_ptr->command_code = *code;
+        if ((rc_ptr->command_code >= 0) && (rc_ptr->command_code < rc_ptr->power_count())) {
+            return true;
+        }
     }
 
     screen_save();

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -319,12 +319,11 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, std::string_view pro
     SPELL_IDX spell = -1;
     int num = 0;
     SPELL_IDX spells[64]{};
-    COMMAND_CODE code;
     int menu_line = (use_menu ? 1 : 0);
 
     /* Get the spell, if available */
-    if (repeat_pull(&code)) {
-        *sn = (SPELL_IDX)code;
+    if (const auto code = repeat_pull(); code) {
+        *sn = *code;
         /* Verify the spell */
         if (spell_okay(player_ptr, *sn, learned, false, use_realm)) {
             /* Success */
@@ -526,33 +525,26 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, std::string_view pro
  */
 static void confirm_use_force(PlayerType *player_ptr, bool browse_only)
 {
-    char which;
-    COMMAND_CODE code;
-
-    /* Get the item index */
-    if (repeat_pull(&code) && (code == INVEN_FORCE)) {
+    if (const auto code = repeat_pull(); code == INVEN_FORCE) {
         browse_only ? do_cmd_mind_browse(player_ptr) : do_cmd_mind(player_ptr);
         return;
     }
 
-    /* Show the prompt */
     prt(_("('w'練気術, ESC) 'w'かESCを押してください。 ", "(w for the Force, ESC) Hit 'w' or ESC. "), 0, 0);
-
+    char which;
     while (true) {
-        /* Get a key */
         which = inkey();
-
         if (which == ESCAPE) {
             break;
-        } else if (which == 'w') {
+        }
+
+        if (which == 'w') {
             repeat_push(INVEN_FORCE);
             break;
         }
     }
 
-    /* Clear the prompt line */
     prt("", 0, 0);
-
     if (which == 'w') {
         browse_only ? do_cmd_mind_browse(player_ptr) : do_cmd_mind(player_ptr);
     }

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -326,9 +326,8 @@ std::optional<char> input_command(std::string_view prompt, bool z_escape)
  */
 int input_quantity(int max, std::string_view initial_prompt)
 {
-    int amt;
     if (command_arg) {
-        amt = command_arg;
+        int amt = command_arg;
         command_arg = 0;
         if (amt > max) {
             amt = max;
@@ -337,19 +336,9 @@ int input_quantity(int max, std::string_view initial_prompt)
         return amt;
     }
 
-    short code;
-    auto result = repeat_pull(&code);
-    amt = code;
-    if ((max != 1) && result) {
-        if (amt > max) {
-            return max;
-        }
-
-        if (amt < 0) {
-            return 0;
-        }
-
-        return amt;
+    const auto code = repeat_pull();
+    if ((max != 1) && code) {
+        return std::clamp<int>(*code, 0, max);
     }
 
     std::string prompt;
@@ -365,11 +354,12 @@ int input_quantity(int max, std::string_view initial_prompt)
         return 0;
     }
 
+    int amt;
     if (isalpha((*input_amount)[0])) {
         amt = max;
     } else {
         try {
-            amt = std::clamp<int>(std::stoi(*input_amount), 0, max);
+            amt = std::clamp(std::stoi(*input_amount), 0, max);
         } catch (const std::exception &) {
             amt = 0;
         }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -139,10 +139,12 @@ static bool check_floor_item_tag_inventory(PlayerType *player_ptr, FloorItemSele
  */
 static bool check_floor_item_tag(PlayerType *player_ptr, FloorItemSelection *fis_ptr, char *prev_tag, const ItemTester &item_tester)
 {
-    if (!repeat_pull(&fis_ptr->cp)) {
+    const auto code = repeat_pull();
+    if (!code) {
         return false;
     }
 
+    fis_ptr->cp = *code;
     if (fis_ptr->force && (fis_ptr->cp == INVEN_FORCE)) {
         command_cmd = 0;
         return true;

--- a/src/inventory/item-getter.cpp
+++ b/src/inventory/item-getter.cpp
@@ -130,10 +130,12 @@ static bool check_item_tag_inventory(PlayerType *player_ptr, ItemSelection *item
  */
 static bool check_item_tag(PlayerType *player_ptr, ItemSelection *item_selection_ptr, char *prev_tag, const ItemTester &item_tester)
 {
-    if (!repeat_pull(&item_selection_ptr->cp)) {
+    const auto code = repeat_pull();
+    if (!code) {
         return false;
     }
 
+    item_selection_ptr->cp = *code;
     if (item_selection_ptr->mode & USE_FORCE && (item_selection_ptr->cp == INVEN_FORCE)) {
         command_cmd = 0;
         return true;

--- a/src/io/command-repeater.cpp
+++ b/src/io/command-repeater.cpp
@@ -11,29 +11,24 @@ static int repeat_counter = 0;
 static int repeat_index = 0;
 
 /* Saved "stuff" */
-static COMMAND_CODE repeat_keys[REPEAT_MAX];
+static short repeat_keys[REPEAT_MAX];
 
-void repeat_push(COMMAND_CODE what)
+void repeat_push(short command)
 {
     if (repeat_counter == REPEAT_MAX) {
         return;
     }
 
-    repeat_keys[repeat_counter++] = what;
+    repeat_keys[repeat_counter++] = command;
     ++repeat_index;
 }
 
-bool repeat_pull(COMMAND_CODE *what)
+std::optional<short> repeat_pull()
 {
-    if (repeat_index == repeat_counter) {
-        return false;
-    }
-
-    *what = repeat_keys[repeat_index++];
-    return true;
+    return repeat_index == repeat_counter ? std::nullopt : std::make_optional(repeat_keys[repeat_index++]);
 }
 
-void repeat_check(void)
+void repeat_check()
 {
     if (command_cmd == ESCAPE) {
         return;
@@ -48,16 +43,14 @@ void repeat_check(void)
         return;
     }
 
-    COMMAND_CODE what;
     if (command_cmd == 'n') {
         repeat_index = 0;
-        if (repeat_pull(&what)) {
-            command_cmd = what;
+        if (const auto code = repeat_pull(); code) {
+            command_cmd = *code;
         }
     } else {
         repeat_counter = 0;
         repeat_index = 0;
-        what = command_cmd;
-        repeat_push(what);
+        repeat_push(command_cmd);
     }
 }

--- a/src/io/command-repeater.h
+++ b/src/io/command-repeater.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "system/angband.h"
+#include <optional>
 
-void repeat_push(COMMAND_CODE what);
-bool repeat_pull(COMMAND_CODE *what);
+void repeat_push(short command);
+std::optional<short> repeat_pull();
 void repeat_check();

--- a/src/mind/mind-archer.cpp
+++ b/src/mind/mind-archer.cpp
@@ -35,9 +35,9 @@ enum ammo_creation_type {
 
 static bool select_ammo_creation_type(ammo_creation_type &type, PLAYER_LEVEL plev)
 {
-    COMMAND_CODE code;
-    if (repeat_pull(&code)) {
-        type = i2enum<ammo_creation_type>(code);
+    const auto code = repeat_pull();
+    if (code) {
+        type = i2enum<ammo_creation_type>(*code);
         switch (type) {
         case AMMO_SHOT:
         case AMMO_ARROW:

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -699,13 +699,12 @@ static bool get_element_power(PlayerType *player_ptr, SPELL_IDX *sn, bool only_b
     TERM_LEN y = 1;
     TERM_LEN x = 10;
     PLAYER_LEVEL plev = player_ptr->lev;
-    COMMAND_CODE code;
     bool flag, redraw;
     int menu_line = (use_menu ? 1 : 0);
 
     *sn = -1;
-    if (repeat_pull(&code)) {
-        *sn = (SPELL_IDX)code;
+    if (const auto code = repeat_pull(); code) {
+        *sn = *code;
         if (get_elemental_info(player_ptr, *sn).min_lev <= plev) {
             return true;
         }

--- a/src/mind/mind-power-getter.cpp
+++ b/src/mind/mind-power-getter.cpp
@@ -125,19 +125,21 @@ void MindPowerGetter::select_mind_description()
 
 bool MindPowerGetter::select_spell_index(SPELL_IDX *sn)
 {
-    COMMAND_CODE code;
     this->mind_ptr = &mind_powers[enum2i(this->use_mind)];
     *sn = -1;
-    if (!repeat_pull(&code)) {
+    auto code = repeat_pull();
+    if (!code) {
         return false;
     }
 
-    *sn = (SPELL_IDX)code;
+    *sn = *code;
     if (*sn == INVEN_FORCE) {
-        (void)repeat_pull(&code);
+        code = repeat_pull();
+        if (code) {
+            *sn = *code;
+        }
     }
 
-    *sn = (SPELL_IDX)code;
     return mind_ptr->info[*sn].min_lev <= this->player_ptr->lev;
 }
 

--- a/src/mind/mind-sniper.cpp
+++ b/src/mind/mind-sniper.cpp
@@ -262,10 +262,11 @@ static int get_snipe_power(PlayerType *player_ptr, COMMAND_CODE *sn, bool only_b
 
     /* Repeat previous command */
     /* Get the spell, if available */
-    if (repeat_pull(sn)) {
+    const auto code = repeat_pull();
+    if (code) {
         /* Verify the spell */
+        *sn = *code;
         if ((snipe_powers[*sn].min_lev <= plev) && (snipe_powers[*sn].mana_cost <= sniper_data->concent)) {
-            /* Success */
             return true;
         }
     }

--- a/src/mind/mind-weaponsmith.cpp
+++ b/src/mind/mind-weaponsmith.cpp
@@ -28,6 +28,7 @@
 #include "view/display-messages.h"
 #include "view/display-util.h"
 #include <algorithm>
+#include <fmt/format.h>
 #include <sstream>
 #include <string>
 
@@ -66,18 +67,16 @@ static void display_essence(PlayerType *player_ptr)
         for (auto i = 1U; i <= row_count + 1; i++) {
             prt("", i, 0);
         }
-        prt(_("エッセンス   個数     エッセンス   個数     エッセンス   個数", "Essence      Num      Essence      Num      Essence      Num "), 1, 8);
 
-        for (auto num = 0U, ei = page * essence_num_per_page;
-             num < essence_num_per_page && ei < essences.size();
-             ++num, ++ei) {
+        prt(_("エッセンス   個数     エッセンス   個数     エッセンス   個数", "Essence      Num      Essence      Num      Essence      Num "), 1, 8);
+        for (auto num = 0U, ei = page * essence_num_per_page; (num < essence_num_per_page) && (ei < essences.size()); ++num, ++ei) {
             auto name = Smith::get_essence_name(essences[ei]);
             auto amount = smith.get_essence_num_of_posessions(essences[ei]);
             prt(format("%-11s %5d", name, amount), 2 + num % row_count, 8 + (num / row_count) * column_width);
         }
-        prt(format(_("現在所持しているエッセンス %d/%d", "List of all essences you have. %d/%d"), (page + 1), page_max), 0, 0);
 
-        auto key = inkey();
+        prt(fmt::format(_("現在所持しているエッセンス {}/{}", "List of all essences you have. {}/{}"), (page + 1), page_max), 0, 0);
+        const auto key = inkey();
         if (key == ESCAPE) {
             break;
         }
@@ -100,8 +99,8 @@ static void display_essence(PlayerType *player_ptr)
             page = 0;
         }
     }
+
     screen_load();
-    return;
 }
 
 static void set_smith_redrawing_flags()
@@ -165,7 +164,6 @@ static void drain_essence(PlayerType *player_ptr)
  */
 static COMMAND_CODE choose_essence(void)
 {
-    COMMAND_CODE mode = 0;
     char choice;
     COMMAND_CODE menu_line = (use_menu ? 1 : 0);
 
@@ -175,24 +173,24 @@ static COMMAND_CODE choose_essence(void)
     concptr menu_name[] = { "Brand weapon", "Resistance", "Ability", "Magic number", "Slay", "ESP", "Others", "Activation" };
 #endif
     const COMMAND_CODE mode_max = 8;
-
-    if (repeat_pull(&mode) && 1 <= mode && mode <= mode_max) {
+    auto mode = repeat_pull().value_or(0);
+    if ((1 <= mode) && (mode <= mode_max)) {
         return mode;
     }
-    mode = 0;
+
     if (use_menu) {
         screen_save();
-
-        while (!mode) {
+        while (mode == 0) {
             int i;
-            for (i = 0; i < mode_max; i++)
+            for (i = 0; i < mode_max; i++) {
 #ifdef JP
                 prt(format(" %s %s", (menu_line == 1 + i) ? "》" : "  ", menu_name[i]), 2 + i, 14);
-            prt("どの種類のエッセンス付加を行いますか？", 0, 0);
 #else
                 prt(format(" %s %s", (menu_line == 1 + i) ? "> " : "  ", menu_name[i]), 2 + i, 14);
-            prt("Choose from menu.", 0, 0);
 #endif
+            }
+
+            prt(_("どの種類のエッセンス付加を行いますか？", "Choose from menu."), 0, 0);
 
             choice = inkey();
             switch (choice) {
@@ -225,7 +223,7 @@ static COMMAND_CODE choose_essence(void)
         screen_load();
     } else {
         screen_save();
-        while (!mode) {
+        while (mode == 0) {
             for (short i = 0; i < mode_max; i++) {
                 prt(format("  %c) %s", 'a' + i, menu_name[i]), 2 + i, 14);
             }
@@ -242,7 +240,7 @@ static COMMAND_CODE choose_essence(void)
             }
 
             if ('a' <= choice && choice <= 'a' + (char)mode_max - 1) {
-                mode = (int)choice - 'a' + 1;
+                mode = choice - 'a' + 1;
             }
         }
         screen_load();
@@ -326,13 +324,11 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
     const int page_max = (smith_effect_list.size() - 1) / effect_num_per_page + 1;
 
     COMMAND_CODE i = -1;
-    COMMAND_CODE effect_idx;
+    auto effect_index = repeat_pull().value_or(-1);
     bool flag;
-    if (!repeat_pull(&effect_idx) || effect_idx < 0 || effect_idx >= smith_effect_list_max) {
+    if (effect_index < 0 || effect_index >= smith_effect_list_max) {
         flag = false;
-
         screen_save();
-
         while (!flag) {
             std::string prompt;
             if (page_max > 1) {
@@ -420,9 +416,9 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
                 i = A2I(*choice);
             }
 
-            effect_idx = page * effect_num_per_page + i;
+            effect_index = page * effect_num_per_page + i;
             /* Totally Illegal */
-            if ((effect_idx < 0) || (effect_idx >= smith_effect_list_max) || smith.get_addable_count(smith_effect_list[effect_idx]) <= 0) {
+            if ((effect_index < 0) || (effect_index >= smith_effect_list_max) || smith.get_addable_count(smith_effect_list[effect_index]) <= 0) {
                 bell();
                 continue;
             }
@@ -437,10 +433,10 @@ static void add_essence(PlayerType *player_ptr, SmithCategoryType mode)
             return;
         }
 
-        repeat_push(effect_idx);
+        repeat_push(effect_index);
     }
 
-    auto effect = smith_effect_list[effect_idx];
+    const auto effect = smith_effect_list[effect_index];
 
     auto item_tester = Smith::get_item_tester(effect);
 
@@ -548,7 +544,6 @@ static void erase_essence(PlayerType *player_ptr)
  */
 void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
 {
-    COMMAND_CODE mode = 0;
     COMMAND_CODE menu_line = (use_menu ? 1 : 0);
     if (!only_browse) {
         if (cmd_limit_confused(player_ptr)) {
@@ -564,7 +559,8 @@ void do_cmd_kaji(PlayerType *player_ptr, bool only_browse)
         }
     }
 
-    if (!(repeat_pull(&mode) && (1 <= mode) && (mode <= 5))) {
+    auto mode = repeat_pull().value_or(0);
+    if ((1 > mode) || (mode > 5)) {
         if (only_browse) {
             screen_save();
         }

--- a/src/player-info/magic-eater-data-type.cpp
+++ b/src/player-info/magic-eater-data-type.cpp
@@ -36,22 +36,22 @@ std::vector<MagicEaterDataList::MagicEaterDatum> &MagicEaterDataList::get_item_g
 
 std::optional<BaseitemKey> MagicEaterDataList::check_magic_eater_spell_repeat() const
 {
-    short sn;
-    if (!repeat_pull(&sn)) {
+    const auto code = repeat_pull();
+    if (!code) {
         return std::nullopt;
     }
 
     auto tval = ItemKindType::NONE;
-    if (EATER_STAFF_BASE <= sn && sn < EATER_STAFF_BASE + EATER_ITEM_GROUP_SIZE) {
+    if (EATER_STAFF_BASE <= code && code < EATER_STAFF_BASE + EATER_ITEM_GROUP_SIZE) {
         tval = ItemKindType::STAFF;
-    } else if (EATER_WAND_BASE <= sn && sn < EATER_WAND_BASE + EATER_ITEM_GROUP_SIZE) {
+    } else if (EATER_WAND_BASE <= code && code < EATER_WAND_BASE + EATER_ITEM_GROUP_SIZE) {
         tval = ItemKindType::WAND;
-    } else if (EATER_ROD_BASE <= sn && sn < EATER_ROD_BASE + EATER_ITEM_GROUP_SIZE) {
+    } else if (EATER_ROD_BASE <= code && code < EATER_ROD_BASE + EATER_ITEM_GROUP_SIZE) {
         tval = ItemKindType::ROD;
     }
 
     const auto &item_group = this->get_item_group(tval);
-    auto sval = sn % EATER_ITEM_GROUP_SIZE;
+    auto sval = *code % EATER_ITEM_GROUP_SIZE;
     if (sval >= static_cast<int>(item_group.size())) {
         return std::nullopt;
     }

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -152,9 +152,9 @@ int store_check_num(const ItemEntity *o_ptr, StoreSaleType store_num)
  */
 std::optional<short> input_stock(std::string_view fmt, int min, int max, [[maybe_unused]] StoreSaleType store_num)
 {
-    short repeat_command;
-    if (repeat_pull(&repeat_command) && (repeat_command >= min) && (repeat_command <= max)) {
-        return repeat_command;
+    const auto code = repeat_pull();
+    if ((code >= min) && (code <= max)) {
+        return code;
     }
 
     msg_print(nullptr);

--- a/src/target/target-getter.cpp
+++ b/src/target/target-getter.cpp
@@ -37,13 +37,13 @@ Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
         dir = command_dir;
         auto try_old_target = use_old_target;
 
-        short code = 0;
-        if (repeat_pull(&code) && Direction::is_valid_dir(code)) {
+        const auto code = repeat_pull();
+        if (code && Direction::is_valid_dir(*code)) {
             if (code == 5) {
                 try_old_target = true;
             } else {
                 try_old_target = false;
-                dir = Direction(code);
+                dir = Direction(*code);
             }
         }
 
@@ -109,10 +109,10 @@ Direction get_aim_dir(PlayerType *player_ptr, bool enable_repeat)
  */
 Direction get_direction(PlayerType *player_ptr)
 {
-    auto dir = command_dir;
-    short code = 0;
-    if (repeat_pull(&code) && Direction::is_valid_dir(code)) {
-        dir = Direction(code);
+    Direction dir = command_dir;
+    const auto code = repeat_pull();
+    if (code && Direction::is_valid_dir(*code)) {
+        dir = Direction(*code);
     }
 
     constexpr auto prompt = _("方向 (ESCで中断)? ", "Direction (Escape to cancel)? ");
@@ -167,10 +167,10 @@ Direction get_direction(PlayerType *player_ptr)
  */
 Direction get_rep_dir(PlayerType *player_ptr, bool under)
 {
-    auto dir = command_dir;
-    short code = 0;
-    if (repeat_pull(&code) && Direction::is_valid_dir(code)) {
-        dir = Direction(code);
+    Direction dir = command_dir;
+    const auto code = repeat_pull();
+    if (code && Direction::is_valid_dir(*code)) {
+        dir = Direction(*code);
     }
 
     const auto prompt = under ? _("方向 ('.'足元, ESCで中断)? ", "Direction ('.' at feet, Escape to cancel)? ")


### PR DESCRIPTION
掲題の通りです
その他2点修正しました
ご確認下さい

```cpp
// 前はautoかつ右辺がリテラルだったが、Direction型に変わってサジェスト発生、コピーが正しいので左辺の型を明示
Direction dir = command_dir;

// 元は改行だった。MSVCとClangで先頭の空白が微妙に食い違っており、長くて少し見づらいが1行にまとめた
for (auto num = 0U, ei = page * essence_num_per_page; (num < essence_num_per_page) && (ei < essences.size()); ++num, ++ei) {
```

## gemini code assist
Please write all summary and review comments in Japanese.