### PR TITLE
[Fix] 忍び寄る人形『メリー』のフラグ修正

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -88614,7 +88614,6 @@
         "UNIQUE",
         "FORCE_MAXHP",
         "WILD_TOWN",
-        "SPEAK_BATTLE",
         "ONLY_GOLD",
         "DROP_4D2",
         "EMPTY_MIND",


### PR DESCRIPTION
メッセージに関する仕様を変更した影響により『メリー』が戦闘時にデフォルトメッセージを発するようになった。 本来の意図とは異なるため、SPEAKフラグを削除する。

## gemini code assist
Please write all summary and review comments in Japanese.