### PR TITLE
[Fix] easy_floorが「いいえ」でアイテムを拾うとクラッシュ

### DIFF
--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -120,7 +120,7 @@ void autopick_pickup_items(PlayerType *player_ptr, const Grid &grid)
         }
 
         if (!(autopick_list[idx].action & DO_QUERY_AUTOPICK)) {
-            describe_pickup_item(player_ptr, this_o_idx);
+            process_player_pickup_item(player_ptr, this_o_idx);
             continue;
         }
 
@@ -136,6 +136,6 @@ void autopick_pickup_items(PlayerType *player_ptr, const Grid &grid)
             continue;
         }
 
-        describe_pickup_item(player_ptr, this_o_idx);
+        process_player_pickup_item(player_ptr, this_o_idx);
     }
 }

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -254,14 +254,14 @@ void carry(PlayerType *player_ptr, bool pickup)
         return;
     }
 
-    std::vector<OBJECT_IDX> delete_i_idx_list;
-    for (const auto this_o_idx : grid.o_idx_list) {
+    for (auto it = grid.o_idx_list.begin(); it != grid.o_idx_list.end();) {
+        const auto this_o_idx = *it++;
         auto &item = *player_ptr->current_floor_ptr->o_list[this_o_idx];
         const auto item_name = describe_flavor(player_ptr, item, 0);
         disturb(player_ptr, false, false);
         if (item.bi_key.tval() == ItemKindType::GOLD) {
             const auto value = item.pval;
-            delete_i_idx_list.push_back(this_o_idx);
+            delete_object_idx(player_ptr, this_o_idx);
             msg_format(_(" $%d の価値がある%sを見つけた。", "You collect %d gold pieces worth of %s."), value, item_name.data());
             sound(SoundKind::SELL);
             player_ptr->au += value;
@@ -295,5 +295,4 @@ void carry(PlayerType *player_ptr, bool pickup)
             process_player_pickup_item(player_ptr, this_o_idx);
         }
     }
-    delete_items(player_ptr, std::move(delete_i_idx_list));
 }

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -75,7 +75,7 @@ static bool py_pickup_floor_aux(PlayerType *player_ptr)
         return false;
     }
 
-    describe_pickup_item(player_ptr, this_o_idx);
+    process_player_pickup_item(player_ptr, this_o_idx);
     return true;
 }
 
@@ -159,7 +159,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
     }
 
     if (!carry_query_flag) {
-        describe_pickup_item(player_ptr, floor_o_idx);
+        process_player_pickup_item(player_ptr, floor_o_idx);
         return;
     }
 
@@ -170,12 +170,11 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
         return;
     }
 
-    describe_pickup_item(player_ptr, floor_o_idx);
+    process_player_pickup_item(player_ptr, floor_o_idx);
 }
 
 /*!
- * @brief プレイヤーがオブジェクトを拾った際のメッセージ表示処理 /
- * Helper routine for py_pickup() and py_pickup_floor().
+ * @brief プレイヤーがアイテムを拾う処理
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param o_idx 取得したオブジェクトの参照ID
  * @details
@@ -186,7 +185,7 @@ void py_pickup_floor(PlayerType *player_ptr, bool pickup)
  * Add the given dungeon object to the character's inventory.\n
  * Delete the object afterwards.\n
  */
-void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
+void process_player_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
 {
     auto *o_ptr = player_ptr->current_floor_ptr->o_list[o_idx].get();
 #ifdef JP
@@ -293,7 +292,7 @@ void carry(PlayerType *player_ptr, bool pickup)
         }
 
         if (is_pickup_successful) {
-            describe_pickup_item(player_ptr, this_o_idx);
+            process_player_pickup_item(player_ptr, this_o_idx);
         }
     }
     delete_items(player_ptr, std::move(delete_i_idx_list));

--- a/src/inventory/player-inventory.h
+++ b/src/inventory/player-inventory.h
@@ -7,5 +7,5 @@ class PlayerType;
 class ItemTester;
 bool can_get_item(PlayerType *player_ptr, const ItemTester &item_tester);
 void py_pickup_floor(PlayerType *player_ptr, bool pickup);
-void describe_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx);
+void process_player_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx);
 void carry(PlayerType *player_ptr, bool pickup);

--- a/src/monster-floor/monster-object.cpp
+++ b/src/monster-floor/monster-object.cpp
@@ -214,14 +214,13 @@ void update_object_by_monster_movement(PlayerType *player_ptr, turn_flags *turn_
  */
 void monster_drop_carried_objects(PlayerType *player_ptr, MonsterEntity &monster)
 {
-    std::vector<OBJECT_IDX> delete_i_idx_list;
-    for (const auto this_o_idx : monster.hold_o_idx_list) {
+    for (auto it = monster.hold_o_idx_list.begin(); it != monster.hold_o_idx_list.end();) {
+        const auto this_o_idx = *it++;
         auto drop_item = player_ptr->current_floor_ptr->o_list[this_o_idx]->clone();
         drop_item.held_m_idx = 0;
-        delete_i_idx_list.push_back(this_o_idx);
+        delete_object_idx(player_ptr, this_o_idx);
         (void)drop_near(player_ptr, &drop_item, monster.get_position());
     }
-    delete_items(player_ptr, std::move(delete_i_idx_list));
 
     monster.hold_o_idx_list.clear();
 }


### PR DESCRIPTION
床上アイテムリストをイテレーションしている途中で床上のアイテム削除によりリストから消去されるとイテレータが無効となるためクラッシュする。
range-based forではなく自前でイテレータを走査し、ループ処理の先頭でイテレータを次の要素へ進めておくことでこの問題を回避する。