### PR TITLE
[Refactor] monrace-message.cpp/h

### DIFF
--- a/src/system/monrace/monrace-message.h
+++ b/src/system/monrace/monrace-message.h
@@ -3,12 +3,13 @@
 #include "monster-race/race-speak-flags.h"
 #include <map>
 #include <string>
+#include <string_view>
 #include <tl/optional.hpp>
 #include <vector>
 
 class MonsterMessage {
 public:
-    MonsterMessage(int chance, std::string message);
+    MonsterMessage(int chance, std::string_view message);
     int get_message_chance() const;
     const std::string &get_message() const;
 
@@ -20,7 +21,7 @@ private:
 class MonsterMessageList {
 public:
     tl::optional<const MonsterMessage &> get_message() const;
-    void emplace(MonsterMessage message);
+    void emplace(const int chance, std::string_view message_str);
 
 private:
     std::vector<MonsterMessage> messages;
@@ -29,7 +30,7 @@ private:
 class MonraceMessage {
 public:
     tl::optional<const MonsterMessage &> get_message(MonsterMessageType message_type) const;
-    void emplace(const MonsterMessageType message_type, const int chance, const std::string &message_str);
+    void emplace(const MonsterMessageType message_type, const int chance, std::string_view message_str);
 
 private:
     std::map<MonsterMessageType, MonsterMessageList> messages;
@@ -45,7 +46,7 @@ public:
 
     static MonraceMessageList &get_instance();
     tl::optional<const MonsterMessage &> get_message(const int monrace_id, const MonsterMessageType message_type) const;
-    void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, const std::string &message_str);
+    void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, std::string_view message_str);
 
 private:
     MonraceMessageList() = default;


### PR DESCRIPTION
- 文字列を受け取る引数の型を std::string_view に変更
- emplaceを真にemplaceするように修正
- mapのキーが見つからない場合にデフォルトコンストラクタでオブジェクトをつくる処理を operator[] を使用することでシンプルにする。

## gemini code assist
Please write all summary and review comments in Japanese.