### PR TITLE
[Refactor] record_o_name

### DIFF
--- a/src/cmd-io/cmd-diary.cpp
+++ b/src/cmd-io/cmd-diary.cpp
@@ -17,6 +17,7 @@
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <fmt/format.h>
 #include <sstream>
 #include <string>
 
@@ -57,11 +58,11 @@ static void add_diary_note(const FloorType &floor)
  */
 static void do_cmd_last_get(const FloorType &floor)
 {
-    if (record_o_name[0] == '\0') {
+    if (record_item_name.empty()) {
         return;
     }
 
-    const auto record = format(_("%sの入手を記録します。", "Do you really want to record getting %s? "), record_o_name);
+    const auto record = fmt::format(_("{}の入手を記録します。", "Do you really want to record getting {}? "), record_item_name);
     if (!input_check(record)) {
         return;
     }
@@ -69,7 +70,7 @@ static void do_cmd_last_get(const FloorType &floor)
     auto &world = AngbandWorld::get_instance();
     const auto turn_tmp = world.game_turn;
     world.game_turn = record_turn;
-    const auto mes = format(_("%sを手に入れた。", "discover %s."), record_o_name);
+    const auto mes = fmt::format(_("{}を手に入れた。", "discover {}."), record_item_name);
     exe_write_diary(floor, DiaryKind::DESCRIPTION, 0, mes);
     world.game_turn = turn_tmp;
 }

--- a/src/core/game-play.cpp
+++ b/src/core/game-play.cpp
@@ -239,7 +239,7 @@ static void reset_world_info(PlayerType *player_ptr)
     world.timewalk_m_idx = 0;
     player_ptr->now_damaged = false;
     now_message = 0;
-    record_o_name[0] = '\0';
+    record_item_name.clear();
 }
 
 static void generate_wilderness(PlayerType *player_ptr)

--- a/src/game-option/play-record-options.cpp
+++ b/src/game-option/play-record-options.cpp
@@ -13,5 +13,5 @@ bool record_danger; /* Record hitpoint warning */
 bool record_arena; /* Record on_defeat_arena_monster victories */
 bool record_ident; /* Record first identified items */
 bool record_named_pet; /* Record information about named pets */
-char record_o_name[MAX_NLEN];
+std::string record_item_name;
 GAME_TURN record_turn;

--- a/src/game-option/play-record-options.h
+++ b/src/game-option/play-record-options.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
+#include <string>
 
 extern bool record_fix_art; /* Record fixed artifacts */
 extern bool record_rand_art; /* Record random artifacts */
@@ -16,5 +17,5 @@ extern bool record_arena; /* Record on_defeat_arena_monster victories */
 extern bool record_ident; /* Record first identified items */
 extern bool record_named_pet; /* Record information about named pets */
 
-extern char record_o_name[MAX_NLEN];
+extern std::string record_item_name; ///< 最後に取得したアイテムの名前(プレイ記録用)
 extern GAME_TURN record_turn;

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -225,10 +225,10 @@ void process_player_pickup_item(PlayerType *player_ptr, OBJECT_IDX o_idx)
         }
     }
 
-    angband_strcpy(record_o_name, old_item_name, old_item_name.length());
+    record_item_name = old_item_name;
 #else
     msg_format("You have %s (%c).", item_name.data(), index_to_label(slot));
-    angband_strcpy(record_o_name, item_name, item_name.length());
+    record_item_name = item_name;
 #endif
     record_turn = AngbandWorld::get_instance().game_turn;
     check_find_art_quest_completion(player_ptr, o_ptr);

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -85,7 +85,7 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
         SubWindowRedrawingFlag::FOUND_ITEMS,
     };
     rfu.set_flags(flags_swrf);
-    angband_strcpy(record_o_name, known_item_name, MAX_NLEN);
+    record_item_name = known_item_name;
     record_turn = AngbandWorld::get_instance().game_turn;
 
     const auto item_name = describe_flavor(player_ptr, *o_ptr, OD_NAME_ONLY);

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -272,7 +272,7 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
     object_aware(player_ptr, item);
 
     msg_print(_("{}を ${}で購入しました。", "You bought {} for {} gold."), purchased_item_name, price);
-    angband_strcpy(record_o_name, purchased_item_name, MAX_NLEN);
+    record_item_name = purchased_item_name;
     record_turn = world.game_turn;
     const auto &floor = *player_ptr->current_floor_ptr;
     if (record_buy) {


### PR DESCRIPTION
プレイ記録に入手したアイテムを記録するためにアイテム名を記憶しておく変数である record_o_name の型を std::string に変更し、record_item_name に改名する。

ちょっとしたリファクタリングなのでIssueはなし。