### PR TITLE
[Feature] モンスターメッセージに名前を使用するオプションの追加

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -50479,6 +50479,7 @@
         {
           "action": "WALK_CLOSERANGE",
           "chance": 20,
+          "use_name" : false,
           "message": {
             "ja": "近くで重厚な足音が聞こえた。",
             "en": "You hear heavy steps nearby."
@@ -50487,6 +50488,7 @@
         {
           "action": "WALK_MIDDLERANGE",
           "chance": 20,
+          "use_name" : false,
           "message": {
             "ja": "重厚な足音が聞こえた。",
             "en": "You hear heavy steps."
@@ -50495,6 +50497,7 @@
         {
           "action": "WALK_LONGRANGE",
           "chance": 40,
+          "use_name" : false,
           "message": {
             "ja": "遠くで重厚な足音が聞こえた。",
             "en": "You hear heavy steps in the distance."
@@ -55903,8 +55906,8 @@
           "action": "MESSAGE_REFLECT",
           "chance": 1,
           "message": {
-            "ja": "ディオ・ブランドーは指一本で攻撃を弾き返した！",
-            "en": "Dio Brando deflected the attack with just one finger!"
+            "ja": "は指一本で攻撃を弾き返した！",
+            "en": "deflected the attack with just one finger!"
           }
         }
       ]
@@ -59862,6 +59865,7 @@
         {
           "action": "MESSAGE_REFLECT",
           "chance": 1,
+          "use_name" : false,
           "message": {
             "ja": "「北斗神拳奥義・二指真空把！」",
             "en": "The twofingergrasp of nil space!"
@@ -65081,6 +65085,7 @@
         {
           "action": "MESSAGE_REFLECT",
           "chance": 1,
+          "use_name" : false,
           "message": {
             "ja": "「北斗神拳奥義・二指真空把！」",
             "en": "The twofingergrasp of nil space!"
@@ -88633,14 +88638,16 @@
         {
           "action": "MESSAGE_STALKER",
           "chance": 1,
+          "use_name" : false,
           "message": {
-            "ja": "から電話だ。「わたしメリーさん。今、あなたの後ろに居るの。」",
-            "en": "is calling you. 'I'm Mary. Now I'm behind you.'"
+            "ja": "電話だ。「わたしメリーさん。今、あなたの後ろに居るの。」",
+            "en": "You get a call. 'I'm Mary. Now I'm behind you.'"
           }
         },
         {
           "action": "WALK_CLOSERANGE",
           "chance": 10,
+          "use_name" : false,
           "message": {
             "ja": "電話だ。「わたしメリーさん。今、あなたの家の前に居るの。」",
             "en": "You get a call. 'I'm Mary. Now I'm in front of your house.'"
@@ -88649,6 +88656,7 @@
         {
           "action": "WALK_MIDDLERANGE",
           "chance": 10,
+          "use_name" : false,
           "message": {
             "ja": "電話だ。「わたしメリーさん。今、雑貨屋の前に居るの。」",
             "en": "You get a call. 'I'm Mary. Now I'm in front of the general store.'"
@@ -88657,6 +88665,7 @@
         {
           "action": "WALK_MIDDLERANGE",
           "chance": 10,
+          "use_name" : false,
           "message": {
             "ja": "電話だ。「わたしメリーさん。今、宿屋の前に居るの。」",
             "en": "You get a call. 'I'm Mary. Now I'm in front of the inn.'"
@@ -88665,6 +88674,7 @@
         {
           "action": "WALK_LONGRANGE",
           "chance": 20,
+          "use_name" : false,
           "message": {
             "ja": "電話だ。「わたしメリーさん。今、ゴミ捨て場に居るの。」",
             "en": "You get a call. 'I'm Mary. Now I'm at garbage dump.'"
@@ -88673,6 +88683,7 @@
         {
           "action": "WALK_LONGRANGE",
           "chance": 20,
+          "use_name" : false,
           "message": {
             "ja": "電話だ。「わたしメリーさん。今、街の入口に居るの。」",
             "en": "You get a call. 'I'm Mary. Now I'm at the entrance to the town.'"

--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -8318,6 +8318,7 @@
                 {
                     "action": "MESSAGE_REFLECT",
                     "chance": 1,
+                    "use_name": false,
                     "message": {
                         "ja": [
                             "攻撃は跳ね返った！"

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -727,6 +727,10 @@
                                     "minimum": 1,
                                     "maximum": 100
                                 },
+                                "use_name": {
+                                    "type": "boolean",
+                                    "description": "メッセージの先頭にモンスター名を表示する。"
+                                },
                                 "message": {
                                     "type": "object",
                                     "description": "メッセージ",

--- a/schema/MonsterMessages.schema.json
+++ b/schema/MonsterMessages.schema.json
@@ -64,6 +64,10 @@
                                 "minimum": 1,
                                 "maximum": 100
                             },
+                            "use_name": {
+                                "type": "boolean",
+                                "description": "メッセージの先頭にモンスター名を表示する。"
+                            },
                             "message": {
                                 "type": "object",
                                 "description": "メッセージ",

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -289,8 +289,9 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                     }
 
                     if (is_seen(player_ptr, monster)) {
+                        const auto m_name = monster.ml ? monster_desc(player_ptr, monster, 0) : std::string(_("それ", "It"));
                         sound(SoundKind::REFLECT);
-                        const auto reflect_message = monrace.get_message(MonsterMessageType::MESSAGE_REFLECT);
+                        const auto reflect_message = monrace.get_message(m_name, MonsterMessageType::MESSAGE_REFLECT);
                         if (reflect_message) {
                             msg_print(*reflect_message);
                         }

--- a/src/info-reader/message-reader.cpp
+++ b/src/info-reader/message-reader.cpp
@@ -98,6 +98,15 @@ static errr set_mon_message(const nlohmann::json &group_data)
             return err;
         }
 
+        bool use_name = true;
+        const auto use_name_iter = message.value().find("use_name");
+        if (use_name_iter != message.value().end()) {
+            const auto &use_name_data = use_name_iter.value();
+            if (auto err = info_set_bool(use_name_data, use_name, false)) {
+                return err;
+            }
+        }
+
         const auto language_iter = message.value().find("message");
         if (language_iter == message.value().end() || !language_iter->is_object()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -142,10 +151,10 @@ static errr set_mon_message(const nlohmann::json &group_data)
 #endif
             if (has_id_list) {
                 for (auto id : id_list) {
-                    MonraceMessageList::get_instance().emplace(id, action->second, chance, str);
+                    MonraceMessageList::get_instance().emplace(id, action->second, chance, use_name, str);
                 }
             } else {
-                MonraceMessageList::get_instance().emplace_default(action->second, chance, str);
+                MonraceMessageList::get_instance().emplace_default(action->second, chance, use_name, str);
             }
         }
     }

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -440,12 +440,21 @@ static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinitio
             return err;
         }
 
+        bool use_name = true;
+        const auto use_name_iter = message.value().find("use_name");
+        if (use_name_iter != message.value().end()) {
+            const auto &use_name_data = use_name_iter.value();
+            if (auto err = info_set_bool(use_name_data, use_name, false)) {
+                return err;
+            }
+        }
+
         std::string str;
         if (auto err = info_set_string(message.value()["message"], str, false)) {
             return err;
         }
 
-        MonraceMessageList::get_instance().emplace((int)monrace.idx, action->second, chance, str);
+        MonraceMessageList::get_instance().emplace((int)monrace.idx, action->second, chance, use_name, str);
     }
     return PARSE_ERROR_NONE;
 }

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -38,7 +38,6 @@
 #include "system/terrain/terrain-definition.h"
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
-#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 static bool check_hp_for_terrain_destruction(const TerrainType &terrain, const MonsterEntity &monster)
@@ -566,23 +565,24 @@ void process_sound(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if (monster.ml || player_ptr->skill_srh < randint1(100)) {
         return;
     }
+    const auto m_name = std::string(_("それ", "It"));
 
     if (monster.cdis <= MAX_PLAYER_SIGHT / 2) {
-        const auto message = monrace.get_message(MonsterMessageType::WALK_CLOSERANGE);
+        const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_CLOSERANGE);
         if (message) {
             show_sound_message(player_ptr, *message);
         }
         return;
     }
     if (monster.cdis <= MAX_PLAYER_SIGHT) {
-        const auto message = monrace.get_message(MonsterMessageType::WALK_MIDDLERANGE);
+        const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_MIDDLERANGE);
         if (message) {
             show_sound_message(player_ptr, *message);
         }
         return;
     }
     if (monster.cdis <= MAX_PLAYER_SIGHT * 2) {
-        const auto message = monrace.get_message(MonsterMessageType::WALK_LONGRANGE);
+        const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_LONGRANGE);
         if (message) {
             show_sound_message(player_ptr, *message);
         }
@@ -620,8 +620,8 @@ void process_speak(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSIT
         return;
     }
 
-    const auto monster_message = monrace.get_message(*message_type);
+    const auto monster_message = monrace.get_message(m_name, *message_type);
     if (monster_message) {
-        msg_print(_("{}{}", "{} {}"), str_upcase_first(m_name), *monster_message);
+        msg_print(*monster_message);
     }
 }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -36,7 +36,6 @@
 #include "timed-effect/timed-effects.h"
 #include "tracking/health-bar-tracker.h"
 #include "tracking/lore-tracker.h"
-#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <string>
@@ -246,9 +245,9 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
         return;
     }
 
-    const auto death_message = r_ref.get_message(MonsterMessageType::SPEAK_DEATH);
+    const auto death_message = r_ref.get_message(m_name, MonsterMessageType::SPEAK_DEATH);
     if (death_message) {
-        msg_print("{} {}", str_upcase_first(m_name), *death_message);
+        msg_print(*death_message);
     }
 
 #ifdef WORLD_SCORE

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -68,7 +68,6 @@
 #include "system/redrawing-flags-updater.h"
 #include "target/projection-path-calculator.h"
 #include "tracking/lore-tracker.h"
-#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -774,9 +773,9 @@ bool process_stalking(PlayerType *player_ptr, MONSTER_IDX m_idx)
     disturb(player_ptr, true, true);
 
     if (see_monster(player_ptr, m_idx)) {
-        const auto message_stalker = monrace.get_message(MonsterMessageType::MESSAGE_STALKER);
+        const auto message_stalker = monrace.get_message(m_name, MonsterMessageType::MESSAGE_STALKER);
         if (message_stalker) {
-            msg_print(_("{}{}", "{} {}"), str_upcase_first(m_name), *message_stalker);
+            msg_print(*message_stalker);
         }
     }
 

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -332,9 +332,9 @@ bool MonraceDefinition::has_reinforce() const
     return it != end;
 }
 
-std::optional<std::string_view> MonraceDefinition::get_message(const MonsterMessageType message_type) const
+std::optional<std::string> MonraceDefinition::get_message(std::string_view monster_name, const MonsterMessageType message_type) const
 {
-    return MonraceMessageList::get_instance().get_message((int)this->idx, message_type);
+    return MonraceMessageList::get_instance().get_message((int)this->idx, monster_name, message_type);
 }
 
 const std::vector<DropArtifact> &MonraceDefinition::get_drop_artifacts() const

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -162,7 +162,7 @@ public:
     int calc_capture_value() const;
     std::string build_eldritch_horror_message(std::string_view description) const;
     bool has_reinforce() const;
-    std::optional<std::string_view> get_message(const MonsterMessageType message_type) const;
+    std::optional<std::string> get_message(std::string_view monster_name, const MonsterMessageType message_type) const;
     const std::vector<DropArtifact> &get_drop_artifacts() const;
     const std::vector<Reinforce> &get_reinforces() const;
     bool can_generate() const;

--- a/src/system/monrace/monrace-message.h
+++ b/src/system/monrace/monrace-message.h
@@ -5,22 +5,25 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 
 class MonsterMessage {
 public:
-    MonsterMessage(int chance, std::string_view message);
+    MonsterMessage(int chance, bool use_name, std::string_view message);
     std::optional<std::string_view> get_message() const;
+    bool start_with_monname() const;
 
 private:
     int chance;
+    bool use_name;
     std::string message;
 };
 
 class MonsterMessageList {
 public:
-    std::optional<std::string_view> get_message() const;
-    void emplace(const int chance, std::string_view message_str);
+    tl::optional<const MonsterMessage &> get_message_obj() const;
+    void emplace(const int chance, bool use_name, std::string_view message_str);
 
 private:
     std::vector<MonsterMessage> messages;
@@ -28,9 +31,9 @@ private:
 
 class MonraceMessage {
 public:
-    std::optional<std::string_view> get_message(MonsterMessageType message_type) const;
+    tl::optional<const MonsterMessage &> get_message_obj(MonsterMessageType message_type) const;
     bool has_message(MonsterMessageType message_type) const;
-    void emplace(const MonsterMessageType message_type, const int chance, std::string_view message_str);
+    void emplace(const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
 
 private:
     std::map<MonsterMessageType, MonsterMessageList> messages;
@@ -45,13 +48,14 @@ public:
     ~MonraceMessageList() = default;
 
     static MonraceMessageList &get_instance();
-    std::optional<std::string_view> get_message(const int monrace_id, const MonsterMessageType message_type) const;
-    void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, std::string_view message_str);
-    void emplace_default(const MonsterMessageType message_type, const int chance, std::string_view message_str);
+    std::optional<std::string> get_message(const int monrace_id, std::string_view monrace_name, const MonsterMessageType message_type);
+    void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
+    void emplace_default(const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
 
 private:
     MonraceMessageList() = default;
     static MonraceMessageList instance;
+    tl::optional<const MonsterMessage &> get_message_obj(const int monrace_id, const MonsterMessageType message_type) const;
 
     std::map<int, MonraceMessage> messages;
     MonraceMessage default_messages;


### PR DESCRIPTION
モンスターが発するメッセージには先頭にモンスター名を表記するものとしないものが混在している。
JSON設定ファイルにuse_nameを追加し、これを選択可能とする。
デフォルトはtrueとし、この場合use_nameは省略できる仕様とする。

## gemini code assist
Please write all summary and review comments in Japanese.