### PR TITLE
[Feature] `str_upcase_first()` の追加

### DIFF
--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -36,6 +36,7 @@
 #include "timed-effect/timed-effects.h"
 #include "tracking/health-bar-tracker.h"
 #include "tracking/lore-tracker.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <string>
@@ -247,7 +248,7 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
 
     const auto death_message = r_ref.get_message(MonsterMessageType::SPEAK_DEATH);
     if (death_message) {
-        msg_format("%s^ %s", m_name.data(), death_message->data());
+        msg_print("{} {}", str_upcase_first(m_name), *death_message);
     }
 
 #ifdef WORLD_SCORE

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -68,6 +68,7 @@
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
 #include "tracking/lore-tracker.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -774,7 +775,7 @@ bool process_stalking(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if (see_monster(player_ptr, m_idx)) {
         const auto message_stalker = monrace.get_message(MonsterMessageType::MESSAGE_STALKER);
         if (message_stalker) {
-            msg_format(_("%s^%s", "%s^ %s"), m_name.data(), message_stalker->data());
+            msg_print(_("{}{}", "{} {}"), str_upcase_first(m_name), *message_stalker);
         }
     }
 

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -524,6 +524,28 @@ std::string str_tolower(std::string_view str)
 }
 
 /*!
+ * @brief 文字列の最初の文字を大文字に変換する
+ *
+ * @param str 変換元の文字列
+ * @return 変換後の文字列
+ */
+std::string str_upcase_first(std::string_view str)
+{
+    if (str.empty()) {
+        return {};
+    }
+
+    std::string result_str(str);
+
+    const auto first_char = static_cast<unsigned char>(result_str[0]);
+    if (isalpha(first_char)) {
+        result_str[0] = static_cast<char>(toupper(first_char));
+    }
+
+    return result_str;
+}
+
+/*!
  * @brief 文字列に含まれるすべてのマルチバイト文字のインデックスを取得する
  *
  * @param str 文字列

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -28,6 +28,7 @@ std::string str_substr(std::string &&str, size_t pos = 0, size_t n = std::string
 std::string str_substr(const char *str, size_t pos = 0, size_t n = std::string_view::npos);
 std::string str_toupper(std::string_view str);
 std::string str_tolower(std::string_view str);
+std::string str_upcase_first(std::string_view str);
 std::set<int> str_find_all_multibyte_chars(std::string_view str);
 char hexify_upper(uint8_t value);
 char hexify_lower(uint8_t value);


### PR DESCRIPTION
Resolves #5130 

使用例として MonraceDefinition::get_message() の結果をmsg_formatで表示している処理をmsg_printでの置き換えるときに str_upcase_first を使用するコミットを追加。

## gemini code assist
Please write all summary and review comments in Japanese.