### PR TITLE
Fixing scrolls of door/stair location and treasure detection

### DIFF
--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -242,8 +242,8 @@ bool ScrollReadExecutor::read()
         this->ident = true;
         break;
     case SV_SCROLL_DETECT_GOLD: {
-        bool detected_treasure = detect_treasure(this->player_ptr, DETECT_RAD_DEFAULT);
-        bool detected_gold = detect_objects_gold(this->player_ptr, DETECT_RAD_DEFAULT);
+        const auto detected_treasure = detect_treasure(this->player_ptr, DETECT_RAD_DEFAULT);
+        const auto detected_gold = detect_objects_gold(this->player_ptr, DETECT_RAD_DEFAULT);
 
         if (detected_treasure || detected_gold) {
             this->ident = true;
@@ -264,8 +264,8 @@ bool ScrollReadExecutor::read()
 
         break;
     case SV_SCROLL_DETECT_DOOR: {
-        bool detected_doors = detect_doors(this->player_ptr, DETECT_RAD_DEFAULT);
-        bool detected_stairs = detect_stairs(this->player_ptr, DETECT_RAD_DEFAULT);
+        const auto detected_doors = detect_doors(this->player_ptr, DETECT_RAD_DEFAULT);
+        const auto detected_stairs = detect_stairs(this->player_ptr, DETECT_RAD_DEFAULT);
 
         if (detected_doors || detected_stairs) {
             this->ident = true;

--- a/src/object-use/read/scroll-read-executor.cpp
+++ b/src/object-use/read/scroll-read-executor.cpp
@@ -241,12 +241,16 @@ bool ScrollReadExecutor::read()
         map_area(this->player_ptr, DETECT_RAD_MAP);
         this->ident = true;
         break;
-    case SV_SCROLL_DETECT_GOLD:
-        if (detect_treasure(this->player_ptr, DETECT_RAD_DEFAULT) || detect_objects_gold(this->player_ptr, DETECT_RAD_DEFAULT)) {
+    case SV_SCROLL_DETECT_GOLD: {
+        bool detected_treasure = detect_treasure(this->player_ptr, DETECT_RAD_DEFAULT);
+        bool detected_gold = detect_objects_gold(this->player_ptr, DETECT_RAD_DEFAULT);
+
+        if (detected_treasure || detected_gold) {
             this->ident = true;
         }
 
         break;
+    }
     case SV_SCROLL_DETECT_ITEM:
         if (detect_objects_normal(this->player_ptr, DETECT_RAD_DEFAULT)) {
             this->ident = true;
@@ -259,12 +263,16 @@ bool ScrollReadExecutor::read()
         }
 
         break;
-    case SV_SCROLL_DETECT_DOOR:
-        if (detect_doors(this->player_ptr, DETECT_RAD_DEFAULT) || detect_stairs(this->player_ptr, DETECT_RAD_DEFAULT)) {
+    case SV_SCROLL_DETECT_DOOR: {
+        bool detected_doors = detect_doors(this->player_ptr, DETECT_RAD_DEFAULT);
+        bool detected_stairs = detect_stairs(this->player_ptr, DETECT_RAD_DEFAULT);
+
+        if (detected_doors || detected_stairs) {
             this->ident = true;
         }
 
         break;
+    }
     case SV_SCROLL_DETECT_INVIS:
         if (detect_monsters_invis(this->player_ptr, DETECT_RAD_DEFAULT)) {
             this->ident = true;


### PR DESCRIPTION
Hello!

The previous implementation seemed to short circuit on the first condition of the `if` statement, causing the part after the `or` operator to be ignored. This resulted in `Scrolls of Door/Stair Location` only showing doors, and `Scrolls of Treasure Detection` only showing buried treasure.

Doors and stairs, as well as buried treasure and treasure, should properly show now.

I'm not familiar with C++, so there are probably many better ways to fix these :)