### PR TITLE
[Feature] MonsterMessageをMonraceDefinitionから分離

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -649,6 +649,7 @@
     <ClCompile Include="..\..\src\system\monster-entity.cpp" />
     <ClCompile Include="..\..\src\system\item-entity.cpp" />
     <ClCompile Include="..\..\src\system\monrace\monrace-definition.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-message.cpp" />
     <ClCompile Include="..\..\src\system\player-type-definition.cpp" />
     <ClCompile Include="..\..\src\system\services\baseitem-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\terrain\terrain-definition.cpp" />
@@ -1656,6 +1657,7 @@
     <ClInclude Include="..\..\src\system\building-type-definition.h" />
     <ClInclude Include="..\..\src\game-option\game-option-page.h" />
     <ClInclude Include="..\..\src\system\monrace\monrace-definition.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-message.h" />
     <ClInclude Include="..\..\src\system\item-entity.h" />
     <ClInclude Include="..\..\src\object-enchant\old-ego-extra-values.h" />
     <ClInclude Include="..\..\src\object-enchant\special-object-flags.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2514,6 +2514,9 @@
     <ClCompile Include="..\..\src\system\monrace\monrace-definition.cpp">
       <Filter>system\monrace</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-message.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\system\floor\floor-info.cpp">
       <Filter>system\floor</Filter>
     </ClCompile>
@@ -5488,6 +5491,9 @@
       <Filter>system\monrace</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\monrace\monrace-definition.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-message.h">
       <Filter>system\monrace</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\floor\floor-info.h">

--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -88626,11 +88626,27 @@
           }
         },
         {
+          "action": "WALK_MIDDLERANGE",
+          "chance": 10,
+          "message": {
+            "ja": "電話だ。「わたしメリーさん。今、宿屋の前に居るの。」",
+            "en": "You get a call. 'I'm Mary. Now I'm in front of the inn.'"
+          }
+        },
+        {
           "action": "WALK_LONGRANGE",
           "chance": 20,
           "message": {
             "ja": "電話だ。「わたしメリーさん。今、ゴミ捨て場に居るの。」",
             "en": "You get a call. 'I'm Mary. Now I'm at garbage dump.'"
+          }
+        },
+        {
+          "action": "WALK_LONGRANGE",
+          "chance": 20,
+          "message": {
+            "ja": "電話だ。「わたしメリーさん。今、街の入口に居るの。」",
+            "en": "You get a call. 'I'm Mary. Now I'm at the entrance to the town.'"
           }
         }
       ]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1292,6 +1292,7 @@ hengband_SOURCES = \
 	system/monrace/monrace-allocation.cpp system/monrace/monrace-allocation.h \
 	system/monrace/monrace-definition.cpp system/monrace/monrace-definition.h \
 	system/monrace/monrace-list.cpp system/monrace/monrace-list.h \
+	system/monrace/monrace-message.cpp system/monrace/monrace-message.h \
 	\
 	system/services/baseitem-monrace-service.cpp system/services/baseitem-monrace-service.h \
 	system/services/dungeon-service.cpp system/services/dungeon-service.h \

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -9,6 +9,7 @@
 #include "player-ability/player-ability-types.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-message.h"
 #include "term/gameterm.h"
 #include "util/enum-converter.h"
 #include "util/string-processor.h"
@@ -444,7 +445,7 @@ static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinitio
             return err;
         }
 
-        monrace.set_message(action->second, chance, str);
+        MonraceMessageList::get_instance().emplace((int)monrace.idx, action->second, chance, str);
     }
     return PARSE_ERROR_NONE;
 }

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -572,25 +572,22 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
     if (player_ptr->skill_srh > randint1(100)) {
         if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT / 2)) {
             const auto message = monrace.get_message(MonsterMessageType::WALK_CLOSERANGE);
-            const auto message_chance = monrace.get_message_chance(MonsterMessageType::WALK_CLOSERANGE);
-            if (message && message_chance) {
-                process_sound(player_ptr, message.value(), message_chance.value());
+            if (message) {
+                process_sound(player_ptr, message.value().get_message(), message.value().get_message_chance());
                 return;
             }
         }
         if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT)) {
             const auto message = monrace.get_message(MonsterMessageType::WALK_MIDDLERANGE);
-            const auto message_chance = monrace.get_message_chance(MonsterMessageType::WALK_MIDDLERANGE);
-            if (message && message_chance) {
-                process_sound(player_ptr, message.value(), message_chance.value());
+            if (message) {
+                process_sound(player_ptr, message.value().get_message(), message.value().get_message_chance());
                 return;
             }
         }
         if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT * 2)) {
             const auto message = monrace.get_message(MonsterMessageType::WALK_LONGRANGE);
-            const auto message_chance = monrace.get_message_chance(MonsterMessageType::WALK_LONGRANGE);
-            if (message && message_chance) {
-                process_sound(player_ptr, message.value(), message_chance.value());
+            if (message) {
+                process_sound(player_ptr, message.value().get_message(), message.value().get_message_chance());
                 return;
             }
         }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -774,7 +774,7 @@ bool process_stalking(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if (see_monster(player_ptr, m_idx)) {
         const auto message_stalker = monrace.get_message(MonsterMessageType::MESSAGE_STALKER);
         if (message_stalker) {
-            msg_print(message_stalker.value());
+            msg_print(message_stalker.value().get_message());
         } else {
             msg_format(_("%s^があなたの傍に忍び寄った。", "%s^ crept up beside you."), m_name.data());
         }

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -8,6 +8,7 @@
 #include "system/enums/grid-flow.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-message.h"
 #include "system/system-variables.h"
 #include "util/enum-converter.h"
 #include "util/string-processor.h"
@@ -33,12 +34,6 @@ static int count_lore_mflag_group(const EnumClassFlagGroup<T> &flags, const Enum
 DropArtifact::DropArtifact(FixedArtifactId fa_id, int chance)
     : fa_id(fa_id)
     , chance(chance)
-{
-}
-
-MonsterMessage::MonsterMessage(int chance, std::string message)
-    : chance(chance)
-    , message(message)
 {
 }
 
@@ -337,20 +332,12 @@ bool MonraceDefinition::has_reinforce() const
     return it != end;
 }
 
-const std::optional<std::string> MonraceDefinition::get_message(const MonsterMessageType message_type) const
+const std::optional<MonsterMessage> MonraceDefinition::get_message(const MonsterMessageType message_type) const
 {
-    const auto &message = this->messages.find(message_type);
-    if (message != this->messages.end()) {
-        return message->second.message;
-    }
-    return std::nullopt;
-}
+    auto message = MonraceMessageList::get_instance().get_message((int)this->idx, message_type);
 
-const std::optional<int> MonraceDefinition::get_message_chance(const MonsterMessageType message_type) const
-{
-    const auto &message = this->messages.find(message_type);
-    if (message != this->messages.end()) {
-        return message->second.chance;
+    if (message) {
+        return message;
     }
     return std::nullopt;
 }
@@ -796,11 +783,6 @@ void MonraceDefinition::make_lore_treasure(int num_item, int num_gold)
     if (this->drop_flags.has(MonsterDropType::DROP_GREAT)) {
         this->r_drop_flags.set(MonsterDropType::DROP_GREAT);
     }
-}
-
-void MonraceDefinition::set_message(MonsterMessageType message_type, int chance, std::string message)
-{
-    this->messages.insert(std::make_pair(message_type, MonsterMessage(chance, message)));
 }
 
 void MonraceDefinition::emplace_drop_artifact(FixedArtifactId fa_id, int chance)

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "locale/localized-string.h"
+#include "monrace-message.h"
 #include "monster-race/monster-aura-types.h"
 #include "monster-race/race-ability-flags.h"
 #include "monster-race/race-behavior-flags.h"
@@ -45,13 +46,6 @@ public:
     RaceBlowMethodType method{};
     RaceBlowEffectType effect{};
     Dice damage_dice;
-};
-
-class MonsterMessage {
-public:
-    MonsterMessage(int chance, std::string message);
-    int chance;
-    std::string message;
 };
 
 class MonraceDefinition;
@@ -167,8 +161,7 @@ public:
     int calc_capture_value() const;
     std::string build_eldritch_horror_message(std::string_view description) const;
     bool has_reinforce() const;
-    const std::optional<std::string> get_message(const MonsterMessageType message_type) const;
-    const std::optional<int> get_message_chance(const MonsterMessageType message_type) const;
+    const std::optional<MonsterMessage> get_message(const MonsterMessageType message_type) const;
     const std::vector<DropArtifact> &get_drop_artifacts() const;
     const std::vector<Reinforce> &get_reinforces() const;
     bool can_generate() const;
@@ -237,7 +230,6 @@ public:
     void increment_tkills();
 
 private:
-    std::unordered_map<MonsterMessageType, MonsterMessage> messages; //!< メッセージリスト
     std::vector<DropArtifact> drop_artifacts; //!< 特定アーティファクトドロップリスト
     std::vector<Reinforce> reinforces; //!< 指定護衛リスト
     MonsterSex sex{}; //!< 性別 / Sex

--- a/src/system/monrace/monrace-message.cpp
+++ b/src/system/monrace/monrace-message.cpp
@@ -1,0 +1,84 @@
+#include "system/monrace/monrace-message.h"
+#include "term/z-rand.h"
+#include <optional>
+#include <vector>
+
+MonsterMessage::MonsterMessage(int chance, std::string message)
+    : chance(chance)
+    , message(message)
+{
+}
+
+int MonsterMessage::get_message_chance() const
+{
+    return this->chance;
+}
+
+const std::string &MonsterMessage::get_message() const
+{
+    return this->message;
+}
+
+void MonsterMessageList::emplace(MonsterMessage message)
+{
+    this->messages.emplace_back(std::move(message));
+}
+
+const std::optional<MonsterMessage> MonsterMessageList::get_message() const
+{
+    if (this->messages.empty()) {
+        return std::nullopt;
+    }
+
+    const auto size = this->messages.size();
+    return this->messages[randint1(size) - 1];
+}
+
+void MonraceMessage::emplace(const MonsterMessageType message_type, const int chance, const std::string &message_str)
+{
+    const auto &message = this->messages.find(message_type);
+    if (message == this->messages.end()) {
+        auto list = MonsterMessageList();
+        list.emplace(MonsterMessage(chance, message_str));
+        this->messages.emplace(message_type, list);
+        return;
+    }
+    message->second.emplace(MonsterMessage(chance, message_str));
+}
+
+const std::optional<MonsterMessage> MonraceMessage::get_message(MonsterMessageType message_type) const
+{
+    const auto &message = this->messages.find(message_type);
+    if (message == this->messages.end()) {
+        return std::nullopt;
+    }
+    return message->second.get_message();
+}
+
+MonraceMessageList MonraceMessageList::instance{};
+
+MonraceMessageList &MonraceMessageList::get_instance()
+{
+    return instance;
+}
+
+void MonraceMessageList::emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, const std::string &message_str)
+{
+    const auto &message = this->messages.find(monrace_id);
+    if (message == this->messages.end()) {
+        auto monrace_message = MonraceMessage();
+        monrace_message.emplace(message_type, chance, message_str);
+        this->messages.emplace(monrace_id, monrace_message);
+        return;
+    }
+    message->second.emplace(message_type, chance, message_str);
+}
+
+const std::optional<MonsterMessage> MonraceMessageList::get_message(const int monrace_id, const MonsterMessageType message_type) const
+{
+    auto message = this->messages.find(monrace_id);
+    if (message == this->messages.end()) {
+        return std::nullopt;
+    }
+    return message->second.get_message(message_type);
+}

--- a/src/system/monrace/monrace-message.h
+++ b/src/system/monrace/monrace-message.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "monster-race/race-speak-flags.h"
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+class MonsterMessage {
+public:
+    MonsterMessage(int chance, std::string message);
+    int get_message_chance() const;
+    const std::string &get_message() const;
+
+private:
+    int chance;
+    std::string message;
+};
+
+class MonsterMessageList {
+public:
+    const std::optional<MonsterMessage> get_message() const;
+    void emplace(MonsterMessage message);
+
+private:
+    std::vector<MonsterMessage> messages;
+};
+
+class MonraceMessage {
+public:
+    const std::optional<MonsterMessage> get_message(MonsterMessageType message_type) const;
+    void emplace(const MonsterMessageType message_type, const int chance, const std::string &message_str);
+
+private:
+    std::map<MonsterMessageType, MonsterMessageList> messages;
+};
+
+class MonraceMessageList {
+public:
+    MonraceMessageList(const MonraceMessageList &) = delete;
+    MonraceMessageList(MonraceMessageList &&) = delete;
+    MonraceMessageList &operator=(const MonraceMessageList &) = delete;
+    MonraceMessageList &operator=(MonraceMessageList &&) = delete;
+    ~MonraceMessageList() = default;
+
+    static MonraceMessageList &get_instance();
+    const std::optional<MonsterMessage> get_message(const int monrace_id, const MonsterMessageType message_type) const;
+    void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, const std::string &message_str);
+
+private:
+    MonraceMessageList() = default;
+    static MonraceMessageList instance;
+
+    std::map<int, MonraceMessage> messages;
+};


### PR DESCRIPTION
MonraceDefinitionからメッセージ取得処理を分離してMonraceMessageListを作成した。
シングルトンにてメッセージを管理する。
また、同一MonsterMessageTypeに対して複数メッセージを設定可能とした。
取得の度にランダムに一つ設定されたものを提示する。

## gemini code assist
Please write all summary and review comments in Japanese.