### PR TITLE
[Refactor] モンスターの反射時メッセージを外部読込に変更する

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -55897,7 +55897,17 @@
       "flavor": {
         "ja": "石仮面の力で不死の吸血鬼となったディオは冒険者を餌としか見ていない。『ザ・ワールド』に気をつけろ！「奴のスタンドの正体は分からないが、至近距離でしか使えないことは確かだッ」",
         "en": "Dio, who became an immortal vampire with the help of a stone mask, looks only at the adventurer.  Watch out for The World, Dio's stand or visual manifestation of his life energy:  \"I don't know what his stand is, but it is certain that it can only be used at close range.\""
-      }
+      },
+      "message": [
+        {
+          "action": "MESSAGE_REFLECT",
+          "chance": 1,
+          "message": {
+            "ja": "ディオ・ブランドーは指一本で攻撃を弾き返した！",
+            "en": "Dio Brando deflected the attack with just one finger!"
+          }
+        }
+      ]
     },
     {
       "id": 879,
@@ -59847,7 +59857,17 @@
       "flavor": {
         "ja": "一子相伝とされる北斗神拳の伝承者だ。力が全てを支配すると思われた時代にあって愛に生き、愛のために戦っている。",
         "en": "He is the rightful master of the martial art, Hokuto Shinken.  At a time when power seems to be everything, he lives in love and fights for love."
-      }
+      },
+      "message": [
+        {
+          "action": "MESSAGE_REFLECT",
+          "chance": 1,
+          "message": {
+            "ja": "「北斗神拳奥義・二指真空把！」",
+            "en": "The twofingergrasp of nil space!"
+          }
+        }
+      ]
     },
     {
       "id": 937,
@@ -65056,7 +65076,17 @@
       "flavor": {
         "ja": "ラオウは北斗神拳伝承者ケンシロウの義兄であり北斗神拳の使い手である。激動の闇の時代に、己の信念で新たな時代を築こうとした。",
         "en": "Raou is the eldest of four honorary brothers, another being Kenshirou, who were trained by the master of Hokuto Shinken, a martial art.  Headstrong, Raou tries to forge a new order through conquest in a turbulent dark era."
-      }
+      },
+      "message": [
+        {
+          "action": "MESSAGE_REFLECT",
+          "chance": 1,
+          "message": {
+            "ja": "「北斗神拳奥義・二指真空把！」",
+            "en": "The twofingergrasp of nil space!"
+          }
+        }
+      ]
     },
     //#
     //# ジュリアンのやつのコピー。名前？

--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -8314,6 +8314,18 @@
                             "crept up beside you."
                         ]
                     }
+                },
+                {
+                    "action": "MESSAGE_REFLECT",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "攻撃は跳ね返った！"
+                        ],
+                        "en": [
+                            "The attack bounces!"
+                        ]
+                    }
                 }
             ]
         }

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -717,7 +717,8 @@
                                         "WALK_CLOSERANGE",
                                         "WALK_MIDDLERANGE",
                                         "WALK_LONGRANGE",
-                                        "MESSAGE_STALKER"
+                                        "MESSAGE_STALKER",
+                                        "MESSAGE_REFLECT"
                                     ]
                                 },
                                 "chance": {

--- a/schema/MonsterMessages.schema.json
+++ b/schema/MonsterMessages.schema.json
@@ -54,7 +54,8 @@
                                     "WALK_CLOSERANGE",
                                     "WALK_MIDDLERANGE",
                                     "WALK_LONGRANGE",
-                                    "MESSAGE_STALKER"
+                                    "MESSAGE_STALKER",
+                                    "MESSAGE_REFLECT"
                                 ]
                             },
                             "chance": {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -290,12 +290,11 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
 
                     if (is_seen(player_ptr, monster)) {
                         sound(SoundKind::REFLECT);
-                        if ((monster.r_idx == MonraceId::KENSHIROU) || (monster.r_idx == MonraceId::RAOU)) {
-                            msg_print(_("「北斗神拳奥義・二指真空把！」", "The attack bounces!"));
-                        } else if (monster.r_idx == MonraceId::DIO) {
-                            msg_print(_("ディオ・ブランドーは指一本で攻撃を弾き返した！", "The attack bounces!"));
-                        } else {
-                            msg_print(_("攻撃は跳ね返った！", "The attack bounces!"));
+                        const auto reflect_message = monrace.get_message(MonsterMessageType::MESSAGE_REFLECT);
+                        if (reflect_message) {
+                            if (one_in_(reflect_message->get_message_chance())) {
+                                msg_print(reflect_message->get_message());
+                            }
                         }
                     } else if (!is_monster(src_idx)) {
                         sound(SoundKind::REFLECT);

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -419,6 +419,7 @@ const std::unordered_map<std::string_view, MonsterMessageType> r_info_message_fl
     { "WALK_MIDDLERANGE", MonsterMessageType::WALK_MIDDLERANGE },
     { "WALK_LONGRANGE", MonsterMessageType::WALK_LONGRANGE },
     { "MESSAGE_STALKER", MonsterMessageType::MESSAGE_STALKER },
+    { "MESSAGE_REFLECT", MonsterMessageType::MESSAGE_REFLECT },
 };
 
 const std::unordered_map<std::string_view, MonsterBrightnessType> r_info_brightness_flags = {

--- a/src/monster-race/race-speak-flags.h
+++ b/src/monster-race/race-speak-flags.h
@@ -21,5 +21,6 @@ enum class MonsterMessageType {
     WALK_MIDDLERANGE = 7,
     WALK_LONGRANGE = 8,
     MESSAGE_STALKER = 9,
+    MESSAGE_REFLECT = 10,
     MAX
 };


### PR DESCRIPTION
モンスターが攻撃を反射したときのメッセージを外部読込可能とする。
既存の動作は変更しない。

## gemini code assist
Please write all summary and review comments in Japanese.