### PR TITLE
[Refactor] optional型を tl::optional に統一する

### DIFF
--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -80,19 +80,19 @@ int travel_flow_cost(PlayerType *player_ptr, const Pos2D &pos)
  * @param pos 隣接するマスの座標
  * @param current_cost 現在のマスのコスト
  * @param wall プレイヤーが壁の中にいるならばTRUE
- * @return 隣接するマスのコスト。移動不可ならばstd::nullopt
+ * @return 隣接するマスのコスト。移動不可ならばtl::nullopt
  */
-std::optional<int> travel_flow_aux(PlayerType *player_ptr, const Pos2D pos, int current_cost, bool wall)
+tl::optional<int> travel_flow_aux(PlayerType *player_ptr, const Pos2D pos, int current_cost, bool wall)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain();
     if (!floor.contains(pos)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (floor.is_underground() && !(grid.info & CAVE_KNOWN)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto from_wall = (current_cost / TRAVEL_UNABLE);
@@ -105,7 +105,7 @@ std::optional<int> travel_flow_aux(PlayerType *player_ptr, const Pos2D pos, int 
     auto add_cost = 1;
     if (is_wall || can_move) {
         if (!wall || !from_wall) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         add_cost += TRAVEL_UNABLE;
@@ -211,7 +211,7 @@ bool Travel::can_travel_to(const FloorType &floor, const Pos2D &pos)
     return !is_marked || (!is_wall && !is_door);
 }
 
-const std::optional<Pos2D> &Travel::get_goal() const
+const tl::optional<Pos2D> &Travel::get_goal() const
 {
     return this->pos_goal;
 }

--- a/src/action/travel-execution.h
+++ b/src/action/travel-execution.h
@@ -7,7 +7,7 @@
 #include "floor/floor-base-definitions.h"
 #include "floor/geometry.h"
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class TravelState {
     STOP, ///< トラベル停止中
@@ -29,7 +29,7 @@ public:
     static Travel &get_instance();
     static bool can_travel_to(const FloorType &floor, const Pos2D &pos);
 
-    const std::optional<Pos2D> &get_goal() const;
+    const tl::optional<Pos2D> &get_goal() const;
     void set_goal(PlayerType *player_ptr, const Pos2D &pos);
     void reset_goal();
     bool is_ongoing() const;
@@ -43,7 +43,7 @@ private:
     void update_flow(PlayerType *player_ptr);
     void forget_flow();
 
-    std::optional<Pos2D> pos_goal; /* Target position */
+    tl::optional<Pos2D> pos_goal; /* Target position */
     TravelState state = TravelState::STOP;
     Direction dir = Direction::none(); /* Running direction */
     std::array<std::array<int, MAX_WID>, MAX_HGT> costs{};

--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -21,9 +21,9 @@
 #include "system/monrace/monrace-definition.h"
 #include "system/player-type-definition.h"
 #include "util/string-processor.h"
-#include <optional>
 #include <sstream>
 #include <string>
+#include <tl/optional.hpp>
 
 #ifdef JP
 static char kanji_colon[] = "：";
@@ -243,7 +243,7 @@ bool autopick_new_entry(autopick_type *entry, std::string_view str_view, bool al
         }
     }
 
-    std::optional<int> previous_flag = std::nullopt;
+    tl::optional<int> previous_flag = tl::nullopt;
     if (MATCH_KEY2(KEY_ARTIFACT)) {
         entry->add(FLG_ARTIFACT);
         previous_flag = FLG_ARTIFACT;

--- a/src/birth/birth-select-realm.cpp
+++ b/src/birth/birth-select-realm.cpp
@@ -11,8 +11,8 @@
 #include "term/z-form.h"
 #include "util/int-char-converter.h"
 #include "view/display-util.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 constexpr auto TOTAL_REALM_NUM = std::ssize(MAGIC_REALM_RANGE) + std::ssize(TECHNIC_REALM_RANGE);
 
@@ -190,7 +190,7 @@ static bool get_a_realm(PlayerType *player_ptr, birth_realm_type *birth_realm_pt
  * @return 選択した魔法領域のID
  * @details 領域数が0 (戦士等)or 1 (観光客等)なら自動での値を返す
  */
-static std::optional<RealmType> select_realm(PlayerType *player_ptr, RealmType selecting_realm, RealmChoices choices)
+static tl::optional<RealmType> select_realm(PlayerType *player_ptr, RealmType selecting_realm, RealmChoices choices)
 {
     clear_from(10);
     if (choices.count() <= 1) {
@@ -205,7 +205,7 @@ static std::optional<RealmType> select_realm(PlayerType *player_ptr, RealmType s
     analyze_realms(player_ptr, selecting_realm, choices, &birth_realm);
     birth_realm.cur = format("%c%c %s", '*', birth_realm.p2, _("ランダム", "Random"));
     if (get_a_realm(player_ptr, &birth_realm)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     clear_from(10);
@@ -239,7 +239,7 @@ static bool check_realm_selection(PlayerType *player_ptr, int count)
     return false;
 }
 
-static std::optional<RealmType> process_choose_realm(PlayerType *player_ptr, RealmChoices choices)
+static tl::optional<RealmType> process_choose_realm(PlayerType *player_ptr, RealmChoices choices)
 {
     auto selecting_realm = RealmType::NONE;
     while (true) {

--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -97,14 +97,14 @@ static bool cast_blue_hand_doom(PlayerType *player_ptr, bmc_type *bmc_ptr)
     return true;
 }
 
-/* 効果が抵抗された場合、返される std::optional には値がありません。*/
-static std::optional<std::string> exe_blue_teleport_back(PlayerType *player_ptr, const Pos2D &pos)
+/* 効果が抵抗された場合、返される tl::optional には値がありません。*/
+static tl::optional<std::string> exe_blue_teleport_back(PlayerType *player_ptr, const Pos2D &pos)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
     const auto p_pos = player_ptr->get_position();
     if (!grid.has_monster() || !grid.has_los() || !projectable(floor, p_pos, p_pos, pos)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto &monster = floor.m_list[grid.m_idx];
@@ -120,7 +120,7 @@ static std::optional<std::string> exe_blue_teleport_back(PlayerType *player_ptr,
         }
 
         msg_format(_("%sには効果がなかった！", "%s is unaffected!"), m_name.data());
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (monrace.level <= randint1(100)) {
@@ -132,7 +132,7 @@ static std::optional<std::string> exe_blue_teleport_back(PlayerType *player_ptr,
     }
 
     msg_format(_("%sには耐性がある！", "%s resists!"), m_name.data());
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 static bool cast_blue_teleport_back(PlayerType *player_ptr)

--- a/src/blue-magic/learnt-power-getter.cpp
+++ b/src/blue-magic/learnt-power-getter.cpp
@@ -33,18 +33,18 @@
 #include "view/display-messages.h"
 #include <algorithm>
 #include <iterator>
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 /*!
  * @brief コマンド反復チェック
- * @return 反復可能な青魔法があればそれを返す。なければ std::nullopt を返す。
+ * @return 反復可能な青魔法があればそれを返す。なければ tl::nullopt を返す。
  */
-static std::optional<MonsterAbilityType> check_blue_magic_repeat()
+static tl::optional<MonsterAbilityType> check_blue_magic_repeat()
 {
     const auto code = repeat_pull();
     if (!code) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (auto spell = i2enum<MonsterAbilityType>(*code);
@@ -52,19 +52,19 @@ static std::optional<MonsterAbilityType> check_blue_magic_repeat()
         return spell;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!
  * @brief 青魔法のタイプをコマンドメニューにより選択する
  *
  * @return 選択した青魔法のタイプ
- * 選択をキャンセルした場合は std::nullopt
+ * 選択をキャンセルした場合は tl::nullopt
  */
-static std::optional<BlueMagicType> select_blue_magic_type_by_menu()
+static tl::optional<BlueMagicType> select_blue_magic_type_by_menu()
 {
     auto menu_line = 1;
-    std::optional<BlueMagicType> type;
+    tl::optional<BlueMagicType> type;
 
     screen_save();
 
@@ -82,7 +82,7 @@ static std::optional<BlueMagicType> select_blue_magic_type_by_menu()
         case 'z':
         case 'Z':
             screen_load();
-            return std::nullopt;
+            return tl::nullopt;
             break;
         case '2':
         case 'j':
@@ -115,16 +115,16 @@ static std::optional<BlueMagicType> select_blue_magic_type_by_menu()
  * @brief 青魔法のタイプを記号により選択する
  *
  * @return 選択した青魔法のタイプ
- * 選択をキャンセルした場合は std::nullopt
+ * 選択をキャンセルした場合は tl::nullopt
  */
-static std::optional<BlueMagicType> select_blue_magic_kind_by_symbol()
+static tl::optional<BlueMagicType> select_blue_magic_kind_by_symbol()
 {
     constexpr auto candidate_desc = _("[A]ボルト, [B]ボール, [C]ブレス, [D]召喚, [E]その他:",
         "[A] bolt, [B] ball, [C] breath, [D] summoning, [E] others:");
     while (true) {
         const auto command = input_command(candidate_desc, true);
         if (!command) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         switch (*command) {
@@ -148,7 +148,7 @@ static std::optional<BlueMagicType> select_blue_magic_kind_by_symbol()
         }
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!
@@ -157,16 +157,16 @@ static std::optional<BlueMagicType> select_blue_magic_kind_by_symbol()
  * @param bluemage_data 青魔道士の固有データへの参照
  * @param type 青魔法のタイプ
  * @return 指定したタイプの青魔法のリストを(覚えていないものも含め)返す
- * 但し、そのタイプの魔法を1つも覚えていない場合は std::nullopt を返す
+ * 但し、そのタイプの魔法を1つも覚えていない場合は tl::nullopt を返す
  */
-static std::optional<std::vector<MonsterAbilityType>> sweep_learnt_spells(const bluemage_data_type &bluemage_data, BlueMagicType type)
+static tl::optional<std::vector<MonsterAbilityType>> sweep_learnt_spells(const bluemage_data_type &bluemage_data, BlueMagicType type)
 {
     EnumClassFlagGroup<MonsterAbilityType> ability_flags;
     set_rf_masks(ability_flags, type);
 
     if (bluemage_data.learnt_blue_magics.has_none_of(ability_flags)) {
         msg_print(_("その種類の魔法は覚えていない！", "You don't know any spell of this type."));
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     std::vector<MonsterAbilityType> blue_magics;
@@ -354,16 +354,16 @@ static bool confirm_cast_blue_magic(MonsterAbilityType spell)
  *
  * @param bluemage_data 青魔道士の固有データへの参照
  * @param blue_magics 青魔法のリスト(覚えていないものも含まれているが、覚えていない物は候補に出ず選択できない)
- * @return 選択した青魔法。選択をキャンセルした場合は std::nullopt
+ * @return 選択した青魔法。選択をキャンセルした場合は tl::nullopt
  */
-static std::optional<MonsterAbilityType> select_learnt_spells_by_symbol(PlayerType *player_ptr, const bluemage_data_type &bluemage_data, std::vector<MonsterAbilityType> spells)
+static tl::optional<MonsterAbilityType> select_learnt_spells_by_symbol(PlayerType *player_ptr, const bluemage_data_type &bluemage_data, std::vector<MonsterAbilityType> spells)
 {
     constexpr auto fmt = _("(%c-%c, '*'で一覧, ESC) どの%sを唱えますか？", "(%c-%c, *=List, ESC=exit) Use which %s? ");
     const auto prompt = format(fmt, I2A(0), I2A(spells.size() - 1), _("魔法", "magic"));
 
     bool first_show_list = always_show_list;
     auto show_list = false;
-    std::optional<MonsterAbilityType> selected_spell;
+    tl::optional<MonsterAbilityType> selected_spell;
 
     while (!selected_spell) {
         auto choice = '\0';
@@ -416,16 +416,16 @@ static std::optional<MonsterAbilityType> select_learnt_spells_by_symbol(PlayerTy
  *
  * @param bluemage_data 青魔道士の固有データへの参照
  * @param blue_magics 青魔法のリスト(覚えていないものも含まれているが、覚えていない物は候補に出ず選択できない)
- * @return 選択した青魔法。選択をキャンセルした場合は std::nullopt
+ * @return 選択した青魔法。選択をキャンセルした場合は tl::nullopt
  */
-static std::optional<MonsterAbilityType> select_learnt_spells_by_menu(PlayerType *player_ptr, const bluemage_data_type &bluemage_data, std::vector<MonsterAbilityType> spells)
+static tl::optional<MonsterAbilityType> select_learnt_spells_by_menu(PlayerType *player_ptr, const bluemage_data_type &bluemage_data, std::vector<MonsterAbilityType> spells)
 {
     constexpr auto prompt = _("(ESC=中断) どの魔法を唱えますか？", "(ESC=exit) Use which magic? ");
 
     auto it = std::find_if(
         spells.begin(), spells.end(), [&bluemage_data](const auto &spell) { return bluemage_data.learnt_blue_magics.has(spell); });
     int menu_line = std::distance(spells.begin(), it) + 1;
-    std::optional<MonsterAbilityType> selected_spell;
+    tl::optional<MonsterAbilityType> selected_spell;
 
     screen_save();
 
@@ -477,11 +477,11 @@ static std::optional<MonsterAbilityType> select_learnt_spells_by_menu(PlayerType
  * when you run it. It's probably easy to fix but I haven't tried,\n
  * sorry.\n
  */
-std::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr)
+tl::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr)
 {
     auto bluemage_data = PlayerClass(player_ptr).get_specific_data<bluemage_data_type>();
     if (!bluemage_data) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (auto repeat_spell = check_blue_magic_repeat();
@@ -493,12 +493,12 @@ std::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr)
                     ? select_blue_magic_type_by_menu()
                     : select_blue_magic_kind_by_symbol();
     if (!type) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto spells = sweep_learnt_spells(*bluemage_data, *type);
     if (!spells || spells->empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto selected_spell = (use_menu)
@@ -509,7 +509,7 @@ std::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr)
     handle_stuff(player_ptr);
 
     if (!selected_spell) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     repeat_push(static_cast<COMMAND_CODE>(*selected_spell));

--- a/src/blue-magic/learnt-power-getter.h
+++ b/src/blue-magic/learnt-power-getter.h
@@ -6,10 +6,10 @@
 
 #include "system/angband.h"
 
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class MonsterAbilityType;
 class PlayerType;
 struct monster_power;
 int calculate_blue_magic_failure_probability(PlayerType *player_ptr, const monster_power &mp, int need_mana);
-std::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr);
+tl::optional<MonsterAbilityType> get_learned_power(PlayerType *player_ptr);

--- a/src/cmd-action/cmd-others.cpp
+++ b/src/cmd-action/cmd-others.cpp
@@ -144,7 +144,7 @@ static void accept_winner_message(PlayerType *player_ptr)
     }
 
     play_music(TERM_XTRA_MUSIC_BASIC, MUSIC_BASIC_WINNER);
-    std::optional<std::string> buf;
+    tl::optional<std::string> buf;
     while (true) {
         buf = input_string(_("*勝利*メッセージ: ", "*Winning* message: "), 1024);
         if (!buf) {

--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -1097,7 +1097,7 @@ bool do_cmd_cast(PlayerType *player_ptr)
             wild_magic(player_ptr, spell_id);
         } else if ((tval == ItemKindType::DEATH_BOOK) && (randint1(100) < spell_id)) {
             if ((sval == 3) && one_in_(2)) {
-                sanity_blast(player_ptr, std::nullopt, true);
+                sanity_blast(player_ptr, tl::nullopt, true);
             } else {
                 msg_print(_("痛い！", "It hurts!"));
                 take_hit(player_ptr, DAMAGE_LOSELIFE, Dice::roll(sval + 1, 6), _("暗黒魔法の逆流", "a miscast Death spell"));

--- a/src/cmd-action/cmd-travel.cpp
+++ b/src/cmd-action/cmd-travel.cpp
@@ -12,7 +12,7 @@
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 
-static std::optional<Pos2D> decide_travel_goal(PlayerType *player_ptr)
+static tl::optional<Pos2D> decide_travel_goal(PlayerType *player_ptr)
 {
     const auto &pos_current_goal = Travel::get_instance().get_goal();
     if (pos_current_goal && pos_current_goal != player_ptr->get_position() && input_check(_("トラベルを継続しますか？", "Do you continue to travel? "))) {

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -162,7 +162,7 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
         }
     }
 
-    TermCenteredOffsetSetter tcos(std::nullopt, std::nullopt);
+    TermCenteredOffsetSetter tcos(tl::nullopt, tl::nullopt);
 
     screen_save();
     while (quit == APE_QUIT) {

--- a/src/cmd-io/cmd-menu-content-table.cpp
+++ b/src/cmd-io/cmd-menu-content-table.cpp
@@ -4,7 +4,7 @@
 #include "util/int-char-converter.h"
 #include "world/world.h"
 
-SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, std::optional<PlayerClassType> class_condition, std::optional<bool> wild_mode)
+SpecialMenuContent::SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, tl::optional<PlayerClassType> class_condition, tl::optional<bool> wild_mode)
     : name(name)
     , window(window)
     , number(number)
@@ -20,18 +20,18 @@ bool SpecialMenuContent::matches_current_wild_mode() const
 }
 
 const std::vector<SpecialMenuContent> special_menu_info = {
-    SpecialMenuContent(_("超能力/特殊能力", "MindCraft/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MINDCRAFTER, std::nullopt),
-    SpecialMenuContent(_("ものまね/特殊能力", "Imitation/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::IMITATOR, std::nullopt),
-    SpecialMenuContent(_("歌/特殊能力", "Song/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BARD, std::nullopt),
-    SpecialMenuContent(_("必殺技/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SAMURAI, std::nullopt),
-    SpecialMenuContent(_("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::FORCETRAINER, std::nullopt),
-    SpecialMenuContent(_("技/特殊能力", "BrutalPower/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BERSERKER, std::nullopt),
-    SpecialMenuContent(_("技術/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SMITH, std::nullopt),
-    SpecialMenuContent(_("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MIRROR_MASTER, std::nullopt),
-    SpecialMenuContent(_("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::NINJA, std::nullopt),
-    SpecialMenuContent(_("広域マップ(<)", "Enter global map(<)"), 2, 6, SpecialMenuType::WILD, std::nullopt, false),
-    SpecialMenuContent(_("通常マップ(>)", "Enter local map(>)"), 2, 7, SpecialMenuType::WILD, std::nullopt, true),
-    SpecialMenuContent("", 0, 0, SpecialMenuType::NONE, std::nullopt, std::nullopt),
+    SpecialMenuContent(_("超能力/特殊能力", "MindCraft/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MINDCRAFTER, tl::nullopt),
+    SpecialMenuContent(_("ものまね/特殊能力", "Imitation/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::IMITATOR, tl::nullopt),
+    SpecialMenuContent(_("歌/特殊能力", "Song/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BARD, tl::nullopt),
+    SpecialMenuContent(_("必殺技/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SAMURAI, tl::nullopt),
+    SpecialMenuContent(_("練気術/魔法/特殊能力", "Mind/Magic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::FORCETRAINER, tl::nullopt),
+    SpecialMenuContent(_("技/特殊能力", "BrutalPower/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::BERSERKER, tl::nullopt),
+    SpecialMenuContent(_("技術/特殊能力", "Technique/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::SMITH, tl::nullopt),
+    SpecialMenuContent(_("鏡魔法/特殊能力", "MirrorMagic/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::MIRROR_MASTER, tl::nullopt),
+    SpecialMenuContent(_("忍術/特殊能力", "Ninjutsu/Special"), 0, 0, SpecialMenuType::CLASS, PlayerClassType::NINJA, tl::nullopt),
+    SpecialMenuContent(_("広域マップ(<)", "Enter global map(<)"), 2, 6, SpecialMenuType::WILD, tl::nullopt, false),
+    SpecialMenuContent(_("通常マップ(>)", "Enter local map(>)"), 2, 7, SpecialMenuType::WILD, tl::nullopt, true),
+    SpecialMenuContent("", 0, 0, SpecialMenuType::NONE, tl::nullopt, tl::nullopt),
 };
 
 menu_content menu_info[MAX_COMMAND_MENU_NUM][MAX_COMMAND_PER_SCREEN] = {

--- a/src/cmd-io/cmd-menu-content-table.h
+++ b/src/cmd-io/cmd-menu-content-table.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 struct menu_content {
@@ -19,16 +19,16 @@ enum class SpecialMenuType {
 enum class PlayerClassType : short;
 class SpecialMenuContent {
 public:
-    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, std::optional<PlayerClassType> class_condition, std::optional<bool> in_wilderness);
+    SpecialMenuContent(concptr name, byte window, byte number, SpecialMenuType menu_condition, tl::optional<PlayerClassType> class_condition, tl::optional<bool> in_wilderness);
     concptr name;
     byte window;
     byte number;
     SpecialMenuType menu_condition;
-    std::optional<PlayerClassType> class_condition;
+    tl::optional<PlayerClassType> class_condition;
     bool matches_current_wild_mode() const;
 
 private:
-    std::optional<bool> wild_mode;
+    tl::optional<bool> wild_mode;
 };
 
 constexpr int MAX_COMMAND_PER_SCREEN = 10;

--- a/src/cmd-io/cmd-process-screen.cpp
+++ b/src/cmd-io/cmd-process-screen.cpp
@@ -21,9 +21,9 @@
 #include "util/angband-files.h"
 #include "view/display-messages.h"
 #include "view/display-symbol.h"
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 
 // Encode the screen colors
 static char hack[17] = "dwsorgbuDWvyRGBU";

--- a/src/cmd-item/cmd-destroy.cpp
+++ b/src/cmd-item/cmd-destroy.cpp
@@ -80,30 +80,30 @@ static bool check_destory_item(PlayerType *player_ptr, const ItemEntity &destroy
     }
 }
 
-static std::optional<SelectionResult> select_destroying_item(PlayerType *player_ptr, bool force_destroy)
+static tl::optional<SelectionResult> select_destroying_item(PlayerType *player_ptr, bool force_destroy)
 {
     short i_idx;
     constexpr auto q = _("どのアイテムを壊しますか? ", "Destroy which item? ");
     constexpr auto s = _("壊せるアイテムを持っていない。", "You have nothing to destroy.");
     auto *o_ptr = choose_object(player_ptr, &i_idx, q, s, USE_INVEN | USE_FLOOR);
     if (o_ptr == nullptr) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (!force_destroy && !check_destory_item(player_ptr, *o_ptr, i_idx)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (o_ptr->number <= 1) {
-        return std::make_optional<SelectionResult>(o_ptr, i_idx, 1);
+        return tl::make_optional<SelectionResult>(o_ptr, i_idx, 1);
     }
 
     const auto amt = input_quantity(o_ptr->number);
     if (amt <= 0) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
-    return std::make_optional<SelectionResult>(o_ptr, i_idx, amt);
+    return tl::make_optional<SelectionResult>(o_ptr, i_idx, amt);
 }
 
 /*!

--- a/src/cmd-item/cmd-magiceat.cpp
+++ b/src/cmd-item/cmd-magiceat.cpp
@@ -83,14 +83,14 @@
 #include "view/display-messages.h"
 #include "view/display-util.h"
 #include <algorithm>
-#include <optional>
+#include <tl/optional.hpp>
 
 /*!
  * @brief 魔道具術師の取り込んだ魔力一覧から選択/閲覧する /
  * @param only_browse 閲覧するだけならばTRUE
  * @return 選択したアイテムのベースアイテムキー、キャンセルならばnullopt
  */
-static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, bool only_browse)
+static tl::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, bool only_browse)
 {
     bool flag, request_list;
     auto tval = ItemKindType::NONE;
@@ -128,7 +128,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
             case 'z':
             case 'Z':
                 screen_load();
-                return std::nullopt;
+                return tl::nullopt;
             case '2':
             case 'j':
             case 'J':
@@ -160,7 +160,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
         while (true) {
             const auto choice = input_command(_("[A] 杖, [B] 魔法棒, [C] ロッド:", "[A] staff, [B] wand, [C] rod:"), true);
             if (!choice) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             if (choice == 'A' || choice == 'a') {
@@ -186,7 +186,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
             [](const auto &item) { return item.count > 0; });
         it == item_group.end()) {
         msg_print(_("その種類の魔法は覚えていない！", "You don't have that type of magic!"));
-        return std::nullopt;
+        return tl::nullopt;
     } else {
         if (use_menu) {
             menu_line = 1 + std::distance(std::begin(item_group), it);
@@ -316,7 +316,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
             switch (*choice) {
             case '0': {
                 screen_load();
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             case '8':
@@ -456,7 +456,7 @@ static std::optional<BaseitemKey> select_magic_eater(PlayerType *player_ptr, boo
     screen_load();
 
     if (!flag) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     COMMAND_CODE base = 0;

--- a/src/cmd-visual/cmd-draw.cpp
+++ b/src/cmd-visual/cmd-draw.cpp
@@ -21,7 +21,7 @@
 #include "view/display-messages.h"
 #include "view/display-player.h"
 #include "world/world.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 /*!
  * @brief 画面を再描画するコマンドのメインルーチン
@@ -98,7 +98,7 @@ void do_cmd_redraw(PlayerType *player_ptr)
     }
 }
 
-static std::optional<int> input_status_command(PlayerType *player_ptr, int page)
+static tl::optional<int> input_status_command(PlayerType *player_ptr, int page)
 {
     auto c = inkey();
     switch (c) {
@@ -124,7 +124,7 @@ static std::optional<int> input_status_command(PlayerType *player_ptr, int page)
     case 'h':
         return page + 1;
     case ESCAPE:
-        return std::nullopt;
+        return tl::nullopt;
     default:
         bell();
         return page;

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -27,7 +27,7 @@
 #include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 /*!
  * @brief キャラクタのビジュアルIDを変更する際の対象指定
@@ -37,12 +37,12 @@
  * @return 新しいビジュアルID
  */
 template <typename T>
-static std::optional<T> input_new_visual_id(int i, T initial_visual_id, int max)
+static tl::optional<T> input_new_visual_id(int i, T initial_visual_id, int max)
 {
     if (iscntrl(i)) {
         const auto new_visual_id = input_integer("Input new number", 0, max - 1, initial_visual_id);
         if (!new_visual_id) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         return static_cast<T>(*new_visual_id);
@@ -319,7 +319,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
 
                 switch (c) {
                 case 'n': {
-                    std::optional<short> new_baseitem_id;
+                    tl::optional<short> new_baseitem_id;
                     const auto previous_bi_id = bi_id;
                     while (true) {
                         new_baseitem_id = input_new_visual_id(ch, bi_id, static_cast<short>(baseitems.size()));
@@ -405,7 +405,7 @@ void do_cmd_visuals(PlayerType *player_ptr)
 
                 switch (c) {
                 case 'n': {
-                    std::optional<short> new_terrain_id;
+                    tl::optional<short> new_terrain_id;
                     const auto previous_terrain_id = terrain_id;
                     while (true) {
                         new_terrain_id = input_new_visual_id(ch, terrain_id, static_cast<short>(TerrainList::get_instance().size()));

--- a/src/core/asking-player.cpp
+++ b/src/core/asking-player.cpp
@@ -41,7 +41,7 @@
  * ESCAPE clears the buffer and the window and returns FALSE.
  * RETURN accepts the current buffer contents and returns TRUE.
  */
-std::optional<std::string> askfor(int len, std::string_view initial_value, bool numpad_cursor)
+tl::optional<std::string> askfor(int len, std::string_view initial_value, bool numpad_cursor)
 {
     /*
      * Text color
@@ -104,7 +104,7 @@ std::optional<std::string> askfor(int len, std::string_view initial_value, bool 
             pos = buf.length();
             break;
         case ESCAPE:
-            return std::nullopt;
+            return tl::nullopt;
         case '\n':
         case '\r':
             return buf;
@@ -179,7 +179,7 @@ std::optional<std::string> askfor(int len, std::string_view initial_value, bool 
  *
  * We clear the input, and return FALSE, on "ESCAPE".
  */
-std::optional<std::string> input_string(std::string_view prompt, int len, std::string_view initial_value, bool numpad_cursor)
+tl::optional<std::string> input_string(std::string_view prompt, int len, std::string_view initial_value, bool numpad_cursor)
 {
     msg_erase();
     prt(prompt, 0, 0);
@@ -298,7 +298,7 @@ bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, EnumCla
  *
  * Returns TRUE unless the character is "Escape"
  */
-std::optional<char> input_command(std::string_view prompt, bool z_escape)
+tl::optional<char> input_command(std::string_view prompt, bool z_escape)
 {
     msg_erase();
     prt(prompt, 0, 0);
@@ -312,7 +312,7 @@ std::optional<char> input_command(std::string_view prompt, bool z_escape)
     prt("", 0, 0);
     const auto is_z = (command == 'z') || (command == 'Z');
     if ((command == ESCAPE) || (z_escape && is_z)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return command;
@@ -384,7 +384,7 @@ void pause_line(int row)
     prt("", row, 0);
 }
 
-std::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value)
+tl::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value)
 {
     std::stringstream ss;
     ss << prompt << "(" << min << "-" << max << "): ";
@@ -392,7 +392,7 @@ std::optional<int> input_integer(std::string_view prompt, int min, int max, int 
     while (true) {
         const auto input_str = input_string(ss.str(), digit, std::to_string(initial_value), false);
         if (!input_str) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         try {

--- a/src/core/asking-player.h
+++ b/src/core/asking-player.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "util/flag-group.h"
-#include <optional>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <type_traits>
 
 enum class UserCheck {
@@ -15,24 +15,24 @@ enum class UserCheck {
 };
 
 class PlayerType;
-std::optional<std::string> askfor(int len, std::string_view initial_value = "", bool numpad_cursor = true);
-std::optional<std::string> input_string(std::string_view prompt, int len, std::string_view initial_value = "", bool numpad_cursor = true);
+tl::optional<std::string> askfor(int len, std::string_view initial_value = "", bool numpad_cursor = true);
+tl::optional<std::string> input_string(std::string_view prompt, int len, std::string_view initial_value = "", bool numpad_cursor = true);
 bool input_check(std::string_view prompt);
 bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, UserCheck one_mode);
 bool input_check_strict(PlayerType *player_ptr, std::string_view prompt, EnumClassFlagGroup<UserCheck> mode);
-std::optional<char> input_command(std::string_view prompt, bool z_escape = false);
+tl::optional<char> input_command(std::string_view prompt, bool z_escape = false);
 int input_quantity(int max, std::string_view initial_prompt = "");
 void pause_line(int row);
-std::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value = 0);
+tl::optional<int> input_integer(std::string_view prompt, int min, int max, int initial_value = 0);
 
 template <typename T>
-std::optional<T> input_numerics(std::string_view prompt, int min, int max, T initial_value = static_cast<T>(0))
+tl::optional<T> input_numerics(std::string_view prompt, int min, int max, T initial_value = static_cast<T>(0))
     requires std::is_integral_v<T> || std::is_enum_v<T>
 {
     auto result = input_integer(prompt, min, max, static_cast<int>(initial_value));
     if (!result) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
-    return std::make_optional(static_cast<T>(*result));
+    return tl::make_optional(static_cast<T>(*result));
 }

--- a/src/core/show-file.cpp
+++ b/src/core/show-file.cpp
@@ -134,7 +134,7 @@ static void show_file_aux_line(std::string_view str, int cy, std::string_view sh
  */
 void FileDisplayer::display(bool show_version, std::string_view name_with_tag, int initial_line, uint32_t mode, std::string_view what)
 {
-    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, tl::nullopt);
 
     const auto &[wid, hgt] = term_get_size();
 

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -400,7 +400,7 @@ static int calcutate_capturable_hp(PlayerType *player_ptr, const MonsterEntity &
  * @param player_ptr プレイヤー情報への参照ポインタ
  * @param em_ptr 効果情報への参照ポインタ
  */
-static void effect_monster_captured(PlayerType *player_ptr, EffectMonster *em_ptr, std::optional<CapturedMonsterType *> tmp_cap_mon_ptr)
+static void effect_monster_captured(PlayerType *player_ptr, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> tmp_cap_mon_ptr)
 {
     if (em_ptr->m_ptr->mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
         em_ptr->m_ptr->reset_chameleon_polymorph();
@@ -427,7 +427,7 @@ static void effect_monster_captured(PlayerType *player_ptr, EffectMonster *em_pt
  * @param em_ptr 効果情報への参照ポインタ
  * @return 効果発動結果
  */
-ProcessResult effect_monster_capture(PlayerType *player_ptr, EffectMonster *em_ptr, std::optional<CapturedMonsterType *> cap_mon_ptr)
+ProcessResult effect_monster_capture(PlayerType *player_ptr, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> cap_mon_ptr)
 {
     const auto &quests = QuestList::get_instance();
     const auto &floor = *player_ptr->current_floor_ptr;

--- a/src/effect/effect-monster-charm.h
+++ b/src/effect/effect-monster-charm.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class ProcessResult;
 class EffectMonster;
@@ -14,4 +14,4 @@ ProcessResult effect_monster_control_animal(PlayerType *player_ptr, EffectMonste
 ProcessResult effect_monster_charm_living(PlayerType *player_ptr, EffectMonster *em_ptr);
 ProcessResult effect_monster_domination(PlayerType *player_ptr, EffectMonster *em_ptr);
 ProcessResult effect_monster_crusade(PlayerType *player_ptr, EffectMonster *em_ptr);
-ProcessResult effect_monster_capture(PlayerType *player_ptr, EffectMonster *em_ptr, std::optional<CapturedMonsterType *> cap_mon_ptr);
+ProcessResult effect_monster_capture(PlayerType *player_ptr, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> cap_mon_ptr);

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -313,7 +313,7 @@ ProcessResult effect_monster_wounds(EffectMonster *em_ptr)
  * @param em_ptr モンスター効果構造体への参照ポインタ
  * @return ここのスイッチングで終るならTRUEかFALSE、後続処理を実行するならCONTINUE
  */
-ProcessResult switch_effects_monster(PlayerType *player_ptr, EffectMonster *em_ptr, std::optional<CapturedMonsterType *> cap_mon_ptr)
+ProcessResult switch_effects_monster(PlayerType *player_ptr, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> cap_mon_ptr)
 {
     switch (em_ptr->attribute) {
     case AttributeType::PSY_SPEAR:

--- a/src/effect/effect-monster-switcher.h
+++ b/src/effect/effect-monster-switcher.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class EffectMonster;
 class CapturedMonsterType;
 class PlayerType;
-ProcessResult switch_effects_monster(PlayerType *player_ptr, EffectMonster *em_ptr, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt);
+ProcessResult switch_effects_monster(PlayerType *player_ptr, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> cap_mon_ptr = tl::nullopt);

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -122,7 +122,7 @@ static void make_description_of_affecred_monster(PlayerType *player_ptr, EffectM
  * 完全な耐性を持っていたら、一部属性を除いて影響は及ぼさない
  * デバッグ属性、モンスター打撃、モンスター射撃であれば貫通する
  */
-static ProcessResult exe_affect_monster_by_effect(PlayerType *player_ptr, EffectMonster *em_ptr, std::optional<CapturedMonsterType *> cap_mon_ptr)
+static ProcessResult exe_affect_monster_by_effect(PlayerType *player_ptr, EffectMonster *em_ptr, tl::optional<CapturedMonsterType *> cap_mon_ptr)
 {
     const std::vector<AttributeType> effect_arrtibute = {
         AttributeType::OLD_CLONE,
@@ -727,7 +727,7 @@ static void exe_affect_monster_postprocess(PlayerType *player_ptr, EffectMonster
  */
 bool affect_monster(
     PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType attribute, BIT_FLAGS flag, bool see_s_msg,
-    std::optional<CapturedMonsterType *> cap_mon_ptr, FallOffHorseEffect *fall_off_horse_effect)
+    tl::optional<CapturedMonsterType *> cap_mon_ptr, FallOffHorseEffect *fall_off_horse_effect)
 {
     EffectMonster tmp_effect(player_ptr, src_idx, r, y, x, dam, attribute, flag, see_s_msg);
     auto *em_ptr = &tmp_effect;

--- a/src/effect/effect-monster.h
+++ b/src/effect/effect-monster.h
@@ -2,9 +2,9 @@
 
 #include "effect/attribute-types.h"
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class CapturedMonsterType;
 class FallOffHorseEffect;
 class PlayerType;
-bool affect_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, bool see_s_msg, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt, FallOffHorseEffect *fall_off_horse_effect = nullptr);
+bool affect_monster(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, bool see_s_msg, tl::optional<CapturedMonsterType *> cap_mon_ptr = tl::nullopt, FallOffHorseEffect *fall_off_horse_effect = nullptr);

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -109,7 +109,7 @@ static bool process_bolt_reflection(PlayerType *player_ptr, EffectPlayerType *ep
         pos = p_pos + vec;
     }
 
-    (*project)(player_ptr, 0, 0, pos.y, pos.x, ep_ptr->dam, ep_ptr->attribute, (PROJECT_STOP | PROJECT_KILL | PROJECT_REFLECTABLE), std::nullopt);
+    (*project)(player_ptr, 0, 0, pos.y, pos.x, ep_ptr->dam, ep_ptr->attribute, (PROJECT_STOP | PROJECT_KILL | PROJECT_REFLECTABLE), tl::nullopt);
     disturb(player_ptr, true, true);
     return true;
 }
@@ -213,7 +213,7 @@ bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name
     if ((player_ptr->tim_eyeeye || SpellHex(player_ptr).is_spelling_specific(HEX_EYE_FOR_EYE)) && (ep_ptr->get_damage > 0) && !player_ptr->is_dead && ep_ptr->is_monster()) {
         const auto m_name_self = monster_desc(player_ptr, *ep_ptr->m_ptr, MD_PRON_VISIBLE | MD_POSSESSIVE | MD_OBJECTIVE);
         msg_print(_(format("攻撃が%s自身を傷つけた！", ep_ptr->m_name.data()), format("The attack of %s has wounded %s!", ep_ptr->m_name.data(), m_name_self.data())));
-        (*project)(player_ptr, 0, 0, ep_ptr->m_ptr->fy, ep_ptr->m_ptr->fx, ep_ptr->get_damage, AttributeType::MISSILE, PROJECT_KILL, std::nullopt);
+        (*project)(player_ptr, 0, 0, ep_ptr->m_ptr->fy, ep_ptr->m_ptr->fx, ep_ptr->get_damage, AttributeType::MISSILE, PROJECT_KILL, tl::nullopt);
         if (player_ptr->tim_eyeeye) {
             set_tim_eyeeye(player_ptr, player_ptr->tim_eyeeye - 5, true);
         }

--- a/src/effect/effect-player.h
+++ b/src/effect/effect-player.h
@@ -2,7 +2,7 @@
 
 #include "effect/attribute-types.h"
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class MonsterEntity;
 class FallOffHorseEffect;
@@ -30,7 +30,7 @@ struct ProjectResult;
 class CapturedMonsterType;
 class PlayerType;
 using project_func = ProjectResult (*)(
-    PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION rad, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, std::optional<CapturedMonsterType *> cap_mon_ptr);
+    PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION rad, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag, tl::optional<CapturedMonsterType *> cap_mon_ptr);
 
 bool affect_player(MONSTER_IDX src_idx, PlayerType *player_ptr, concptr src_name, int r, POSITION y, POSITION x, int dam, AttributeType typ, BIT_FLAGS flag,
     FallOffHorseEffect &fall_off_horse_effect, project_func project);

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -62,7 +62,7 @@ Pos2D decide_source_position(PlayerType *player_ptr, MONSTER_IDX src_idx, const 
  * @todo 引数にそのまま再代入していてカオスすぎる。直すのは簡単ではない
  */
 ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITION rad, const POSITION target_y, const POSITION target_x, const int dam,
-    const AttributeType typ, BIT_FLAGS flag, std::optional<CapturedMonsterType *> cap_mon_ptr)
+    const AttributeType typ, BIT_FLAGS flag, tl::optional<CapturedMonsterType *> cap_mon_ptr)
 {
     monster_target_y = player_ptr->y;
     monster_target_x = player_ptr->x;

--- a/src/effect/effect-processor.h
+++ b/src/effect/effect-processor.h
@@ -16,4 +16,4 @@ class EffectPlayerType;
 class PlayerType;
 ProjectResult project(
     PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITION rad, POSITION y, POSITION x, const int dam, const AttributeType typ,
-    BIT_FLAGS flag, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt);
+    BIT_FLAGS flag, tl::optional<CapturedMonsterType *> cap_mon_ptr = tl::nullopt);

--- a/src/external-lib/include/tl/expected.hpp
+++ b/src/external-lib/include/tl/expected.hpp
@@ -16,6 +16,11 @@
 #ifndef TL_EXPECTED_HPP
 #define TL_EXPECTED_HPP
 
+// MSVCの警告レベルを最大に設定してあるため大量の警告を出力してしまうので警告を抑制しておく.
+#if defined(_MSC_VER)
+#pragma warning(push, 0)
+#endif
+
 #define TL_EXPECTED_VERSION_MAJOR 1
 #define TL_EXPECTED_VERSION_MINOR 1
 #define TL_EXPECTED_VERSION_PATCH 0
@@ -2440,5 +2445,10 @@ void swap(expected<T, E> &lhs,
   lhs.swap(rhs);
 }
 } // namespace tl
+
+// MSVCの警告レベルを最大に設定してあるため大量の警告を出力してしまうので警告を抑制しておく.
+#if defined(_MSC_VER)
+#pragma warning(push, 0)
+#endif
 
 #endif

--- a/src/external-lib/include/tl/optional.hpp
+++ b/src/external-lib/include/tl/optional.hpp
@@ -17,6 +17,11 @@
 #ifndef TL_OPTIONAL_HPP
 #define TL_OPTIONAL_HPP
 
+// MSVCの警告レベルを最大に設定してあるため大量の警告を出力してしまうので警告を抑制しておく.
+#if defined(_MSC_VER)
+#pragma warning(push, 0)
+#endif
+
 #define TL_OPTIONAL_VERSION_MAJOR 1
 #define TL_OPTIONAL_VERSION_MINOR 1
 #define TL_OPTIONAL_VERSION_PATCH 0
@@ -2058,5 +2063,9 @@ template <class T> struct hash<tl::optional<T>> {
   }
 };
 } // namespace std
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif

--- a/src/flavor/flag-inscriptions-table.h
+++ b/src/flavor/flag-inscriptions-table.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 #include "locale/localized-string.h"
@@ -12,7 +12,7 @@ enum tr_type : int32_t;
 
 /*! オブジェクトの特性表示記号テーブルの構造体 / Structs and tables for Auto Inscription for flags */
 struct flag_insc_table {
-    flag_insc_table(LocalizedString &&inscription, tr_type flag, const std::optional<tr_type> &except_flag = std::nullopt)
+    flag_insc_table(LocalizedString &&inscription, tr_type flag, const tl::optional<tr_type> &except_flag = tl::nullopt)
         : inscription(std::move(inscription))
         , flag(flag)
         , except_flag(except_flag)
@@ -21,7 +21,7 @@ struct flag_insc_table {
 
     LocalizedString inscription;
     tr_type flag;
-    std::optional<tr_type> except_flag;
+    tl::optional<tr_type> except_flag;
 };
 
 extern const concptr game_inscriptions[MAX_GAME_INSCRIPTIONS];

--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -122,10 +122,10 @@ static std::string describe_unique_name_before_body_ja(const ItemEntity &item, c
     return "";
 }
 
-static std::optional<std::string> describe_random_artifact_name_after_body_ja(const ItemEntity &item)
+static tl::optional<std::string> describe_random_artifact_name_after_body_ja(const ItemEntity &item)
 {
     if (!item.is_random_artifact()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const std::string_view name_sv = *item.randart_name;

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -377,7 +377,7 @@ static void decide_grid_glowing(FloorType &floor, DungeonData *dd_ptr, const Dun
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return ダンジョン生成が全て無事に成功したらnullopt、何かエラーがあったらその文字列
  */
-std::optional<std::string> cave_gen(PlayerType *player_ptr)
+tl::optional<std::string> cave_gen(PlayerType *player_ptr)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     reset_lite_area(floor);
@@ -409,5 +409,5 @@ std::optional<std::string> cave_gen(PlayerType *player_ptr)
     }
 
     decide_grid_glowing(floor, &dd, dungeon);
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/floor/cave-generator.h
+++ b/src/floor/cave-generator.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> cave_gen(PlayerType *player_ptr);
+tl::optional<std::string> cave_gen(PlayerType *player_ptr);

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -301,7 +301,7 @@ static void generate_fixed_floor(PlayerType *player_ptr)
  * @param concptr
  * @return フロアの生成に成功したらTRUE
  */
-static std::optional<std::string> level_gen(PlayerType *player_ptr)
+static tl::optional<std::string> level_gen(PlayerType *player_ptr)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &dungeon = floor.get_dungeon_definition();
@@ -504,7 +504,7 @@ void generate_floor(PlayerType *player_ptr)
     auto &floor = *player_ptr->current_floor_ptr;
     const auto is_wild_mode = AngbandWorld::get_instance().is_wild_mode();
     for (int num = 0; true; num++) {
-        std::optional<std::string> why;
+        tl::optional<std::string> why;
         clear_cave(player_ptr);
         player_ptr->x = player_ptr->y = 0;
         if (floor.inside_arena) {

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -54,7 +54,7 @@ static void object_mention(PlayerType *player_ptr, ItemEntity &item)
     msg_format_wizard(player_ptr, CHEAT_OBJECT, _("%sを生成しました。", "%s was generated."), item_name.data());
 }
 
-static int get_base_floor(const FloorType &floor, BIT_FLAGS mode, std::optional<int> rq_mon_level)
+static int get_base_floor(const FloorType &floor, BIT_FLAGS mode, tl::optional<int> rq_mon_level)
 {
     if (any_bits(mode, AM_GREAT)) {
         if (rq_mon_level) {
@@ -89,7 +89,7 @@ static void set_ammo_quantity(ItemEntity *j_ptr)
  * @param rq_mon_level ランダムクエスト討伐対象のレベル。ランダムクエスト以外の生成であれば無効値
  * @return アイテムの生成成功可否
  */
-bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std::optional<int> rq_mon_level)
+bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, tl::optional<int> rq_mon_level)
 {
     const auto apply = [player_ptr, j_ptr, mode] {
         ItemMagicApplier(player_ptr, j_ptr, player_ptr->current_floor_ptr->object_level, mode).execute();
@@ -284,7 +284,7 @@ ObjectIndexList &get_o_idx_list_contains(FloorType &floor, OBJECT_IDX o_idx)
  * @param pos 配置したい座標
  * @param chance 投擲物の消滅率(%)。投擲物以外はnullopt
  */
-short drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, const Pos2D &pos, std::optional<int> chance)
+short drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, const Pos2D &pos, tl::optional<int> chance)
 {
 #ifdef JP
 #else

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -3,7 +3,7 @@
 #include "object/item-tester-hooker.h"
 #include "system/angband.h"
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 class ObjectIndexList;
@@ -12,7 +12,7 @@ class FloorType;
 class ItemEntity;
 class PlayerType;
 class ItemTester;
-bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, std::optional<int> rq_mon_level = std::nullopt);
+bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, tl::optional<int> rq_mon_level = tl::nullopt);
 void delete_all_items_from_floor(PlayerType *player_ptr, const Pos2D &pos);
 void floor_item_increase(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER num);
 void floor_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx);
@@ -20,7 +20,7 @@ void delete_object_idx(PlayerType *player_ptr, OBJECT_IDX o_idx);
 void excise_object_idx(FloorType &floor, OBJECT_IDX o_idx);
 void delete_items(PlayerType *player_ptr, std::vector<OBJECT_IDX> delete_i_idx_list);
 ObjectIndexList &get_o_idx_list_contains(FloorType &floor, OBJECT_IDX o_idx);
-short drop_near(PlayerType *player_ptr, ItemEntity *o_ptr, const Pos2D &pos, std::optional<int> chance = std::nullopt);
+short drop_near(PlayerType *player_ptr, ItemEntity *o_ptr, const Pos2D &pos, tl::optional<int> chance = tl::nullopt);
 void floor_item_charges(const FloorType &floor, INVENTORY_IDX i_idx);
 void floor_item_describe(PlayerType *player_ptr, INVENTORY_IDX i_idx);
 ItemEntity *choose_object(PlayerType *player_ptr, short *initial_i_idx, concptr q, concptr s, BIT_FLAGS option, const ItemTester &item_tester = AllMatchItemTester());

--- a/src/floor/geometry.h
+++ b/src/floor/geometry.h
@@ -5,8 +5,8 @@
 #include "target/target.h"
 #include "util/point-2d.h"
 #include <array>
-#include <optional>
 #include <span>
+#include <tl/optional.hpp>
 #include <utility>
 
 /*!
@@ -150,9 +150,9 @@ public:
 
     /*!
      * @brief 円周順に方向を示す値を取得する
-     * @return 円周順に方向を示す値。示す値がない(方向IDが0もしくは5)場合はstd::nulloptを返す
+     * @return 円周順に方向を示す値。示す値がない(方向IDが0もしくは5)場合はtl::nulloptを返す
      */
-    constexpr std::optional<int> cdir() const
+    constexpr tl::optional<int> cdir() const
     {
         return DIR_TO_CDIR[this->dir_];
     }
@@ -254,10 +254,10 @@ private:
     };
 
     /// 方向IDに対応する円周順に方向を示す値の定義
-    static constexpr std::array<std::optional<int>, 10> DIR_TO_CDIR = { { std::nullopt, 7, 0, 1, 6, std::nullopt, 2, 5, 4, 3 } };
+    static constexpr std::array<tl::optional<int>, 10> DIR_TO_CDIR = { { tl::nullopt, 7, 0, 1, 6, tl::nullopt, 2, 5, 4, 3 } };
 
     int dir_; //<! 方向ID
-    std::optional<Target> target; //<! ターゲット
+    tl::optional<Target> target; //<! ターゲット
 };
 
 constexpr bool operator==(const Direction &dir1, const Direction &dir2) noexcept

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -617,12 +617,12 @@ void wilderness_gen_small(PlayerType *player_ptr)
  * @param pos_parsing 解析対象の座標
  * @return エラーコードと座標のペア。エラー時は座標は無効値。Dタグの時だけ更新の可能性があり、それ以外はpos_parsingをそのまま返却
  */
-std::pair<parse_error_type, std::optional<Pos2D>> parse_line_wilderness(char *line, int xmin, int xmax, const Pos2D &pos_parsing)
+std::pair<parse_error_type, tl::optional<Pos2D>> parse_line_wilderness(char *line, int xmin, int xmax, const Pos2D &pos_parsing)
 {
     auto &letters = WildernessLetters::get_instance();
     letters.initialize();
     if (!std::string_view(line).starts_with("W:")) {
-        return { PARSE_ERROR_GENERIC, std::nullopt };
+        return { PARSE_ERROR_GENERIC, tl::nullopt };
     }
 
     Pos2D pos = pos_parsing;
@@ -644,7 +644,7 @@ std::pair<parse_error_type, std::optional<Pos2D>> parse_line_wilderness(char *li
         char *zz[33];
         const auto num = tokenize(line + 4, 6, zz, 0);
         if (num <= 1) {
-            return { PARSE_ERROR_TOO_FEW_ARGUMENTS, std::nullopt };
+            return { PARSE_ERROR_TOO_FEW_ARGUMENTS, tl::nullopt };
         }
 
         const int index = zz[0][0];
@@ -697,19 +697,19 @@ std::pair<parse_error_type, std::optional<Pos2D>> parse_line_wilderness(char *li
 
         char *zz[33];
         if (tokenize(line + 4, 2, zz, 0) != 2) {
-            return { PARSE_ERROR_TOO_FEW_ARGUMENTS, std::nullopt };
+            return { PARSE_ERROR_TOO_FEW_ARGUMENTS, tl::nullopt };
         }
 
         wilderness.set_starting_player_position({ std::stoi(zz[0]), std::stoi(zz[1]) });
         wilderness.initialize_position();
         if (!wilderness.is_player_in_bounds()) {
-            return { PARSE_ERROR_OUT_OF_BOUNDS, std::nullopt };
+            return { PARSE_ERROR_OUT_OF_BOUNDS, tl::nullopt };
         }
 
         break;
     }
     default:
-        return { PARSE_ERROR_UNDEFINED_DIRECTIVE, std::nullopt };
+        return { PARSE_ERROR_UNDEFINED_DIRECTIVE, tl::nullopt };
     }
 
     for (const auto &[dungeon_id, dungeon] : DungeonList::get_instance()) {

--- a/src/floor/wild.h
+++ b/src/floor/wild.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 #include <utility>
 
 enum parse_error_type : int;
@@ -19,5 +19,5 @@ class PlayerType;
 void wilderness_gen(PlayerType *player_ptr);
 void wilderness_gen_small(PlayerType *player_ptr);
 void init_wilderness_terrains();
-std::pair<parse_error_type, std::optional<Pos2D>> parse_line_wilderness(char *buf, int xmin, int xmax, const Pos2D &pos_parsing);
+std::pair<parse_error_type, tl::optional<Pos2D>> parse_line_wilderness(char *buf, int xmin, int xmax, const Pos2D &pos_parsing);
 bool change_wild_mode(PlayerType *player_ptr, bool encount);

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -13,7 +13,7 @@
 #include "locale/language-switcher.h"
 #include <utility>
 
-GameOption::GameOption(bool *value, bool norm, uint8_t set, uint8_t bits, std::string &&text, std::string &&description, const std::optional<GameOptionPage> &page)
+GameOption::GameOption(bool *value, bool norm, uint8_t set, uint8_t bits, std::string &&text, std::string &&description, const tl::optional<GameOptionPage> &page)
     : value(value)
     , default_value(norm)
     , flag_position(set)

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -1,21 +1,21 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class GameOptionPage : int;
 class GameOption {
 public:
-    GameOption(bool *value, bool norm, uint8_t set, uint8_t bits, std::string &&text, std::string &&description, const std::optional<GameOptionPage> &page = std::nullopt);
+    GameOption(bool *value, bool norm, uint8_t set, uint8_t bits, std::string &&text, std::string &&description, const tl::optional<GameOptionPage> &page = tl::nullopt);
     bool *value;
     bool default_value;
     uint8_t flag_position;
     uint8_t offset;
     std::string text;
     std::string description;
-    std::optional<GameOptionPage> page;
+    tl::optional<GameOptionPage> page;
 };
 
 extern const std::vector<GameOption> option_info;

--- a/src/grid/door.cpp
+++ b/src/grid/door.cpp
@@ -54,7 +54,7 @@ void add_door(PlayerType *player_ptr, const Pos2D &pos)
  * @param pos 配置先座標
  * @param door_kind ドア種別
  */
-void place_secret_door(PlayerType *player_ptr, const Pos2D &pos, std::optional<DoorKind> door_kind_initial)
+void place_secret_door(PlayerType *player_ptr, const Pos2D &pos, tl::optional<DoorKind> door_kind_initial)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &dungeon = floor.get_dungeon_definition();

--- a/src/grid/door.h
+++ b/src/grid/door.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class DoorKind;
 class PlayerType;
 void add_door(PlayerType *player_ptr, const Pos2D &pos);
-void place_secret_door(PlayerType *player_ptr, const Pos2D &pos, std::optional<DoorKind> door_kind_initial = std::nullopt);
+void place_secret_door(PlayerType *player_ptr, const Pos2D &pos, tl::optional<DoorKind> door_kind_initial = tl::nullopt);
 void place_locked_door(PlayerType *player_ptr, const Pos2D &pos);
 void place_random_door(PlayerType *player_ptr, const Pos2D &pos, bool is_room_door);
 void place_closed_door(PlayerType *player_ptr, const Pos2D &pos, DoorKind door_kind);

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -153,7 +153,7 @@ void set_terrain_id_to_grid(PlayerType *player_ptr, const Pos2D &pos, short terr
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return 配置に成功したらその座標、失敗したらnullopt
  */
-std::optional<Pos2D> new_player_spot(PlayerType *player_ptr)
+tl::optional<Pos2D> new_player_spot(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     auto max_attempts = 10000;
@@ -205,7 +205,7 @@ std::optional<Pos2D> new_player_spot(PlayerType *player_ptr)
     }
 
     if (max_attempts < 1) { /* Should be -1, actually if we failed... */
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return pos;

--- a/src/grid/grid.h
+++ b/src/grid/grid.h
@@ -11,7 +11,7 @@
 #include "spell/spells-util.h"
 #include "system/angband.h"
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class AttributeType;
 class Grid;
@@ -63,7 +63,7 @@ enum class TerrainCharacteristics;
 enum class TerrainTag;
 void set_terrain_id_to_grid(PlayerType *player_ptr, const Pos2D &pos, TerrainTag tag);
 void set_terrain_id_to_grid(PlayerType *player_ptr, const Pos2D &pos, short terrain_id);
-std::optional<Pos2D> new_player_spot(PlayerType *player_ptr);
+tl::optional<Pos2D> new_player_spot(PlayerType *player_ptr);
 bool player_can_enter(PlayerType *player_ptr, FEAT_IDX feature, BIT_FLAGS16 mode);
 void update_local_illumination(PlayerType *player_ptr, const Pos2D &pos);
 bool no_lite(PlayerType *player_ptr);

--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -107,7 +107,7 @@ static bool grab_one_spell_monster_flag(DungeonDefinition &dungeon, std::string_
     return false;
 }
 
-static std::optional<ProbabilityTable<short>> parse_terrain_probability(std::span<const std::string> tokens)
+static tl::optional<ProbabilityTable<short>> parse_terrain_probability(std::span<const std::string> tokens)
 {
     const auto &terrains = TerrainList::get_instance();
     ProbabilityTable<short> prob_table;
@@ -118,7 +118,7 @@ static std::optional<ProbabilityTable<short>> parse_terrain_probability(std::spa
             const auto prob = static_cast<short>(std::stoi(tokens[i + 1]));
             prob_table.entry_item(terrain_id, prob);
         } catch (const std::exception &) {
-            return std::nullopt;
+            return tl::nullopt;
         }
     }
 

--- a/src/info-reader/info-reader-util.h
+++ b/src/info-reader/info-reader-util.h
@@ -4,9 +4,9 @@
 #include "util/bit-flags-calculator.h"
 #include <concepts>
 #include <map>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <unordered_map>
 #include <utility>
 
@@ -45,12 +45,12 @@ concept DictIndexedBy = requires(T t, Key k) {
  * @return 見つけたら定数を返す。見つからなければnulloptを返す
  */
 template <typename Key, DictIndexedBy<Key> Dict>
-std::optional<typename Dict::mapped_type> info_get_const(const Dict &dict, Key &&what)
+tl::optional<typename Dict::mapped_type> info_get_const(const Dict &dict, Key &&what)
 {
     if (auto it = dict.find(what); it != dict.end()) {
         return it->second;
     }
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!

--- a/src/info-reader/json-reader-util.h
+++ b/src/info-reader/json-reader-util.h
@@ -4,7 +4,7 @@
 #include "info-reader/parse-error-types.h"
 #include "system/angband.h"
 #include <concepts>
-#include <optional>
+#include <tl/optional.hpp>
 #include <utility>
 
 class Dice;
@@ -31,7 +31,7 @@ errr info_set_bool(const nlohmann::json &json, bool &bool_value, bool is_require
  * @return エラーコード
  */
 template <IntegralOrEnum T>
-errr info_set_integer(const nlohmann::json &json, T &data, bool is_required, std::optional<Range> range = std::nullopt)
+errr info_set_integer(const nlohmann::json &json, T &data, bool is_required, tl::optional<Range> range = tl::nullopt)
 {
     if (json.is_null()) {
         return is_required ? PARSE_ERROR_TOO_FEW_ARGUMENTS : PARSE_ERROR_NONE;

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -33,8 +33,8 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 // clang-format off
 namespace {

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -583,7 +583,7 @@ static std::string get_check_sum()
  */
 void make_character_dump(PlayerType *player_ptr, FILE *fff)
 {
-    TermCenteredOffsetSetter tos(MAIN_TERM_MIN_COLS, std::nullopt);
+    TermCenteredOffsetSetter tos(MAIN_TERM_MIN_COLS, tl::nullopt);
 
     constexpr auto fmt = _("  [{} キャラクタ情報]\n", "  [{} Character Dump]\n");
     fmt::println(fff, fmt, AngbandSystem::get_instance().build_version_expression(VersionExpression::FULL));

--- a/src/io/command-repeater.cpp
+++ b/src/io/command-repeater.cpp
@@ -23,9 +23,9 @@ void repeat_push(short command)
     ++repeat_index;
 }
 
-std::optional<short> repeat_pull()
+tl::optional<short> repeat_pull()
 {
-    return repeat_index == repeat_counter ? std::nullopt : std::make_optional(repeat_keys[repeat_index++]);
+    return repeat_index == repeat_counter ? tl::nullopt : tl::make_optional(repeat_keys[repeat_index++]);
 }
 
 void repeat_check()

--- a/src/io/command-repeater.h
+++ b/src/io/command-repeater.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <optional>
+#include <tl/optional.hpp>
 
 void repeat_push(short command);
-std::optional<short> repeat_pull();
+tl::optional<short> repeat_pull();
 void repeat_check();

--- a/src/io/files-util.cpp
+++ b/src/io/files-util.cpp
@@ -107,12 +107,12 @@ void file_character(PlayerType *player_ptr, std::string_view filename)
  * @param entry 特定条件時のN:タグヘッダID
  * @return ファイルから取得した行 (但しファイルがなかったり異常値ならばnullopt)
  */
-std::optional<std::string> get_random_line(concptr file_name, int entry)
+tl::optional<std::string> get_random_line(concptr file_name, int entry)
 {
     const auto path = path_build(ANGBAND_DIR_FILE, file_name);
     auto *fp = angband_fopen(path, FileOpenMode::READ);
     if (!fp) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     int test;
@@ -123,7 +123,7 @@ std::optional<std::string> get_random_line(concptr file_name, int entry)
         const auto line_str = angband_fgets(fp);
         if (!line_str) {
             angband_fclose(fp);
-            return std::nullopt;
+            return tl::nullopt;
         }
         const auto *buf = line_str->data();
 
@@ -151,14 +151,14 @@ std::optional<std::string> get_random_line(concptr file_name, int entry)
         } else {
             msg_format("Error in line %d of %s!", line_num, file_name);
             angband_fclose(fp);
-            return std::nullopt;
+            return tl::nullopt;
         }
     }
 
     auto counter = 0;
-    std::optional<std::string> line{};
+    tl::optional<std::string> line{};
     while (true) {
-        std::optional<std::string> buf;
+        tl::optional<std::string> buf;
         while (true) {
             buf = angband_fgets(fp);
             if (!buf) {
@@ -198,13 +198,13 @@ std::optional<std::string> get_random_line(concptr file_name, int entry)
  * @return ファイルから取得した行 (但しファイルがなかったり異常値ならばnullopt)
  * @details
  */
-std::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, int count)
+tl::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, int count)
 {
-    std::optional<std::string> line;
+    tl::optional<std::string> line;
     for (auto i = 0; i < count; i++) {
         line = get_random_line(file_name, entry);
         if (!line) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         auto is_kanji = false;

--- a/src/io/files-util.h
+++ b/src/io/files-util.h
@@ -2,9 +2,9 @@
 
 #include "system/angband.h"
 #include <filesystem>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 
 extern std::filesystem::path savefile; //!< セーブファイルのフルパス
 extern std::filesystem::path savefile_base; //!< セーブファイル名
@@ -27,11 +27,11 @@ class PlayerType;
 typedef void (*update_playtime_pf)();
 
 void file_character(PlayerType *player_ptr, std::string_view filename);
-std::optional<std::string> get_random_line(concptr file_name, int entry);
+tl::optional<std::string> get_random_line(concptr file_name, int entry);
 void read_dead_file();
 
 #ifdef JP
-std::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, int count);
+tl::optional<std::string> get_random_line_ja_only(concptr file_name, int entry, int count);
 #endif
 errr counts_write(PlayerType *player_ptr, int where, uint32_t count);
 uint32_t counts_read(PlayerType *player_ptr, int where);

--- a/src/io/input-key-processor.cpp
+++ b/src/io/input-key-processor.cpp
@@ -94,8 +94,8 @@
 #include "window/display-sub-windows.h"
 #include "wizard/cmd-wizard.h"
 #include "world/world.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 /*!
  * @brief ウィザードモードへの導入処理

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -315,7 +315,7 @@ void InputKeyRequestor::sweep_confirmation_equipments()
     }
 }
 
-void InputKeyRequestor::confirm_command(const std::optional<std::string> &inscription, const int caret_command)
+void InputKeyRequestor::confirm_command(const tl::optional<std::string> &inscription, const int caret_command)
 {
     if (!inscription) {
         return;

--- a/src/io/input-key-requester.h
+++ b/src/io/input-key-requester.h
@@ -3,8 +3,8 @@
 #include "floor/geometry.h"
 #include "game-option/keymap-directory-getter.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 extern bool use_menu;
 
@@ -48,7 +48,7 @@ private:
     void change_shopping_command() const;
     int get_caret_command() const;
     void sweep_confirmation_equipments();
-    void confirm_command(const std::optional<std::string> &inscription, const int caret_command);
+    void confirm_command(const tl::optional<std::string> &inscription, const int caret_command);
 
     void make_commands_frame() const;
     std::string switch_special_menu_condition(const SpecialMenuContent &special_menu) const;

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -26,7 +26,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 
-std::optional<std::string> histpref_buf;
+tl::optional<std::string> histpref_buf;
 
 /*!
  * @brief 生い立ちメッセージの内容をバッファに加える。 / Hook function for reading the histpref.prf file.

--- a/src/io/interpret-pref-file.h
+++ b/src/io/interpret-pref-file.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
-extern std::optional<std::string> histpref_buf;
+extern tl::optional<std::string> histpref_buf;
 
 class PlayerType;
 int interpret_pref_file(PlayerType *player_ptr, char *buf);

--- a/src/io/macro-configurations-store.cpp
+++ b/src/io/macro-configurations-store.cpp
@@ -12,13 +12,13 @@
 #include <cstdint>
 #include <utility>
 
-std::map<KeymapMode, std::vector<std::optional<std::string>>> keymap_actions_map = {
-    { KeymapMode::ORIGINAL, std::vector<std::optional<std::string>>(256) },
-    { KeymapMode::ROGUE, std::vector<std::optional<std::string>>(256) },
+std::map<KeymapMode, std::vector<tl::optional<std::string>>> keymap_actions_map = {
+    { KeymapMode::ORIGINAL, std::vector<tl::optional<std::string>>(256) },
+    { KeymapMode::ROGUE, std::vector<tl::optional<std::string>>(256) },
 };
 size_t max_macrotrigger = 0;
-std::optional<std::string> macro_template;
-std::optional<std::string> macro_modifier_chr;
+tl::optional<std::string> macro_template;
+tl::optional<std::string> macro_modifier_chr;
 std::vector<std::string> macro_modifier_names = std::vector<std::string>(MAX_MACRO_MOD);
 std::vector<std::string> macro_trigger_names = std::vector<std::string>(MAX_MACRO_TRIG);
 std::map<ShiftStatus, std::vector<std::string>> macro_trigger_keycodes = {

--- a/src/io/macro-configurations-store.h
+++ b/src/io/macro-configurations-store.h
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <map>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 
 constexpr size_t MAX_MACRO_MOD = 12;
@@ -25,10 +25,10 @@ enum class KeymapMode {
     ROGUE = 1, //!< ローグライクキー配置
 };
 
-extern std::map<KeymapMode, std::vector<std::optional<std::string>>> keymap_actions_map;
+extern std::map<KeymapMode, std::vector<tl::optional<std::string>>> keymap_actions_map;
 extern size_t max_macrotrigger; //!< 現在登録中のマクロ(トリガー)の数
-extern std::optional<std::string> macro_template; //!< Angband設定ファイルのT: タグ情報から読み込んだ長いTコードを処理するために利用する文字列
-extern std::optional<std::string> macro_modifier_chr; //!< &x# で指定されるマクロトリガーに関する情報を記録する文字列
+extern tl::optional<std::string> macro_template; //!< Angband設定ファイルのT: タグ情報から読み込んだ長いTコードを処理するために利用する文字列
+extern tl::optional<std::string> macro_modifier_chr; //!< &x# で指定されるマクロトリガーに関する情報を記録する文字列
 extern std::vector<std::string> macro_modifier_names; //!< マクロ上で取り扱う特殊キーを文字列上で表現するためのフォーマットを記録した文字列配列
 extern std::vector<std::string> macro_trigger_names; //!< マクロのトリガーコード
 extern std::map<ShiftStatus, std::vector<std::string>> macro_trigger_keycodes; //!< マクロの内容

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -313,7 +313,7 @@ bool read_histpref(PlayerType *player_ptr)
         err = process_histpref_file(player_ptr, _("histedit.prf", "histpref.prf"));
     }
 
-    const auto finalizer = util::make_finalizer([]() { histpref_buf = std::nullopt; });
+    const auto finalizer = util::make_finalizer([]() { histpref_buf = tl::nullopt; });
     if (err) {
         msg_print(_("生い立ち設定ファイルの読み込みに失敗しました。", "Failed to load background history preference."));
         msg_erase();

--- a/src/io/record-play-movie.cpp
+++ b/src/io/record-play-movie.cpp
@@ -330,7 +330,7 @@ void prepare_chuukei_hooks(void)
  */
 void prepare_movie_hooks(PlayerType *player_ptr)
 {
-    TermCenteredOffsetSetter tcos(std::nullopt, std::nullopt);
+    TermCenteredOffsetSetter tcos(tl::nullopt, tl::nullopt);
 
     if (movie_mode) {
         movie_mode = 0;

--- a/src/knowledge/knowledge-features.cpp
+++ b/src/knowledge/knowledge-features.cpp
@@ -106,7 +106,7 @@ static void display_feature_list(int col, int row, int per_page, FEAT_IDX *feat_
  */
 void do_cmd_knowledge_features(bool *need_redraw, bool visual_only, IDX direct_f_idx, IDX *lighting_level)
 {
-    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, tl::nullopt);
     std::map<int, DisplaySymbol> symbols;
     const auto &[wid, hgt] = term_get_size();
     auto &terrains = TerrainList::get_instance();

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -233,7 +233,7 @@ static void desc_obj_fake(PlayerType *player_ptr, short bi_id)
  */
 void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool visual_only, short direct_k_idx)
 {
-    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, tl::nullopt);
 
     short object_old, object_top;
     std::vector<short> grp_idx;

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -262,9 +262,9 @@ static void display_monster_list(int col, int row, int per_page, const std::vect
  * @param direct_r_idx モンスターID
  * @todo 引数の詳細について加筆求む
  */
-void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool visual_only, std::optional<MonraceId> direct_r_idx)
+void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool visual_only, tl::optional<MonraceId> direct_r_idx)
 {
-    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, tl::nullopt);
 
     const auto &[wid, hgt] = term_get_size();
     std::vector<MonraceId> monrace_ids;

--- a/src/knowledge/knowledge-monsters.h
+++ b/src/knowledge/knowledge-monsters.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <optional>
 #include <string_view>
+#include <tl/optional.hpp>
 
 enum class MonraceId : short;
 class PlayerType;
-void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool visual_only, std::optional<MonraceId> direct_r_idx = std::nullopt);
+void do_cmd_knowledge_monsters(PlayerType *player_ptr, bool *need_redraw, bool visual_only, tl::optional<MonraceId> direct_r_idx = tl::nullopt);
 void do_cmd_knowledge_pets(PlayerType *player_ptr);
 void do_cmd_knowledge_kill_count(PlayerType *player_ptr);
 void do_cmd_knowledge_bounty(std::string_view player_name);

--- a/src/locale/japanese.cpp
+++ b/src/locale/japanese.cpp
@@ -535,33 +535,33 @@ static bool utf8_to_sys(std::string_view str, char *sys_str_buffer, size_t sys_s
  * @brief システムの文字コードからUTF-8に変換する
  * @param str システムの文字コードの文字列
  * @return UTF-8に変換した文字列
- *         変換に失敗した場合はstd::nullopt
+ *         変換に失敗した場合はtl::nullopt
  */
-std::optional<std::string> sys_to_utf8(std::string_view str)
+tl::optional<std::string> sys_to_utf8(std::string_view str)
 {
 #if defined(EUC)
     std::string utf8str(str.length() * 2 + 1, '\0');
     const auto len = euc_to_utf8(str.data(), str.length(), utf8str.data(), utf8str.size());
 
-    return (len >= 0) ? std::make_optional(std::move(utf8str.erase(len))) : std::nullopt;
+    return (len >= 0) ? tl::make_optional(std::move(utf8str.erase(len))) : tl::nullopt;
 #elif defined(SJIS) && defined(WINDOWS)
     /* SJIS(CP932) -> UTF-16 */
     std::vector<WCHAR> utf16buf(str.length());
     const auto utf16_len = MultiByteToWideChar(932, 0, str.data(), str.size(), utf16buf.data(), utf16buf.size());
     if (utf16_len == 0) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     /* UTF-16 -> UTF-8 */
     std::vector<char> utf8buf(str.length() * 2 + 1);
     const auto utf8_len = WideCharToMultiByte(CP_UTF8, 0, utf16buf.data(), utf16_len, utf8buf.data(), utf8buf.size(), nullptr, nullptr);
     if (utf8_len == 0) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
-    return std::make_optional<std::string>(utf8buf.data(), utf8_len);
+    return tl::make_optional<std::string>(utf8buf.data(), utf8_len);
 #else
-    return std::nullopt;
+    return tl::nullopt;
 #endif
 }
 
@@ -570,18 +570,18 @@ std::optional<std::string> sys_to_utf8(std::string_view str)
  *
  * @param str UTF-8の文字列
  * @return システムの文字コードに変換した文字列
- *         変換に失敗した場合はstd::nullopt
+ *         変換に失敗した場合はtl::nullopt
  */
-std::optional<std::string> utf8_to_sys(std::string_view str)
+tl::optional<std::string> utf8_to_sys(std::string_view str)
 {
     // UTF-8 -> SJIS or EUC でバイト長が増えることはないので、終端文字分を含めて元の文字列と同じ長さを確保しておけばよい
     std::vector<char> sys_str_buf(str.length() + 1);
 
     if (!utf8_to_sys(str, sys_str_buf.data(), sys_str_buf.size())) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
-    return std::make_optional<std::string>(sys_str_buf.data());
+    return tl::make_optional<std::string>(sys_str_buf.data());
 }
 
 /*!

--- a/src/locale/japanese.h
+++ b/src/locale/japanese.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 
 #ifdef JP
 
@@ -22,8 +22,8 @@ void sjis2euc(char *str);
 void euc2sjis(char *str);
 CharacterEncoding codeconv(char *str);
 bool iskanji2(concptr s, int x);
-std::optional<std::string> sys_to_utf8(std::string_view str);
-std::optional<std::string> utf8_to_sys(std::string_view utf8_str);
+tl::optional<std::string> sys_to_utf8(std::string_view str);
+tl::optional<std::string> utf8_to_sys(std::string_view utf8_str);
 size_t guess_convert_to_system_encoding(char *strbuf, int buflen);
 
 int lb_to_kg_integer(int x);
@@ -60,9 +60,9 @@ constexpr bool is_kinsoku(std::string_view)
     return false;
 }
 
-inline std::optional<std::string> sys_to_utf8(std::string_view str)
+inline tl::optional<std::string> sys_to_utf8(std::string_view str)
 {
-    return std::make_optional<std::string>(str);
+    return tl::make_optional<std::string>(str);
 }
 
 #endif

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -129,10 +129,10 @@ std::vector<lore_msg> lore_type::build_speed_description() const
     return texts;
 }
 
-std::optional<std::vector<lore_msg>> lore_type::build_kill_unique_description() const
+tl::optional<std::vector<lore_msg>> lore_type::build_kill_unique_description() const
 {
     if (this->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     std::vector<lore_msg> texts;

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -15,9 +15,9 @@
 #include "system/angband.h"
 #include "term/term-color-types.h"
 #include "util/flag-group.h"
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -87,7 +87,7 @@ struct lore_type {
     bool is_details_known() const;
     bool is_blow_damage_known(int num_blow) const;
 
-    std::optional<std::vector<lore_msg>> build_kill_unique_description() const;
+    tl::optional<std::vector<lore_msg>> build_kill_unique_description() const;
     std::string build_revenge_description(bool has_defeated) const;
     std::vector<lore_msg> build_speed_description() const;
 

--- a/src/main-win/main-win-cfg-reader.cpp
+++ b/src/main-win/main-win-cfg-reader.cpp
@@ -33,13 +33,13 @@ static cfg_key make_cfg_key(int type, int val)
  * @brief 登録されている中からランダムに選択する
  * @param type the "actions" value of "term_xtra()". see:z-term.h TERM_XTRA_xxxxx
  * @param val the 2nd parameter of "term_xtra()"
- * @return キーに対応する値、複数のファイル名の中からからランダムに返す。登録されていない場合はstd::nulloptを返す。
+ * @return キーに対応する値、複数のファイル名の中からからランダムに返す。登録されていない場合はtl::nulloptを返す。
  */
-std::optional<std::string> CfgData::get_rand(int key1_type, int key2_val) const
+tl::optional<std::string> CfgData::get_rand(int key1_type, int key2_val) const
 {
     const auto it = this->map.find(make_cfg_key(key1_type, key2_val));
     if (it == this->map.end()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto &filenames = it->second;
@@ -85,8 +85,8 @@ CfgData CfgReader::read_sections(std::initializer_list<cfg_section> sections) co
     const auto cfg_path_str = this->cfg_path.string();
 
     for (auto &section : sections) {
-        std::optional<std::string> read_key;
-        for (auto index = 0; (read_key = section.key_at(index)) != std::nullopt; ++index) {
+        tl::optional<std::string> read_key;
+        for (auto index = 0; (read_key = section.key_at(index)) != tl::nullopt; ++index) {
             char buf[MAIN_WIN_MAX_PATH]{};
             if (GetPrivateProfileStringA(section.section_name.data(), read_key->data(), "", buf, MAIN_WIN_MAX_PATH, cfg_path_str.data()) == 0) {
                 continue;

--- a/src/main-win/main-win-cfg-reader.h
+++ b/src/main-win/main-win-cfg-reader.h
@@ -5,8 +5,8 @@
 #include <filesystem>
 #include <functional>
 #include <initializer_list>
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <unordered_map>
 #include <vector>
 
@@ -33,7 +33,7 @@ struct cfg_section {
      * Returns a reference to the name of the key at a specified action-val* in the section.
      * *action-val : the 2nd parameter of "term_xtra()"
      */
-    std::function<std::optional<std::string>(int)> key_at;
+    std::function<tl::optional<std::string>(int)> key_at;
     //! 1つでもデータを読み込めた場合にtrueを設定する。（nullptrの場合を除く）
     bool *has_data = nullptr;
 };
@@ -42,7 +42,7 @@ class CfgData {
 public:
     CfgData() = default;
 
-    std::optional<std::string> get_rand(int key1_type, int key2_val) const;
+    tl::optional<std::string> get_rand(int key1_type, int key2_val) const;
     bool has_key(int key1_type, int key2_val) const;
     void insert(int key1_type, int key2_val, cfg_values &&value);
 

--- a/src/main-win/main-win-music.cpp
+++ b/src/main-win/main-win-music.cpp
@@ -41,7 +41,7 @@ std::filesystem::path ANGBAND_DIR_XTRA_MUSIC;
 /*
  * "music.cfg" data
  */
-std::optional<CfgData> music_cfg_data;
+tl::optional<CfgData> music_cfg_data;
 
 namespace main_win_music {
 
@@ -51,10 +51,10 @@ namespace main_win_music {
  * @param buf 使用しない
  * @return 対応するキー名を返す
  */
-static std::optional<std::string> basic_key_at(int index)
+static tl::optional<std::string> basic_key_at(int index)
 {
     if (index >= MUSIC_BASIC_MAX) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return angband_music_basic_name[index];
@@ -66,10 +66,10 @@ static std::optional<std::string> basic_key_at(int index)
  * @param buf バッファ
  * @return 対応するキー名を返す
  */
-static std::optional<std::string> dungeon_key_at(int index)
+static tl::optional<std::string> dungeon_key_at(int index)
 {
     if (index >= static_cast<int>(DungeonList::get_instance().size())) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return format("dungeon%03d", index);
@@ -81,11 +81,11 @@ static std::optional<std::string> dungeon_key_at(int index)
  * @param buf バッファ
  * @return 対応するキー名を返す
  */
-static std::optional<std::string> quest_key_at(int index)
+static tl::optional<std::string> quest_key_at(int index)
 {
     const auto &quests = QuestList::get_instance();
     if (index > enum2i(quests.rbegin()->first)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return format("quest%03d", index);
@@ -97,10 +97,10 @@ static std::optional<std::string> quest_key_at(int index)
  * @param buf バッファ
  * @return 対応するキー名を返す
  */
-static std::optional<std::string> town_key_at(int index)
+static tl::optional<std::string> town_key_at(int index)
 {
     if (index >= static_cast<int>(towns_info.size())) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return format("town%03d", index);
@@ -112,10 +112,10 @@ static std::optional<std::string> town_key_at(int index)
  * @param buf バッファ
  * @return 対応するキー名を返す
  */
-static std::optional<std::string> monster_key_at(int index)
+static tl::optional<std::string> monster_key_at(int index)
 {
     if (index >= static_cast<int>(MonraceList::get_instance().size())) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return format("monster%04d", index);

--- a/src/main-win/main-win-music.h
+++ b/src/main-win/main-win-music.h
@@ -2,13 +2,13 @@
 
 #include <array>
 #include <filesystem>
-#include <optional>
+#include <tl/optional.hpp>
 #include <windows.h>
 
 class CfgData;
 extern bool use_pause_music_inactive;
 extern std::filesystem::path ANGBAND_DIR_XTRA_MUSIC;
-extern std::optional<CfgData> music_cfg_data;
+extern tl::optional<CfgData> music_cfg_data;
 
 namespace main_win_music {
 void load_music_prefs();

--- a/src/main-win/main-win-sound.cpp
+++ b/src/main-win/main-win-sound.cpp
@@ -26,7 +26,7 @@ std::filesystem::path ANGBAND_DIR_XTRA_SOUND;
 /*
  * "sound.cfg" data
  */
-std::optional<CfgData> sound_cfg_data;
+tl::optional<CfgData> sound_cfg_data;
 
 /*!
  * 効果音データ
@@ -188,11 +188,11 @@ static bool play_sound_impl(const std::filesystem::path &path, int volume)
  * @param buf 使用しない
  * @return 対応するキー名を返す
  */
-static std::optional<std::string> sound_key_at(int index)
+static tl::optional<std::string> sound_key_at(int index)
 {
     const auto sk = i2enum<SoundKind>(index);
     if (sk >= SoundKind::MAX) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return sound_names.at(sk);

--- a/src/main-win/main-win-sound.h
+++ b/src/main-win/main-win-sound.h
@@ -3,10 +3,10 @@
 #include "main-win/main-win-cfg-reader.h"
 #include <array>
 #include <filesystem>
-#include <optional>
+#include <tl/optional.hpp>
 
 extern std::filesystem::path ANGBAND_DIR_XTRA_SOUND;
-extern std::optional<CfgData> sound_cfg_data;
+extern tl::optional<CfgData> sound_cfg_data;
 
 void load_sound_prefs();
 void finalize_sound();

--- a/src/main-win/main-win-utils.cpp
+++ b/src/main-win/main-win-utils.cpp
@@ -72,9 +72,9 @@ void open_dir_in_explorer(const std::filesystem::path &path)
  * @param path_dir GetOpenFileNameWに指定する初期フォルダパス。
  * @param path_file 初期選択ファイルパス
  * @param max_name_size 選択ファイルパスの最大長
- * @return 選択されたファイルパス。選択をキャンセルした場合はstd::nullopt。
+ * @return 選択されたファイルパス。選択をキャンセルした場合はtl::nullopt。
  */
-std::optional<std::filesystem::path> get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &path_dir, const std::filesystem::path &path_file, DWORD max_name_size)
+tl::optional<std::filesystem::path> get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &path_dir, const std::filesystem::path &path_file, DWORD max_name_size)
 {
     std::vector<WCHAR> buf(max_name_size);
     const auto path_file_str = path_file.wstring();
@@ -89,8 +89,8 @@ std::optional<std::filesystem::path> get_open_filename(OPENFILENAMEW *ofn, const
     ofn->lpstrInitialDir = path_dir_str.empty() ? nullptr : path_dir_str.data();
 
     if (GetOpenFileNameW(ofn)) {
-        return std::make_optional<std::filesystem::path>(buf.data());
+        return tl::make_optional<std::filesystem::path>(buf.data());
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/main-win/main-win-utils.h
+++ b/src/main-win/main-win-utils.h
@@ -5,9 +5,9 @@
  */
 
 #include <filesystem>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 #include <windows.h>
 
@@ -27,7 +27,7 @@ public:
             this->buf = std::vector<WCHAR>(size + 1);
             if (::MultiByteToWideChar(932, 0, src.data(), src.length(), this->buf->data(), this->buf->size()) == 0) {
                 // fail
-                this->buf = std::nullopt;
+                this->buf = tl::nullopt;
             }
         }
     }
@@ -43,7 +43,7 @@ public:
     }
 
 protected:
-    std::optional<std::vector<WCHAR>> buf;
+    tl::optional<std::vector<WCHAR>> buf;
 };
 
 /*!
@@ -62,7 +62,7 @@ public:
             this->buf = std::vector<char>(size + 1);
             if (::WideCharToMultiByte(932, 0, src, -1, this->buf->data(), this->buf->size(), NULL, NULL) == 0) {
                 // fail
-                this->buf = std::nullopt;
+                this->buf = tl::nullopt;
             }
         }
     }
@@ -78,10 +78,10 @@ public:
     }
 
 protected:
-    std::optional<std::vector<char>> buf;
+    tl::optional<std::vector<char>> buf;
 };
 
 bool is_already_running();
 void save_screen_as_html(HWND hWnd);
 void open_dir_in_explorer(const std::filesystem::path &path);
-std::optional<std::filesystem::path> get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &path_dir, const std::filesystem::path &path_file, DWORD max_name_size);
+tl::optional<std::filesystem::path> get_open_filename(OPENFILENAMEW *ofn, const std::filesystem::path &path_dir, const std::filesystem::path &path_file, DWORD max_name_size);

--- a/src/market/arena-entry.cpp
+++ b/src/market/arena-entry.cpp
@@ -107,7 +107,7 @@ int ArenaEntryList::get_current_entry() const
     return this->current_entry;
 }
 
-std::optional<int> ArenaEntryList::get_defeated_entry() const
+tl::optional<int> ArenaEntryList::get_defeated_entry() const
 {
     return this->defeated_entry;
 }
@@ -207,7 +207,7 @@ void ArenaEntryList::increment_entry()
 void ArenaEntryList::reset_entry()
 {
     this->current_entry = 0;
-    this->defeated_entry = std::nullopt;
+    this->defeated_entry = tl::nullopt;
 }
 
 void ArenaEntryList::set_defeated_entry()
@@ -223,7 +223,7 @@ void ArenaEntryList::load_current_entry(int entry)
 void ArenaEntryList::load_defeated_entry(int entry)
 {
     if (entry < 0) {
-        this->defeated_entry = std::nullopt;
+        this->defeated_entry = tl::nullopt;
         return;
     }
 

--- a/src/market/arena-entry.h
+++ b/src/market/arena-entry.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class ArenaRecord {
@@ -24,7 +24,7 @@ public:
     int get_max_entries() const;
     int get_true_max_entries() const;
     int get_current_entry() const;
-    std::optional<int> get_defeated_entry() const;
+    tl::optional<int> get_defeated_entry() const;
     bool is_player_victor() const;
     bool is_player_true_victor() const;
     const BaseitemKey &get_bi_key() const;
@@ -44,5 +44,5 @@ private:
 
     static ArenaEntryList instance;
     int current_entry = 0; //!< 現在の対戦相手.
-    std::optional<int> defeated_entry; //!< 負けた相手. 無敗ならnullopt. v1.5.0.1以前の敗北済セーブデータは0固定.
+    tl::optional<int> defeated_entry; //!< 負けた相手. 無敗ならnullopt. v1.5.0.1以前の敗北済セーブデータは0固定.
 };

--- a/src/market/arena.cpp
+++ b/src/market/arena.cpp
@@ -20,18 +20,18 @@
 #include "tracking/lore-tracker.h"
 #include "view/display-messages.h"
 #include "world/world.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 /*!
  * @brief 優勝時のメッセージを表示し、賞金を与える
  * @param player_ptr プレイヤーへの参照ポインタ
  * @return まだ優勝していないか、挑戦者モンスターとの戦いではFALSE
  */
-static std::optional<int> process_ostensible_arena_victory()
+static tl::optional<int> process_ostensible_arena_victory()
 {
     auto &entries = ArenaEntryList::get_instance();
     if (!entries.is_player_victor()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     clear_bldg(5, 19);

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1184,7 +1184,7 @@ static int interpret_realm_select_key(int cs, int n, char c)
  * @param n 最後尾の位置
  * @return 領域番号
  */
-static std::optional<ElementRealmType> get_element_realm(PlayerType *player_ptr, ElementRealmType realm, int n)
+static tl::optional<ElementRealmType> get_element_realm(PlayerType *player_ptr, ElementRealmType realm, int n)
 {
     int cs = std::max(0, enum2i(realm) - 1);
     int os = cs;
@@ -1202,7 +1202,7 @@ static std::optional<ElementRealmType> get_element_realm(PlayerType *player_ptr,
         cs = interpret_realm_select_key(cs, n, c);
 
         if (c == 'S') {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         if (c == ' ' || c == '\r' || c == '\n') {
@@ -1251,12 +1251,12 @@ static std::optional<ElementRealmType> get_element_realm(PlayerType *player_ptr,
  * @param player_ptr プレイヤー情報への参照ポインタ
  * @return 領域番号
  */
-std::optional<ElementRealmType> select_element_realm(PlayerType *player_ptr)
+tl::optional<ElementRealmType> select_element_realm(PlayerType *player_ptr)
 {
     clear_from(10);
 
     constexpr auto realm_max = enum2i(ElementRealmType::MAX);
-    auto realm = std::make_optional(ElementRealmType::FIRE);
+    auto realm = tl::make_optional(ElementRealmType::FIRE);
     int row = 16;
     while (1) {
         put_str(
@@ -1435,7 +1435,7 @@ static bool is_target_grid_dark(const FloorType &floor, const Pos2D &pos)
 static bool door_to_darkness(PlayerType *player_ptr, int distance)
 {
     const auto p_pos_orig = player_ptr->get_position();
-    auto p_pos = std::make_optional(player_ptr->get_position());
+    auto p_pos = tl::make_optional(player_ptr->get_position());
     const auto &floor = *player_ptr->current_floor_ptr;
     for (auto i = 0; i < 3; i++) {
         p_pos = point_target(player_ptr);

--- a/src/mind/mind-elementalist.h
+++ b/src/mind/mind-elementalist.h
@@ -2,8 +2,8 @@
 
 #include "effect/attribute-types.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 enum class ElementRealmType {
     NONE = 0,
@@ -30,6 +30,6 @@ void do_cmd_element_browse(PlayerType *player_ptr);
 void display_element_spell_list(PlayerType *player_ptr, int y = 1, int x = 1);
 ProcessResult effect_monster_elemental_genocide(PlayerType *player_ptr, EffectMonster *em_ptr);
 bool has_element_resist(PlayerType *player_ptr, ElementRealmType realm, PLAYER_LEVEL lev);
-std::optional<ElementRealmType> select_element_realm(PlayerType *player_ptr);
+tl::optional<ElementRealmType> select_element_realm(PlayerType *player_ptr);
 void switch_element_racial(PlayerType *player_ptr, rc_type *rc_ptr);
 bool switch_element_execution(PlayerType *player_ptr);

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -169,7 +169,7 @@ bool drop_single_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr, FixedArt
     return create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x);
 }
 
-static std::optional<short> drop_dungeon_final_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr)
+static tl::optional<short> drop_dungeon_final_artifact(PlayerType *player_ptr, MonsterDeath *md_ptr)
 {
     const auto &dungeon = player_ptr->current_floor_ptr->get_dungeon_definition();
     const auto has_reward = dungeon.final_object > 0;
@@ -185,7 +185,7 @@ static std::optional<short> drop_dungeon_final_artifact(PlayerType *player_ptr, 
     }
 
     create_named_art(player_ptr, a_idx, md_ptr->md_y, md_ptr->md_x);
-    return dungeon.final_object ? std::make_optional<short>(bi_id) : std::nullopt;
+    return dungeon.final_object ? tl::make_optional<short>(bi_id) : tl::nullopt;
 }
 
 static void drop_artifacts(PlayerType *player_ptr, MonsterDeath *md_ptr)

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -106,9 +106,9 @@ static void decide_enemy_approch_direction(PlayerType *player_ptr, MONSTER_IDX m
  * Calculate the direction to the next enemy
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx モンスターの参照ID
- * @return 方向が確定した場合移動方向のリスト、接近する敵がそもそもいない場合std::nullopt
+ * @return 方向が確定した場合移動方向のリスト、接近する敵がそもそもいない場合tl::nullopt
  */
-static std::optional<MonsterMovementDirectionList> get_enemy_dir(PlayerType *player_ptr, MONSTER_IDX m_idx)
+static tl::optional<MonsterMovementDirectionList> get_enemy_dir(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
@@ -135,7 +135,7 @@ static std::optional<MonsterMovementDirectionList> get_enemy_dir(PlayerType *pla
         decide_enemy_approch_direction(player_ptr, m_idx, start, plus, &y, &x);
 
         if ((x == 0) && (y == 0)) {
-            return std::nullopt;
+            return tl::nullopt;
         }
     }
 
@@ -185,13 +185,13 @@ static bool random_walk(PlayerType *player_ptr, const MonsterEntity &monster)
  * @brief ペットの移動方向のリストを決定する
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx モンスターID
- * @return ペットであれば移動方向のリスト、そうでなければstd::nullopt
+ * @return ペットであれば移動方向のリスト、そうでなければtl::nullopt
  */
-static std::optional<MonsterMovementDirectionList> decide_pet_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx)
+static tl::optional<MonsterMovementDirectionList> decide_pet_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
     const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
     if (!monster.is_pet()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (const auto mmdl = get_enemy_dir(player_ptr, m_idx)) {
@@ -222,9 +222,9 @@ static std::optional<MonsterMovementDirectionList> decide_pet_movement_direction
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx モンスターID
  * @param aware モンスターがプレイヤーに気付いているならばTRUE、超隠密状態ならばFALSE
- * @return 移動方向のリスト。移動しない場合はstd::nullopt
+ * @return 移動方向のリスト。移動しない場合はtl::nullopt
  */
-std::optional<MonsterMovementDirectionList> decide_monster_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx, bool aware)
+tl::optional<MonsterMovementDirectionList> decide_monster_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx, bool aware)
 {
     const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
     const auto &monrace = monster.get_monrace();

--- a/src/monster-floor/monster-direction.h
+++ b/src/monster-floor/monster-direction.h
@@ -2,8 +2,8 @@
 
 #include "monster-floor/monster-movement-direction-list.h"
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class Direction;
 class PlayerType;
-std::optional<MonsterMovementDirectionList> decide_monster_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx, bool aware);
+tl::optional<MonsterMovementDirectionList> decide_monster_movement_direction(PlayerType *player_ptr, MONSTER_IDX m_idx, bool aware);

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -38,7 +38,7 @@
  * @return 生成成功ならば結果生成位置座標、失敗ならばnullopt
  *
  */
-std::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, const Pos2D &pos, int max_distance)
+tl::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, const Pos2D &pos, int max_distance)
 {
     constexpr auto max_distance_permitted = 10;
     std::vector<Pos2D> places;
@@ -48,7 +48,7 @@ std::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, c
 
     std::vector<int> numbers(max_distance_permitted);
     if (max_distance >= max_distance_permitted) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto p_pos = player_ptr->get_position();
@@ -99,7 +99,7 @@ std::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, c
     }
 
     if (i >= max_distance_permitted) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return places[i];
@@ -111,17 +111,17 @@ std::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, c
  * @param m_idx 増殖するモンスター情報ID
  * @param clone クローン・モンスター処理ならばtrue
  * @param mode 生成オプション
- * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
+ * @return 生成に成功したらモンスターID、失敗したらtl::nullopt
  * @details
  * Note that "reproduction" REQUIRES empty space.
  */
-std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode)
+tl::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     const auto pos = mon_scatter(player_ptr, monster.r_idx, monster.get_position(), 1);
     if (!pos) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (monster.mflag2.has(MonsterConstantFlagType::NOPET)) {
@@ -130,7 +130,7 @@ std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX 
 
     const auto multiplied_m_idx = place_specific_monster(player_ptr, pos->y, pos->x, monster.r_idx, (mode | PM_NO_KAGE | PM_MULTIPLY), m_idx);
     if (!multiplied_m_idx) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (clone || monster.mflag2.has(MonsterConstantFlagType::CLONED)) {
@@ -147,7 +147,7 @@ std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX 
  * @param mode 生成オプション
  * @param summoner_m_idx モンスターの召喚による場合、召喚主のモンスターID
  */
-static void place_monster_group(PlayerType *player_ptr, const Pos2D &pos_center, MonraceId monrace_id, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
+static void place_monster_group(PlayerType *player_ptr, const Pos2D &pos_center, MonraceId monrace_id, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
     const auto &floor = *player_ptr->current_floor_ptr;
@@ -204,10 +204,10 @@ static void place_monster_group(PlayerType *player_ptr, const Pos2D &pos_center,
  * @param r_idx 生成するモンスターの種族ID
  * @param mode 生成オプション
  * @param summoner_m_idx モンスターの召喚による場合、召喚主のモンスターID
- * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
+ * @return 生成に成功したらモンスターID、失敗したらtl::nullopt
  * @details 護衛も一緒に生成する
  */
-std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
+tl::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
     const Pos2D pos(y, x);
     const auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
@@ -217,7 +217,7 @@ std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITI
 
     const auto m_idx = place_monster_one(player_ptr, y, x, r_idx, mode, summoner_m_idx);
     if (!m_idx) {
-        return std::nullopt;
+        return tl::nullopt;
     }
     if (!(mode & PM_ALLOW_GROUP)) {
         return m_idx;
@@ -283,9 +283,9 @@ std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITI
  * @param y 生成地点y座標
  * @param x 生成地点x座標
  * @param mode 生成オプション
- * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
+ * @return 生成に成功したらモンスターID、失敗したらtl::nullopt
  */
-std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode)
+tl::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode)
 {
     const Pos2D pos(y, x);
     const auto &floor = *player_ptr->current_floor_ptr;
@@ -296,7 +296,7 @@ std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION
         monrace_id = get_mon_num(player_ptr, 0, floor.monster_level, PM_NONE);
     } while ((mode & PM_NO_QUEST) && monraces.get_monrace(monrace_id).misc_flags.has(MonsterMiscType::NO_QUEST));
     if (!MonraceList::is_valid(monrace_id)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto try_become_jural = one_in_(5) || !floor.is_underground();
@@ -310,14 +310,14 @@ std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION
     return place_specific_monster(player_ptr, y, x, monrace_id, mode);
 }
 
-static std::optional<MonraceId> select_horde_leader_r_idx(PlayerType *player_ptr)
+static tl::optional<MonraceId> select_horde_leader_r_idx(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &monraces = MonraceList::get_instance();
     for (auto attempts = 1000; attempts > 0; --attempts) {
         const auto monrace_id = get_mon_num(player_ptr, 0, floor.monster_level, PM_NONE);
         if (!MonraceList::is_valid(monrace_id)) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         if (monraces.get_monrace(monrace_id).kind_flags.has(MonsterKindType::UNIQUE)) {
@@ -331,7 +331,7 @@ static std::optional<MonraceId> select_horde_leader_r_idx(PlayerType *player_ptr
         return monrace_id;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!

--- a/src/monster-floor/monster-generator.h
+++ b/src/monster-floor/monster-generator.h
@@ -2,17 +2,17 @@
 
 #include "system/angband.h"
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum summon_type : int;
 enum class MonraceId : short;
 class PlayerType;
-using summon_specific_pf = std::optional<MONSTER_IDX>(PlayerType *, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS, std::optional<MONSTER_IDX>);
+using summon_specific_pf = tl::optional<MONSTER_IDX>(PlayerType *, POSITION, POSITION, DEPTH, summon_type, BIT_FLAGS, tl::optional<MONSTER_IDX>);
 
-std::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, const Pos2D &pos, int max_distance);
-std::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode);
-std::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
-std::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
+tl::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, const Pos2D &pos, int max_distance);
+tl::optional<MONSTER_IDX> multiply_monster(PlayerType *player_ptr, MONSTER_IDX m_idx, bool clone, BIT_FLAGS mode);
+tl::optional<MONSTER_IDX> place_specific_monster(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx = tl::nullopt);
+tl::optional<MONSTER_IDX> place_random_monster(PlayerType *player_ptr, POSITION y, POSITION x, BIT_FLAGS mode);
 bool alloc_horde(PlayerType *player_ptr, POSITION y, POSITION x, summon_specific_pf summon_specific);
 bool alloc_guardian(PlayerType *player_ptr, bool def_val);
 bool alloc_monster(PlayerType *player_ptr, int min_dis, BIT_FLAGS mode, summon_specific_pf summon_specific, int max_dis = 65535);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -512,7 +512,7 @@ static bool can_speak(const MonraceDefinition &ap_r_ref, MonsterSpeakType mon_sp
     return can_speak_all || can_speak_specific;
 }
 
-static std::optional<MonsterMessageType> get_speak_type(const MonsterEntity &monster)
+static tl::optional<MonsterMessageType> get_speak_type(const MonsterEntity &monster)
 {
     const auto &ap_monrace = monster.get_appearance_monrace();
     if (monster.is_fearful() && can_speak(ap_monrace, MonsterSpeakType::SPEAK_FEAR)) {
@@ -531,7 +531,7 @@ static std::optional<MonsterMessageType> get_speak_type(const MonsterEntity &mon
         return MonsterMessageType::SPEAK_BATTLE;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!

--- a/src/monster-floor/monster-safety-hiding.cpp
+++ b/src/monster-floor/monster-safety-hiding.cpp
@@ -90,7 +90,7 @@ static coordinate_candidate sweep_safe_coordinate(PlayerType *player_ptr, MONSTE
  *\n
  * Return TRUE if a safe location is available.\n
  */
-std::optional<Pos2D> find_safety(PlayerType *player_ptr, short m_idx)
+tl::optional<Pos2D> find_safety(PlayerType *player_ptr, short m_idx)
 {
     for (auto d = 1; d < 10; d++) {
         const auto candidate = sweep_safe_coordinate(player_ptr, m_idx, DIST_OFFSETS[d], d);
@@ -101,7 +101,7 @@ std::optional<Pos2D> find_safety(PlayerType *player_ptr, short m_idx)
         return candidate.pos;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!
@@ -144,7 +144,7 @@ static void sweep_hiding_candidate(
  * @param m_idx モンスターの参照ID
  * @return 有効なマスがあった場合、その座標。なかったらnullopt
  */
-std::optional<Pos2D> find_hiding(PlayerType *player_ptr, short m_idx)
+tl::optional<Pos2D> find_hiding(PlayerType *player_ptr, short m_idx)
 {
     const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
     coordinate_candidate candidate;
@@ -158,5 +158,5 @@ std::optional<Pos2D> find_hiding(PlayerType *player_ptr, short m_idx)
         return candidate.pos;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/monster-floor/monster-safety-hiding.h
+++ b/src/monster-floor/monster-safety-hiding.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<Pos2D> find_safety(PlayerType *player_ptr, short m_idx);
-std::optional<Pos2D> find_hiding(PlayerType *player_ptr, short m_idx);
+tl::optional<Pos2D> find_safety(PlayerType *player_ptr, short m_idx);
+tl::optional<Pos2D> find_hiding(PlayerType *player_ptr, short m_idx);

--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -35,18 +35,18 @@ static bool is_dead_summoning(summon_type type)
  * @param type 召喚種別
  * @param mode 生成オプション
  * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
- * @return 召喚に成功したらモンスターID、失敗したらstd::nullopt
+ * @return 召喚に成功したらモンスターID、失敗したらtl::nullopt
  */
-std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
+tl::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     if (floor.inside_arena) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto pos = mon_scatter(player_ptr, MonraceList::empty_id(), { y1, x1 }, 2);
     if (!pos) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto hook = floor.get_monrace_hook_terrain_at(*pos);
@@ -56,7 +56,7 @@ std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, 
     const auto dlev = floor.is_underground() ? floor.get_level() : WildernessGrids::get_instance().get_player_grid().get_level();
     const auto r_idx = get_mon_num(player_ptr, 0, (dlev + lev) / 2 + 5, mode);
     if (!MonraceList::is_valid(r_idx)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (is_dead_summoning(type)) {
@@ -65,7 +65,7 @@ std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, 
 
     auto summoned_m_idx = place_specific_monster(player_ptr, pos->y, pos->x, r_idx, mode, summoner_m_idx);
     if (!summoned_m_idx) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     bool notice = false;
@@ -97,9 +97,9 @@ std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, 
  * @param ox 目標地点x座標
  * @param r_idx 生成するモンスター種族ID
  * @param mode 生成オプション
- * @return 召喚に成功したらモンスターID、失敗したらstd::nullopt
+ * @return 召喚に成功したらモンスターID、失敗したらtl::nullopt
  */
-std::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonraceId r_idx, BIT_FLAGS mode)
+tl::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonraceId r_idx, BIT_FLAGS mode)
 {
     if (!MonraceList::is_valid(r_idx) || (r_idx >= static_cast<MonraceId>(MonraceList::get_instance().size()))) {
         return false;
@@ -114,6 +114,6 @@ std::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER
         return false;
     }
 
-    const auto summon_who = is_monster(src_idx) ? std::make_optional(src_idx) : std::nullopt;
+    const auto summon_who = is_monster(src_idx) ? tl::make_optional(src_idx) : tl::nullopt;
     return place_specific_monster(player_ptr, pos->y, pos->x, r_idx, (mode | PM_NO_KAGE), summon_who);
 }

--- a/src/monster-floor/monster-summon.h
+++ b/src/monster-floor/monster-summon.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum summon_type : int;
 enum class MonraceId : short;
 class PlayerType;
-std::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
-std::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonraceId r_idx, BIT_FLAGS mode);
+tl::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, POSITION x1, DEPTH lev, summon_type type, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx = tl::nullopt);
+tl::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonraceId r_idx, BIT_FLAGS mode);

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -79,7 +79,7 @@ class MonsterMoveGridDecider {
 public:
     MonsterMoveGridDecider() = default;
     virtual ~MonsterMoveGridDecider() = default;
-    virtual std::optional<Pos2D> decide_move_grid() const = 0;
+    virtual tl::optional<Pos2D> decide_move_grid() const = 0;
 
     /*!
      * @brief モンスターの移動先を決定する
@@ -158,14 +158,14 @@ public:
     {
     }
 
-    std::optional<Pos2D> decide_move_grid() const override
+    tl::optional<Pos2D> decide_move_grid() const override
     {
         const auto &floor = *this->player_ptr->current_floor_ptr;
         const auto &monster = floor.m_list[this->m_idx];
         const auto pos_target = monster.get_target_position();
         const auto t_m_idx = floor.get_grid(pos_target).m_idx;
         if (t_m_idx <= 0) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         const auto is_enemies = monster.is_hostile_to_melee(floor.m_list[t_m_idx]);
@@ -176,7 +176,7 @@ public:
             return pos_target;
         }
 
-        return std::nullopt;
+        return tl::nullopt;
     }
 
 private:
@@ -195,7 +195,7 @@ public:
     {
     }
 
-    std::optional<Pos2D> decide_move_grid() const override
+    tl::optional<Pos2D> decide_move_grid() const override
     {
         const auto &floor = *this->player_ptr->current_floor_ptr;
         const auto &monrace = floor.m_list[this->m_idx].get_monrace();
@@ -223,7 +223,7 @@ public:
         }
 
         if (room >= (8 * (this->player_ptr->chp + this->player_ptr->csp)) / (this->player_ptr->mhp + this->player_ptr->msp)) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         return find_hiding(this->player_ptr, this->m_idx);
@@ -245,7 +245,7 @@ public:
     {
     }
 
-    std::optional<Pos2D> decide_move_grid() const override
+    tl::optional<Pos2D> decide_move_grid() const override
     {
         const auto &floor = *this->player_ptr->current_floor_ptr;
         const auto &monster = floor.m_list[this->m_idx];
@@ -288,7 +288,7 @@ public:
     {
     }
 
-    std::optional<Pos2D> decide_move_grid() const override
+    tl::optional<Pos2D> decide_move_grid() const override
     {
         const auto &floor = *this->player_ptr->current_floor_ptr;
         const auto &monster = floor.m_list[this->m_idx];
@@ -296,7 +296,7 @@ public:
         const auto p_pos = this->player_ptr->get_position();
         const auto m_pos = monster.get_position();
         if (projectable(floor, p_pos, m_pos, p_pos)) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         const auto gf = monrace.get_grid_flow_type();
@@ -310,7 +310,7 @@ public:
         const auto can_kill_wall = monrace.feature_flags.has(MonsterFeatureType::KILL_WALL) && !monster.is_riding();
 
         auto best = 999;
-        std::optional<Pos2D> pos_move;
+        tl::optional<Pos2D> pos_move;
         for (const auto &d : Direction::directions_8_reverse()) {
             const auto pos_neighbor = m_pos + d.vec();
             if (!floor.contains(pos_neighbor, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
@@ -320,7 +320,7 @@ public:
             // プレイヤーに隣接している場合最初のprojectableで除外されるため
             // ここで判定する必要はないはずだが、元のコードで判定しているので一応残しておく
             if (p_pos == pos_neighbor) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto &grid = floor.get_grid(pos_neighbor);
@@ -371,7 +371,7 @@ public:
     {
     }
 
-    std::optional<Pos2D> decide_move_grid() const override
+    tl::optional<Pos2D> decide_move_grid() const override
     {
         const auto &floor = *this->player_ptr->current_floor_ptr;
         const auto &monster = floor.m_list[this->m_idx];
@@ -380,7 +380,7 @@ public:
         const auto m_pos = monster.get_position();
 
         auto best = 999;
-        std::optional<Pos2D> pos_move;
+        tl::optional<Pos2D> pos_move;
         for (const auto &d : Direction::directions_8_reverse()) {
             const auto pos_neighbor = m_pos + d.vec();
             if (!floor.contains(pos_neighbor, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
@@ -417,7 +417,7 @@ public:
     {
     }
 
-    std::optional<Pos2D> decide_move_grid() const override
+    tl::optional<Pos2D> decide_move_grid() const override
     {
         const auto &floor = *this->player_ptr->current_floor_ptr;
         const auto &monster = floor.m_list[this->m_idx];
@@ -425,7 +425,7 @@ public:
         const auto m_pos = monster.get_position();
 
         auto best = 0;
-        std::optional<Pos2D> pos_move;
+        tl::optional<Pos2D> pos_move;
         for (const auto &d : Direction::directions_8_reverse()) {
             const auto pos_neighbor = m_pos + d.vec();
             if (!floor.contains(pos_neighbor, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
@@ -517,10 +517,10 @@ MonsterSweepGrid::MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx)
 
 /*!
  * @brief モンスターの移動方向のリストを返す
- * @return 移動方向のリスト。移動できない場合はstd::nullopt
+ * @return 移動方向のリスト。移動できない場合はtl::nullopt
  * @todo 分割したいが条件が多すぎて適切な関数名と詳細処理を追いきれない……
  */
-std::optional<MonsterMovementDirectionList> MonsterSweepGrid::get_movable_grid()
+tl::optional<MonsterMovementDirectionList> MonsterSweepGrid::get_movable_grid()
 {
     const auto deciders = MonsterMoveGridDecidersFactory::create_deciders(this->player_ptr, this->m_idx);
     auto pos_move = MonsterMoveGridDecider::evalute_deciders(deciders, this->player_ptr->get_position());

--- a/src/monster-floor/monster-sweep-grid.h
+++ b/src/monster-floor/monster-sweep-grid.h
@@ -3,7 +3,7 @@
 #include "monster-floor/monster-movement-direction-list.h"
 #include "system/angband.h"
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 #include <utility>
 
 class Direction;
@@ -13,5 +13,5 @@ public:
     MonsterSweepGrid(PlayerType *player_ptr, MONSTER_IDX m_idx);
     PlayerType *player_ptr;
     MONSTER_IDX m_idx;
-    std::optional<MonsterMovementDirectionList> get_movable_grid();
+    tl::optional<MonsterMovementDirectionList> get_movable_grid();
 };

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -210,9 +210,9 @@ static void warn_unique_generation(PlayerType *player_ptr, MonraceId r_idx)
  * @param r_idx 生成モンスター種族
  * @param mode 生成オプション
  * @param summoner_m_idx モンスターの召喚による場合、召喚主のモンスターID
- * @return 生成に成功したらモンスターID、失敗したらstd::nullopt
+ * @return 生成に成功したらモンスターID、失敗したらtl::nullopt
  */
-std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx)
+tl::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     const Pos2D pos(y, x);
@@ -220,15 +220,15 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y,
     auto &monrace = MonraceList::get_instance().get_monrace(r_idx);
     const auto &world = AngbandWorld::get_instance();
     if (world.is_wild_mode() || !floor.contains(pos) || !MonraceList::is_valid(r_idx)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (none_bits(mode, PM_IGNORE_TERRAIN) && (grid.has(TerrainCharacteristics::PATTERN) || !monster_can_enter(player_ptr, pos.y, pos.x, monrace, 0))) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (!check_unique_placeable(floor, r_idx, mode) || !check_quest_placeable(floor, r_idx) || !check_procection_rune(player_ptr, r_idx, pos)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     msg_format_wizard(player_ptr, CHEAT_MONSTER, _("%s(Lv%d)を生成しました。", "%s(Lv%d) was generated."), monrace.name.data(), monrace.level);
@@ -239,7 +239,7 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y,
     const auto m_idx = floor.pop_empty_index_monster();
     grid.m_idx = m_idx;
     if (!grid.has_monster()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto &monster = floor.m_list[grid.m_idx];
@@ -395,5 +395,5 @@ std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y,
 
     warn_unique_generation(player_ptr, r_idx);
     activate_explosive_rune(player_ptr, pos, new_monrace);
-    return monster.is_valid() ? std::make_optional(grid.m_idx) : std::nullopt;
+    return monster.is_valid() ? tl::make_optional(grid.m_idx) : tl::nullopt;
 }

--- a/src/monster-floor/one-monster-placer.h
+++ b/src/monster-floor/one-monster-placer.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class MonraceId : short;
 class PlayerType;
-std::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+tl::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, POSITION x, MonraceId r_idx, BIT_FLAGS mode, tl::optional<MONSTER_IDX> summoner_m_idx = tl::nullopt);

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -14,10 +14,10 @@
 #include "util/bit-flags-calculator.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
-#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 
 // @todo 性別をEnumFlags に切り替えたら引数の型も変えること.
 static int get_monster_pronoun_kind(const MonraceDefinition &monrace, const bool pron)
@@ -90,12 +90,12 @@ static std::string get_monster_personal_pronoun(const int kind, const BIT_FLAGS 
     }
 }
 
-static std::optional<std::string> decide_monster_personal_pronoun(const MonsterEntity &monster, const BIT_FLAGS mode)
+static tl::optional<std::string> decide_monster_personal_pronoun(const MonsterEntity &monster, const BIT_FLAGS mode)
 {
     const auto seen = any_bits(mode, MD_ASSUME_VISIBLE) || (none_bits(mode, MD_ASSUME_HIDDEN) && monster.ml);
     const auto pron = (seen && any_bits(mode, MD_PRON_VISIBLE)) || (!seen && any_bits(mode, MD_PRON_HIDDEN));
     if (seen && !pron) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto &monrace = monster.get_appearance_monrace();
@@ -103,12 +103,12 @@ static std::optional<std::string> decide_monster_personal_pronoun(const MonsterE
     return get_monster_personal_pronoun(kind, mode);
 }
 
-static std::optional<std::string> get_monster_self_pronoun(const MonsterEntity &monster, const BIT_FLAGS mode)
+static tl::optional<std::string> get_monster_self_pronoun(const MonsterEntity &monster, const BIT_FLAGS mode)
 {
     const auto &monrace = monster.get_appearance_monrace();
     constexpr BIT_FLAGS self = MD_POSSESSIVE | MD_OBJECTIVE;
     if (!match_bits(mode, self, self)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (monrace.is_female()) {
@@ -161,12 +161,12 @@ static std::string replace_monster_name_undefined(std::string_view name)
 }
 #endif
 
-static std::optional<std::string> get_fake_monster_name(const PlayerType &player, const MonsterEntity &monster, const std::string &name, const BIT_FLAGS mode)
+static tl::optional<std::string> get_fake_monster_name(const PlayerType &player, const MonsterEntity &monster, const std::string &name, const BIT_FLAGS mode)
 {
     const auto &monrace = monster.get_appearance_monrace();
     const auto is_hallucinated = player.effects()->hallucination().is_hallucinated();
     if (monrace.kind_flags.has_not(MonsterKindType::UNIQUE) || (is_hallucinated && none_bits(mode, MD_IGNORE_HALLU))) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON) && none_bits(mode, MD_TRUE_NAME)) {

--- a/src/monster/monster-list.cpp
+++ b/src/monster/monster-list.cpp
@@ -157,7 +157,7 @@ MonraceId get_mon_num(PlayerType *player_ptr, int min_level, int max_level, uint
     return *it;
 }
 
-static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, short m_idx, short terrain_id, std::optional<short> summoner_m_idx)
+static tl::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, short m_idx, short terrain_id, tl::optional<short> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
@@ -180,7 +180,7 @@ static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, s
 
     const auto new_monrace_id = get_mon_num(player_ptr, 0, level, PM_CHAMELEON);
     if (!MonraceList::is_valid(new_monrace_id)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return new_monrace_id;
@@ -193,7 +193,7 @@ static std::optional<MonraceId> polymorph_of_chameleon(PlayerType *player_ptr, s
  * @param grid カメレオンの足元の地形
  * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
  */
-void choose_chameleon_polymorph(PlayerType *player_ptr, short m_idx, short terrain_id, std::optional<short> summoner_m_idx)
+void choose_chameleon_polymorph(PlayerType *player_ptr, short m_idx, short terrain_id, tl::optional<short> summoner_m_idx)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];

--- a/src/monster/monster-list.h
+++ b/src/monster/monster-list.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class MonraceId : short;
 class FloorType;
 class MonraceDefinition;
 class PlayerType;
 MonraceId get_mon_num(PlayerType *player_ptr, int min_level, int max_level, uint32_t mode);
-void choose_chameleon_polymorph(PlayerType *player_ptr, short m_idx, short terrain_id, std::optional<short> summoner_m_idx = std::nullopt);
+void choose_chameleon_polymorph(PlayerType *player_ptr, short m_idx, short terrain_id, tl::optional<short> summoner_m_idx = tl::nullopt);
 int get_monster_crowd_number(const FloorType &floor, short m_idx);

--- a/src/monster/monster-pain-describer.cpp
+++ b/src/monster/monster-pain-describer.cpp
@@ -189,13 +189,13 @@ MonsterPainDescriber::MonsterPainDescriber(MonraceId r_idx, char symbol, std::st
  * @param dam モンスターが受けたダメージ
  * @return std::string ダメージを受けたモンスターの様子を表す文字列。表示すべき様子が無い場合はnullopt。
  */
-std::optional<std::string> MonsterPainDescriber::describe(int now_hp, int took_damage, bool visible)
+tl::optional<std::string> MonsterPainDescriber::describe(int now_hp, int took_damage, bool visible)
 {
     if (took_damage == 0) {
         if (visible) {
             return format(_("%s^はダメージを受けていない。", "%s^ is unharmed."), this->m_name.data());
         }
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto oldhp = now_hp + took_damage;
@@ -210,5 +210,5 @@ std::optional<std::string> MonsterPainDescriber::describe(int now_hp, int took_d
         return format("%s^%s", this->m_name.data(), msg.data());
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/monster/monster-pain-describer.h
+++ b/src/monster/monster-pain-describer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 
 class PlayerType;
 class MonsterEntity;
@@ -11,7 +11,7 @@ class MonsterPainDescriber {
 public:
     MonsterPainDescriber(MonraceId r_idx, char symbol, std::string_view m_name);
 
-    std::optional<std::string> describe(int now_hp, int took_damage, bool visible);
+    tl::optional<std::string> describe(int now_hp, int took_damage, bool visible);
 
 private:
     MonraceId r_idx;

--- a/src/monster/monster-processor-util.cpp
+++ b/src/monster/monster-processor-util.cpp
@@ -81,12 +81,12 @@ MonsterMovementDirectionList get_enemy_approch_direction(MONSTER_IDX m_idx, cons
 /*!
  * @brief MonsterSweepGrid::get_movable_grid() における移動の方向を取得する
  * @param vec 移動方向のベクトル
- * @return モンスターの移動方向。vec が (0, 0) の場合は std::nullopt を返す
+ * @return モンスターの移動方向。vec が (0, 0) の場合は tl::nullopt を返す
  */
-std::optional<MonsterMovementDirectionList> get_moves_val(MONSTER_IDX m_idx, const Pos2DVec &vec)
+tl::optional<MonsterMovementDirectionList> get_moves_val(MONSTER_IDX m_idx, const Pos2DVec &vec)
 {
     if (vec == Pos2DVec(0, 0)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const Pos2DVec vec_abs(std::abs(vec.y), std::abs(vec.x));

--- a/src/monster/monster-processor-util.h
+++ b/src/monster/monster-processor-util.h
@@ -17,7 +17,7 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 struct turn_flags {
     bool see_m;
@@ -72,4 +72,4 @@ turn_flags *init_turn_flags(bool is_riding, turn_flags *turn_flags_ptr);
 
 class Direction;
 MonsterMovementDirectionList get_enemy_approch_direction(MONSTER_IDX m_idx, const Pos2DVec &vec);
-std::optional<MonsterMovementDirectionList> get_moves_val(MONSTER_IDX m_idx, const Pos2DVec &vec);
+tl::optional<MonsterMovementDirectionList> get_moves_val(MONSTER_IDX m_idx, const Pos2DVec &vec);

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -4,7 +4,7 @@
 #include "system/enums/monrace/monrace-hook-types.h"
 #include "util/point-2d.h"
 #include <functional>
-#include <optional>
+#include <tl/optional.hpp>
 
 enum summon_type : int;
 enum class MonraceId : short;
@@ -14,7 +14,7 @@ void get_mon_num_prep_escort(PlayerType *player_ptr, MonraceId escorted_monrace_
 
 class SummonCondition {
 public:
-    SummonCondition(summon_type type, BIT_FLAGS mode, const std::optional<short> &summoner_m_idx, MonraceHookTerrain hook)
+    SummonCondition(summon_type type, BIT_FLAGS mode, const tl::optional<short> &summoner_m_idx, MonraceHookTerrain hook)
         : type(type)
         , mode(mode)
         , summoner_m_idx(summoner_m_idx)
@@ -24,7 +24,7 @@ public:
 
     summon_type type;
     BIT_FLAGS mode;
-    std::optional<short> summoner_m_idx;
+    tl::optional<short> summoner_m_idx;
     MonraceHookTerrain hook;
 };
 
@@ -39,7 +39,7 @@ public:
      * @param is_unique ユニークであるか否か (実質、カメレオンの王であるか否か)
      * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
      */
-    ChameleonTransformation(short m_idx, short terrain_id, bool is_unique, const std::optional<short> &summoner_m_idx)
+    ChameleonTransformation(short m_idx, short terrain_id, bool is_unique, const tl::optional<short> &summoner_m_idx)
         : m_idx(m_idx)
         , terrain_id(terrain_id)
         , is_unique(is_unique)
@@ -50,7 +50,7 @@ public:
     short m_idx;
     short terrain_id;
     bool is_unique;
-    std::optional<short> summoner_m_idx;
+    tl::optional<short> summoner_m_idx;
 };
 void get_mon_num_prep_chameleon(PlayerType *player_ptr, const ChameleonTransformation &ct);
 void get_mon_num_prep_bounty(PlayerType *player_ptr);

--- a/src/mspell/mspell-lite.cpp
+++ b/src/mspell/mspell-lite.cpp
@@ -24,7 +24,7 @@
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 /*!
  * @brief モンスターがプレイヤーにダメージを与えるための最適な座標を算出する
@@ -35,7 +35,7 @@
  * @param checker 射線判定の振り分け
  * @return 有効な座標があった場合はその座標、なかったらnullopt
  */
-static std::optional<Pos2D> adjacent_grid_check(PlayerType *player_ptr, const MonsterEntity &monster, const Pos2D &pos, TerrainCharacteristics tc)
+static tl::optional<Pos2D> adjacent_grid_check(PlayerType *player_ptr, const MonsterEntity &monster, const Pos2D &pos, TerrainCharacteristics tc)
 {
     constexpr std::array<std::array<int, 8>, 4> directions = {
         {
@@ -83,7 +83,7 @@ static std::optional<Pos2D> adjacent_grid_check(PlayerType *player_ptr, const Mo
         }
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 void decide_lite_range(PlayerType *player_ptr, msa_type *msa_ptr)

--- a/src/net/http-client.cpp
+++ b/src/net/http-client.cpp
@@ -12,7 +12,7 @@ namespace {
 
     constexpr auto HTTP_CONNECTION_TIMEOUT = 10; //!< HTTP接続タイムアウト時間(秒)
 
-    void setup_http_option(libcurl::EasySession &session, const std::optional<std::string> &user_agent)
+    void setup_http_option(libcurl::EasySession &session, const tl::optional<std::string> &user_agent)
     {
         if (user_agent) {
             session.setopt(CURLOPT_USERAGENT, user_agent->data());
@@ -25,17 +25,17 @@ namespace {
 
     class GetRequest {
     public:
-        GetRequest(const std::string &url, const std::optional<std::string> &user_agent = {})
+        GetRequest(const std::string &url, const tl::optional<std::string> &user_agent = {})
             : url(url)
             , user_agent(user_agent)
         {
         }
 
-        std::optional<int> perform()
+        tl::optional<int> perform()
         {
             libcurl::EasySession session;
             if (!session.is_valid()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             session.common_setup(this->url, HTTP_CONNECTION_TIMEOUT);
@@ -50,7 +50,7 @@ namespace {
             }
 
             if (!session.perform()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             long status;
@@ -63,7 +63,7 @@ namespace {
 
     private:
         std::string url;
-        std::optional<std::string> user_agent;
+        tl::optional<std::string> user_agent;
     };
 }
 
@@ -71,9 +71,9 @@ namespace {
  * @brief HTTP GETリクエストを送信する
  * @param url リクエストの送信先URL
  * @param progress_handler 進捗状況を受け取るコールバック関数
- * @return 送信に成功した場合Responseオブジェクト、失敗した場合std::nullopt
+ * @return 送信に成功した場合Responseオブジェクト、失敗した場合tl::nullopt
  */
-std::optional<Response> Client::get(const std::string &url, GetRequestProgressHandler progress_handler)
+tl::optional<Response> Client::get(const std::string &url, GetRequestProgressHandler progress_handler)
 {
     Response response{};
 
@@ -86,11 +86,11 @@ std::optional<Response> Client::get(const std::string &url, GetRequestProgressHa
 
     const auto status_opt = request.perform();
     if (!status_opt) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     response.status = *status_opt;
-    return std::make_optional(std::move(response));
+    return tl::make_optional(std::move(response));
 }
 
 /*!
@@ -101,9 +101,9 @@ std::optional<Response> Client::get(const std::string &url, GetRequestProgressHa
  * @param url リクエストの送信先URL
  * @param path ファイルの保存先パス
  * @param progress_handler 進捗状況を受け取るコールバック関数
- * @return 送信に成功した場合Responseオブジェクト、失敗した場合std::nullopt
+ * @return 送信に成功した場合Responseオブジェクト、失敗した場合tl::nullopt
  */
-std::optional<Response> Client::get(const std::string &url, const std::filesystem::path &path, GetRequestProgressHandler progress_handler)
+tl::optional<Response> Client::get(const std::string &url, const std::filesystem::path &path, GetRequestProgressHandler progress_handler)
 {
     std::ofstream ofs(path, std::ios::binary);
 
@@ -116,7 +116,7 @@ std::optional<Response> Client::get(const std::string &url, const std::filesyste
 
     const auto status_opt = request.perform();
     if (!status_opt) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return Response{ *status_opt, path.string() };
@@ -127,16 +127,16 @@ std::optional<Response> Client::get(const std::string &url, const std::filesyste
  * @param url リクエストの送信先URL
  * @param post_data POSTデータ本体
  * @param media_type POSTデータのメディアタイプ(Content-Typeヘッダの内容)
- * @return 送信に成功した場合Responseオブジェクト、失敗した場合std::nullopt
+ * @return 送信に成功した場合Responseオブジェクト、失敗した場合tl::nullopt
  */
-std::optional<Response> Client::post(const std::string &url, const std::string &post_data, const std::string &media_type)
+tl::optional<Response> Client::post(const std::string &url, const std::string &post_data, const std::string &media_type)
 {
     libcurl::EasySession session;
     libcurl::SList headers;
     headers.append(format("Content-Type: %s", media_type.data()));
 
     if (!session.is_valid() || !headers.is_valid()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     session.common_setup(url, HTTP_CONNECTION_TIMEOUT);
@@ -160,11 +160,11 @@ std::optional<Response> Client::post(const std::string &url, const std::string &
     session.receiver_setup(std::move(receiver));
 
     if (!session.perform()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     session.getinfo(CURLINFO_RESPONSE_CODE, &response.status);
-    return std::make_optional(std::move(response));
+    return tl::make_optional(std::move(response));
 }
 
 }

--- a/src/net/http-client.h
+++ b/src/net/http-client.h
@@ -3,8 +3,8 @@
 #include "system/angband.h"
 #include <filesystem>
 #include <functional>
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 #if !defined(DISABLE_NET)
 
@@ -30,11 +30,11 @@ public:
      */
     using GetRequestProgressHandler = std::function<bool(Progress)>;
 
-    std::optional<Response> get(const std::string &url, GetRequestProgressHandler progress_handler = {});
-    std::optional<Response> get(const std::string &url, const std::filesystem::path &path, GetRequestProgressHandler progress_handler = {});
-    std::optional<Response> post(const std::string &url, const std::string &post_data, const std::string &media_type);
+    tl::optional<Response> get(const std::string &url, GetRequestProgressHandler progress_handler = {});
+    tl::optional<Response> get(const std::string &url, const std::filesystem::path &path, GetRequestProgressHandler progress_handler = {});
+    tl::optional<Response> post(const std::string &url, const std::string &post_data, const std::string &media_type);
 
-    std::optional<std::string> user_agent;
+    tl::optional<std::string> user_agent;
 };
 
 }

--- a/src/object-enchant/activation-info-table.cpp
+++ b/src/object-enchant/activation-info-table.cpp
@@ -48,13 +48,13 @@ const std::vector<ActivationType> activation_info = {
     { "CAST_BA_STAR", RandomArtActType::CAST_BA_STAR, 70, 7500, 100, 0, _("スター・ボール・ダスト(150)", "cast star balls (150)") },
     { "BLADETURNER", RandomArtActType::BLADETURNER, 80, 20000, 80, 0,
         _("エレメントのブレス(300), 士気高揚、祝福、耐性", "breathe elements (300), hero, bless, and resistance") },
-    { "BR_FIRE", RandomArtActType::BR_FIRE, 50, 5000, std::nullopt, 0, _("火炎のブレス (200)", "fire breath (200)") },
-    { "BR_COLD", RandomArtActType::BR_COLD, 50, 5000, std::nullopt, 0, _("冷気のブレス (200)", "cold breath (200)") },
+    { "BR_FIRE", RandomArtActType::BR_FIRE, 50, 5000, tl::nullopt, 0, _("火炎のブレス (200)", "fire breath (200)") },
+    { "BR_COLD", RandomArtActType::BR_COLD, 50, 5000, tl::nullopt, 0, _("冷気のブレス (200)", "cold breath (200)") },
     { "BR_DRAGON", RandomArtActType::BR_DRAGON, 70, 10000, 30, 0, "" /* built by item_activation_dragon_breath() */ },
     { "CONFUSE", RandomArtActType::CONFUSE, 10, 500, 10, 0, _("パニック・モンスター", "confuse monster") },
     { "SLEEP", RandomArtActType::SLEEP, 10, 750, 15, 0, _("周囲のモンスターを眠らせる", "sleep nearby monsters") },
     { "QUAKE", RandomArtActType::QUAKE, 30, 600, 20, 0, _("地震", "earthquake") },
-    { "TERROR", RandomArtActType::TERROR, 20, 2500, std::nullopt, 0, _("恐慌", "terror") },
+    { "TERROR", RandomArtActType::TERROR, 20, 2500, tl::nullopt, 0, _("恐慌", "terror") },
     { "TELE_AWAY", RandomArtActType::TELE_AWAY, 20, 2000, 15, 0, _("テレポート・アウェイ", "teleport away") },
     { "BANISH_EVIL", RandomArtActType::BANISH_EVIL, 40, 2000, 250, 0, _("邪悪消滅", "banish evil") },
     { "GENOCIDE", RandomArtActType::GENOCIDE, 50, 10000, 500, 0, _("抹殺", "genocide") },
@@ -138,7 +138,7 @@ const std::vector<ActivationType> activation_info = {
     { "CAST_OFF", RandomArtActType::CAST_OFF, 30, 15000, 100, 0, _("脱衣と小宇宙燃焼", "cast it off and cosmic heroism") },
     { "FISHING", RandomArtActType::FISHING, 0, 100, 0, 0, _("釣りをする", "fishing") },
     { "INROU", RandomArtActType::INROU, 40, 15000, 150, 150, _("例のアレ", "reveal your identity") },
-    { "MURAMASA", RandomArtActType::MURAMASA, 0, 0, std::nullopt, 0, _("腕力の上昇", "increase STR") },
+    { "MURAMASA", RandomArtActType::MURAMASA, 0, 0, tl::nullopt, 0, _("腕力の上昇", "increase STR") },
     { "BLOODY_MOON", RandomArtActType::BLOODY_MOON, 0, 0, 3333, 0, _("属性変更", "change zokusei") },
 
     { "CRIMSON", RandomArtActType::CRIMSON, 0, 50000, 15, 0, _("ファイア！", "fire!") },
@@ -157,14 +157,14 @@ const std::vector<ActivationType> activation_info = {
     { "CAPTURE_MONSTER", RandomArtActType::CAPTURE_MONSTER, 0, 0, 0, 0, _("モンスターを捕える、又は解放する。", "captures or releases a monster.") },
 };
 
-std::optional<std::string> ActivationType::build_timeout_description() const
+tl::optional<std::string> ActivationType::build_timeout_description() const
 {
     if ((this->constant == 0) && (this->dice == 0)) {
         return _("いつでも", "every turn");
     }
 
     if (!this->constant) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     std::stringstream ss;

--- a/src/object-enchant/activation-info-table.h
+++ b/src/object-enchant/activation-info-table.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class RandomArtActType : short;
@@ -11,11 +11,11 @@ public:
     RandomArtActType index;
     int level;
     int value;
-    std::optional<int> constant; // 発動間隔の最低ターン数
+    tl::optional<int> constant; // 発動間隔の最低ターン数
     int dice; // 発動間隔の追加ターン数
     std::string desc;
 
-    std::optional<std::string> build_timeout_description() const;
+    tl::optional<std::string> build_timeout_description() const;
 };
 
 extern const std::vector<ActivationType> activation_info;

--- a/src/object-use/throw-execution.h
+++ b/src/object-use/throw-execution.h
@@ -78,7 +78,7 @@ private:
     int back_chance{};
     std::string o2_name{};
     bool super_boomerang{};
-    std::optional<ObjectThrowHitMonster> hit_monster{};
+    tl::optional<ObjectThrowHitMonster> hit_monster{};
 
     bool check_what_throw();
     bool check_throw_boomerang();

--- a/src/pet/pet-fall-off.cpp
+++ b/src/pet/pet-fall-off.cpp
@@ -26,7 +26,7 @@
 #include "target/target-checker.h"
 #include "view/display-messages.h"
 #include "world/world.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 /*!
  * @brief モンスターから直接攻撃を受けた時に落馬するかどうかを判定し、判定アウトならば落馬させる
@@ -95,7 +95,7 @@ bool process_fall_off_horse(PlayerType *player_ptr, int dam, bool force)
         return false;
     }
 
-    std::optional<Pos2D> pos_fall_off;
+    tl::optional<Pos2D> pos_fall_off;
     if (dam >= 0 || force) {
         if (!calc_fall_off_possibility(player_ptr, dam, force, monrace)) {
             return false;

--- a/src/player-info/magic-eater-data-type.cpp
+++ b/src/player-info/magic-eater-data-type.cpp
@@ -34,11 +34,11 @@ std::vector<MagicEaterDataList::MagicEaterDatum> &MagicEaterDataList::get_item_g
     }
 }
 
-std::optional<BaseitemKey> MagicEaterDataList::check_magic_eater_spell_repeat() const
+tl::optional<BaseitemKey> MagicEaterDataList::check_magic_eater_spell_repeat() const
 {
     const auto code = repeat_pull();
     if (!code) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto tval = ItemKindType::NONE;
@@ -53,7 +53,7 @@ std::optional<BaseitemKey> MagicEaterDataList::check_magic_eater_spell_repeat() 
     const auto &item_group = this->get_item_group(tval);
     auto sval = *code % EATER_ITEM_GROUP_SIZE;
     if (sval >= static_cast<int>(item_group.size())) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto &item = item_group[sval];
@@ -66,7 +66,7 @@ std::optional<BaseitemKey> MagicEaterDataList::check_magic_eater_spell_repeat() 
             return BaseitemKey(tval, sval);
         }
 
-        return std::nullopt;
+        return tl::nullopt;
     }
     case ItemKindType::STAFF:
     case ItemKindType::WAND:
@@ -74,9 +74,9 @@ std::optional<BaseitemKey> MagicEaterDataList::check_magic_eater_spell_repeat() 
             return BaseitemKey(tval, sval);
         }
 
-        return std::nullopt;
+        return tl::nullopt;
     default:
-        return std::nullopt;
+        return tl::nullopt;
     }
 }
 

--- a/src/player-info/magic-eater-data-type.h
+++ b/src/player-info/magic-eater-data-type.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 inline constexpr int EATER_ITEM_GROUP_SIZE = 256; //!< 魔道具1種あたりの最大数
@@ -29,7 +29,7 @@ public:
     std::vector<MagicEaterDatum> rods{}; //!< ロッドのデータ
     inline static std::vector<MagicEaterDataList::MagicEaterDatum> none{}; //!< いずれの魔道具でもないダミー
 
-    std::optional<BaseitemKey> check_magic_eater_spell_repeat() const;
+    tl::optional<BaseitemKey> check_magic_eater_spell_repeat() const;
     std::vector<MagicEaterDatum> &get_item_group(ItemKindType tval);
 
 private:

--- a/src/player-info/race-info.h
+++ b/src/player-info/race-info.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <optional>
+#include <tl/optional.hpp>
 #include <unordered_map>
 #include <vector>
 
@@ -52,10 +52,10 @@ enum class PlayerRaceFoodType {
 struct player_race_condition {
     tr_type type{};
     PLAYER_LEVEL level{};
-    std::optional<PlayerClassType> pclass{};
+    tl::optional<PlayerClassType> pclass{};
     bool not_class{};
 
-    player_race_condition(tr_type t, PLAYER_LEVEL l = 1, const std::optional<PlayerClassType> &c = std::nullopt, bool nc = false)
+    player_race_condition(tr_type t, PLAYER_LEVEL l = 1, const tl::optional<PlayerClassType> &c = tl::nullopt, bool nc = false)
         : type(t)
         , level(l)
         , pclass(c)

--- a/src/player/eldritch-horror.cpp
+++ b/src/player/eldritch-horror.cpp
@@ -49,10 +49,10 @@ static bool process_mod_hallucination(PlayerType *player_ptr, std::string_view m
 
 /*!
  * @brief ELDRITCH_HORRORによるプレイヤーの精神破壊処理
- * @param m_idx ELDRITCH_HORRORを引き起こしたモンスターの参照ID。薬・罠・魔法の影響ならstd::nullopt。(デフォルト: std::nullopt)
+ * @param m_idx ELDRITCH_HORRORを引き起こしたモンスターの参照ID。薬・罠・魔法の影響ならtl::nullopt。(デフォルト: tl::nullopt)
  * @param necro 暗黒領域魔法の詠唱失敗によるものならばtrueを指定する (デフォルト: false)
  */
-void sanity_blast(PlayerType *player_ptr, std::optional<short> m_idx, bool necro)
+void sanity_blast(PlayerType *player_ptr, tl::optional<short> m_idx, bool necro)
 {
     const auto &world = AngbandWorld::get_instance();
     if (AngbandSystem::get_instance().is_phase_out() || !world.character_dungeon) {

--- a/src/player/eldritch-horror.h
+++ b/src/player/eldritch-horror.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <optional>
+#include <tl/optional.hpp>
 
 class MonsterEntity;
 class PlayerType;
-void sanity_blast(PlayerType *player_ptr, std::optional<short> m_idx = std::nullopt, bool necro = false);
+void sanity_blast(PlayerType *player_ptr, tl::optional<short> m_idx = tl::nullopt, bool necro = false);

--- a/src/player/player-damage.cpp
+++ b/src/player/player-damage.cpp
@@ -467,7 +467,7 @@ int take_hit(PlayerType *player_ptr, int damage_type, int damage, std::string_vi
 
                 msg_erase();
             } else {
-                std::optional<std::string> death_message_opt;
+                tl::optional<std::string> death_message_opt;
                 if (winning_seppuku) {
                     death_message_opt = get_random_line(_("seppuku_j.txt", "seppuku.txt"), 0);
                 } else {

--- a/src/player/player-realm.cpp
+++ b/src/player/player-realm.cpp
@@ -116,7 +116,7 @@ std::string_view PlayerRealm::get_subinfo(RealmType realm)
     THROW_EXCEPTION(std::invalid_argument, format("Invalid realm: %d", enum2i(realm)));
 }
 
-const magic_type &PlayerRealm::get_spell_info(RealmType realm, int spell_id, std::optional<PlayerClassType> pclass)
+const magic_type &PlayerRealm::get_spell_info(RealmType realm, int spell_id, tl::optional<PlayerClassType> pclass)
 {
     if (spell_id < 0 || 32 <= spell_id) {
         THROW_EXCEPTION(std::invalid_argument, format("Invalid spell id: %d", spell_id));

--- a/src/player/player-realm.h
+++ b/src/player/player-realm.h
@@ -4,9 +4,9 @@
 #include "system/angband.h"
 #include "util/flag-group.h"
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 
 using RealmChoices = EnumClassFlagGroup<RealmType>;
@@ -23,7 +23,7 @@ public:
     static const LocalizedString &get_name(RealmType realm);
     static std::string_view get_explanation(RealmType realm);
     static std::string_view get_subinfo(RealmType realm);
-    static const magic_type &get_spell_info(RealmType realm, int spell_id, std::optional<PlayerClassType> pclass = std::nullopt);
+    static const magic_type &get_spell_info(RealmType realm, int spell_id, tl::optional<PlayerClassType> pclass = tl::nullopt);
     static const std::string &get_spell_name(RealmType realm, int spell_id);
     static const std::string &get_spell_description(RealmType realm, int spell_id);
     static ItemKindType get_book(RealmType realm);

--- a/src/racial/racial-draconian.cpp
+++ b/src/racial/racial-draconian.cpp
@@ -6,14 +6,14 @@
 #include "system/player-type-definition.h"
 #include "target/target-getter.h"
 #include "view/display-messages.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <utility>
 
-static std::optional<std::pair<AttributeType, std::string>> decide_breath_kind(PlayerType *player_ptr)
+static tl::optional<std::pair<AttributeType, std::string>> decide_breath_kind(PlayerType *player_ptr)
 {
     if (randint1(100) >= player_ptr->lev) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     switch (player_ptr->pclass) {
@@ -88,7 +88,7 @@ static std::optional<std::pair<AttributeType, std::string>> decide_breath_kind(P
         return std::pair(type, name);
     }
     default:
-        return std::nullopt;
+        return tl::nullopt;
     }
 }
 

--- a/src/realm/realm-arcane.cpp
+++ b/src/realm/realm-arcane.cpp
@@ -32,9 +32,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -52,7 +52,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, dice.roll());
@@ -63,7 +63,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             wizard_lock(player_ptr, dir);
@@ -123,7 +123,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             destroy_door(player_ptr, dir);
@@ -283,7 +283,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
     case 20: {
         if (cast) {
             if (!ident_spell(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -299,7 +299,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             wall_to_mud(player_ptr, dir, base + dice.roll());
@@ -316,7 +316,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             msg_print(_("光線が放たれた。", "A line of light appears."));
@@ -354,7 +354,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
     case 26: {
         if (cast) {
             if (!input_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)"))) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             teleport_level(player_ptr, 0);
         }
@@ -370,7 +370,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -388,7 +388,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             constexpr static auto element_types = {
@@ -425,7 +425,7 @@ std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spe
 
         if (cast) {
             if (!recall_player(player_ptr, dice.roll() + base)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;

--- a/src/realm/realm-arcane.h
+++ b/src/realm/realm-arcane.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_arcane_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-chaos.cpp
+++ b/src/realm/realm-chaos.cpp
@@ -32,9 +32,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -52,7 +52,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, dice.roll());
@@ -112,7 +112,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::MISSILE, dir, dice.roll() + base, rad);
@@ -135,7 +135,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::FIRE, dir, dice.roll());
@@ -152,7 +152,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::DISINTEGRATE, dir, dice.roll(), 0);
@@ -180,7 +180,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
 
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             cast_wonder(player_ptr, dir);
@@ -197,7 +197,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::CHAOS, dir, dice.roll());
@@ -228,7 +228,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_beam(player_ptr, AttributeType::MANA, dir, dice.roll());
@@ -246,7 +246,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::FIRE, dir, dam, rad);
@@ -263,7 +263,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -290,7 +290,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::CHAOS, dir, dam, rad);
@@ -307,7 +307,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             poly_monster(player_ptr, dir, plev);
@@ -336,7 +336,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         }
         if (cast) {
             if (!recharge(player_ptr, power)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -352,7 +352,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::DISINTEGRATE, dir, dam, rad);
@@ -383,7 +383,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             msg_print(_("ロケット発射！", "You launch a rocket!"));
@@ -413,7 +413,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_beam(player_ptr, AttributeType::GRAVITY, dir, dice.roll());
         }
@@ -458,7 +458,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 28: {
         if (cast) {
             if (!input_check(_("変身します。よろしいですか？", "You will polymorph yourself. Are you sure? "))) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             do_poly_self(player_ptr);
         }
@@ -475,7 +475,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball(player_ptr, AttributeType::MANA, dir, dam, rad);
         }
@@ -492,7 +492,7 @@ std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::CHAOS, dir, dam, rad);

--- a/src/realm/realm-chaos.h
+++ b/src/realm/realm-chaos.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_chaos_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-craft.cpp
+++ b/src/realm/realm-craft.cpp
@@ -25,9 +25,9 @@
  * @brief 匠領域魔法の各処理を行う
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -212,7 +212,7 @@ std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         if (cast) {
             if (!choose_ele_attack(player_ptr, base + dice.roll())) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -318,7 +318,7 @@ std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 24: {
         if (cast) {
             if (!mundane_spell(player_ptr, true)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -332,7 +332,7 @@ std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 26: {
         if (cast) {
             if (!identify_fully(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -340,7 +340,7 @@ std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 27: {
         if (cast) {
             if (!enchant_spell(player_ptr, randint0(4) + 1, randint0(4) + 1, 0)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -348,7 +348,7 @@ std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 28: {
         if (cast) {
             if (!enchant_spell(player_ptr, 0, 0, randint0(3) + 2)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -375,7 +375,7 @@ std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         if (cast) {
             if (!choose_ele_immune(player_ptr, base + dice.roll())) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;

--- a/src/realm/realm-craft.h
+++ b/src/realm/realm-craft.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_craft_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-crusade.cpp
+++ b/src/realm/realm-crusade.cpp
@@ -38,9 +38,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -56,7 +56,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::ELEC, dir, dice.roll());
         }
@@ -86,7 +86,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fear_monster(player_ptr, dir, power);
         }
@@ -120,7 +120,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_blast(player_ptr, AttributeType::LITE, dir, dice, 10, 3);
         }
@@ -144,7 +144,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball(player_ptr, AttributeType::AWAY_EVIL, dir, power, 0);
         }
@@ -168,7 +168,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::HOLY_FIRE, dir, dice.roll() + base, rad);
@@ -230,7 +230,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_bolt(player_ptr, AttributeType::ELEC, dir, dam);
         }
@@ -259,7 +259,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             destroy_door(player_ptr, dir);
@@ -276,7 +276,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             stasis_evil(player_ptr, dir);
         }
@@ -337,7 +337,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::LITE, dir, dam, rad);
@@ -433,7 +433,7 @@ std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX sp
 
         if (cast) {
             if (!cast_wrath_of_the_god(player_ptr, dam, rad)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;

--- a/src/realm/realm-crusade.h
+++ b/src/realm/realm-crusade.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_crusade_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-death.cpp
+++ b/src/realm/realm-death.cpp
@@ -34,9 +34,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -67,7 +67,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             /*
@@ -120,7 +120,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::POIS, dir, dam, rad);
@@ -137,7 +137,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             sleep_monster(player_ptr, dir, plev);
@@ -167,7 +167,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fear_monster(player_ptr, dir, plev);
@@ -185,7 +185,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             control_one_undead(player_ptr, dir, plev);
@@ -210,7 +210,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::HYPODYNAMIA, dir, dice.roll() + base, rad);
@@ -227,7 +227,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::NETHER, dir, dice.roll());
@@ -257,7 +257,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball_hide(player_ptr, AttributeType::GENOCIDE, dir, power, 0);
@@ -283,7 +283,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
 
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             if (hypodynamic_bolt(player_ptr, dir, dam)) {
@@ -352,7 +352,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             cast_invoke_spirits(player_ptr, dir);
@@ -369,7 +369,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::DARK, dir, dice.roll());
@@ -410,7 +410,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
 
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             chg_virtue(player_ptr, Virtue::SACRIFICE, -1);
@@ -447,7 +447,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::DARK, dir, dam, rad);
@@ -458,7 +458,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             death_ray(player_ptr, dir, plev);
@@ -475,11 +475,11 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             if (randint1(50) > plev) {
                 if (!ident_spell(player_ptr, false)) {
-                    return std::nullopt;
+                    return tl::nullopt;
                 }
             } else {
                 if (!identify_fully(player_ptr, false)) {
-                    return std::nullopt;
+                    return tl::nullopt;
                 }
             }
         }
@@ -527,7 +527,7 @@ std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::HELL_FIRE, dir, dam, rad);

--- a/src/realm/realm-death.h
+++ b/src/realm/realm-death.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_death_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-demon.cpp
+++ b/src/realm/realm-demon.cpp
@@ -35,9 +35,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -55,7 +55,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::MISSILE, dir, dice.roll());
@@ -110,7 +110,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::FIRE, dir, dice.roll());
@@ -143,7 +143,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::NETHER, dir, dice.roll() + base, rad);
@@ -196,7 +196,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr), AttributeType::PLASMA, dir, dice.roll());
@@ -214,7 +214,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::FIRE, dir, dam, rad);
@@ -251,7 +251,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_bolt(player_ptr, AttributeType::ABYSS, dir, dam);
         }
@@ -319,7 +319,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::PLASMA, dir, dam, rad);
@@ -350,7 +350,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball(player_ptr, AttributeType::FIRE, dir, dam, rad);
         }
@@ -367,7 +367,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball(player_ptr, AttributeType::NEXUS, dir, dam, rad);
         }
@@ -377,7 +377,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             } else {
                 msg_print(_("<破滅の手>を放った！", "You invoke the Hand of Doom!"));
             }
@@ -424,7 +424,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
     case 27: {
         if (cast) {
             if (!cast_summon_greater_demon(player_ptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -440,7 +440,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::FIRE, dir, dam, rad);
@@ -458,7 +458,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::NETHER, dir, dam, rad);
@@ -476,7 +476,7 @@ std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball_hide(player_ptr, AttributeType::ABYSS, dir, dam, rad);

--- a/src/realm/realm-demon.h
+++ b/src/realm/realm-demon.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_daemon_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -59,9 +59,9 @@
  * @brief 呪術領域魔法の各処理を行う
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST / SPELL_CONT / SpellProcessType::STOP)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST / SPELL_CONT / SpellProcessType::STOP 時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST / SPELL_CONT / SpellProcessType::STOP 時は tl::nullopt を返す。
  */
-std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode)
+tl::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode)
 {
     auto info = mode == SpellProcessType::INFO;
     auto cast = mode == SpellProcessType::CAST;
@@ -215,7 +215,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
 
             if (spell_hex.get_revenge_turn() > 0) {
                 msg_print(_("すでに我慢をしている。", "You are already biding your time for vengeance."));
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             spell_hex.set_revenge_type(SpellHexRevengeType::PATIENCE);
@@ -366,7 +366,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
         }
         if (cast) {
             if (!recharge(player_ptr, power)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             should_continue = false;
         }
@@ -459,10 +459,10 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
 
             if (!o_ptr->is_valid()) {
                 msg_print(_("クロークを身につけていない！", "You are not wearing a cloak."));
-                return std::nullopt;
+                return tl::nullopt;
             } else if (!o_ptr->is_cursed()) {
                 msg_print(_("クロークは呪われていない！", "Your cloak is not cursed."));
-                return std::nullopt;
+                return tl::nullopt;
             } else {
                 msg_print(_("影のオーラを身にまとった。", "You are enveloped by a shadowy aura!"));
             }
@@ -637,7 +637,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
     }
     case HEX_SHADOW_MOVE:
         if (cast) {
-            std::optional<Pos2D> pos_target;
+            tl::optional<Pos2D> pos_target;
             bool flag;
             for (auto i = 0; i < 3; i++) {
                 pos_target = point_target(player_ptr);
@@ -699,7 +699,7 @@ std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type s
 
             if (spell_hex.get_revenge_turn() > 0) {
                 msg_print(_("すでに復讐は宣告済みだ。", "You've already declared your revenge."));
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             spell_hex.set_revenge_type(SpellHexRevengeType::REVENGE);

--- a/src/realm/realm-hex.h
+++ b/src/realm/realm-hex.h
@@ -3,8 +3,8 @@
 #include "realm/realm-hex-numbers.h"
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode);
+tl::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type spell, SpellProcessType mode);

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -51,9 +51,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell_id 剣術ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell_id, SpellProcessType mode)
+tl::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell_id, SpellProcessType mode)
 {
     bool cast = mode == SpellProcessType::CAST;
 
@@ -65,7 +65,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             project_length = 2;
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             project_hook(player_ptr, AttributeType::ATTACK, dir, HISSATSU_2, PROJECT_STOP | PROJECT_KILL);
@@ -76,7 +76,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto attack_to = [player_ptr](const Direction &dir) {
@@ -99,7 +99,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
     case 2:
         if (cast) {
             if (!ThrowCommand(player_ptr).do_cmd_throw(1, true, -1)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -108,7 +108,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -116,7 +116,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_FIRE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -131,7 +131,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -139,7 +139,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_MINEUCHI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -148,7 +148,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             if (player_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
-                return std::nullopt;
+                return tl::nullopt;
             }
             msg_print(_("相手の攻撃に対して身構えた。", "You prepare to counterattack."));
             player_ptr->counter = true;
@@ -159,12 +159,12 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             if (player_ptr->riding) {
                 msg_print(_("乗馬中には無理だ。", "You cannot do it when riding."));
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos_target = player_ptr->get_neighbor(dir);
@@ -172,7 +172,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             const auto &grid_target = floor.get_grid(pos_target);
             if (!grid_target.has_monster()) {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             do_cmd_attack(player_ptr, pos_target.y, pos_target.x, HISSATSU_NONE);
@@ -193,7 +193,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -202,7 +202,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_POISON);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -211,7 +211,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -220,7 +220,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_ZANMA);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -229,7 +229,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -239,7 +239,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
             if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
                 return "";
@@ -283,11 +283,11 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             if (plev > 44) {
                 if (!identify_fully(player_ptr, true)) {
-                    return std::nullopt;
+                    return tl::nullopt;
                 }
             } else {
                 if (!ident_spell(player_ptr, true)) {
-                    return std::nullopt;
+                    return tl::nullopt;
                 }
             }
         }
@@ -297,7 +297,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -320,7 +320,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -329,7 +329,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_COLD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -338,7 +338,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -347,7 +347,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_KYUSHO);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -356,7 +356,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -365,7 +365,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_MAJIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -374,7 +374,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -383,7 +383,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_SUTEMI);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
             player_ptr->sutemi = true;
         }
@@ -393,7 +393,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -402,7 +402,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_ELEC);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -410,7 +410,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
     case 18:
         if (cast) {
             if (!rush_attack(player_ptr, nullptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -445,7 +445,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -464,7 +464,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             ItemEntity *o_ptr;
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             msg_print(_("武器を大きく振り下ろした。", "You swing your weapon downward."));
             for (i = 0; i < 2; i++) {
@@ -510,7 +510,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             auto &floor = *player_ptr->current_floor_ptr;
@@ -522,7 +522,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                     do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_3DAN);
                 } else {
                     msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                    return std::nullopt;
+                    return tl::nullopt;
                 }
 
                 if (floor.get_dungeon_definition().flags.has(DungeonFeatureType::NO_MELEE)) {
@@ -581,7 +581,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -590,7 +590,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_DRAIN);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -631,7 +631,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             } while (player_ptr->csp > mana_cost_per_monster);
 
             if (is_new) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             /* Restore reserved mana */
@@ -643,7 +643,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto pos = point_target(player_ptr);
             if (!pos) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto p_pos = player_ptr->get_position();
@@ -666,7 +666,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -679,7 +679,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 }
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "You don't see any monster in this direction"));
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
         break;
@@ -688,7 +688,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -735,7 +735,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             const auto dir = get_direction(player_ptr);
             if (!dir.has_direction()) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             const auto pos = player_ptr->get_neighbor(dir);
@@ -744,7 +744,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_UNDEAD);
             } else {
                 msg_print(_("その方向にはモンスターはいません。", "There is no monster."));
-                return std::nullopt;
+                return tl::nullopt;
             }
             take_hit(player_ptr, DAMAGE_NOESCAPE, 100 + randint1(100), _("慶雲鬼忍剣を使った衝撃", "exhaustion on using Keiun-Kininken"));
         }
@@ -754,7 +754,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
         if (cast) {
             int i;
             if (!input_check(_("本当に自殺しますか？", "Do you really want to commit suicide? "))) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             /* Special Verification for suicide */
             prt(_("確認のため '@' を押して下さい。", "Please verify SUICIDE by typing the '@' sign: "), 0, 0);
@@ -763,7 +763,7 @@ std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX s
             i = inkey();
             prt("", 0, 0);
             if (i != '@') {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             auto &world = AngbandWorld::get_instance();

--- a/src/realm/realm-hissatsu.h
+++ b/src/realm/realm-hissatsu.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-life.cpp
+++ b/src/realm/realm-life.cpp
@@ -30,9 +30,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -73,7 +73,7 @@ std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball_hide(player_ptr, AttributeType::WOUNDS, dir, dice.roll(), 0);
         }
@@ -146,7 +146,7 @@ std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball_hide(player_ptr, AttributeType::WOUNDS, dir, dice.roll(), 0);
         }
@@ -220,7 +220,7 @@ std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell
     case 17: {
         if (cast) {
             if (!ident_spell(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -259,7 +259,7 @@ std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball_hide(player_ptr, AttributeType::WOUNDS, dir, dice.roll(), 0);
         }
@@ -275,7 +275,7 @@ std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell
 
         if (cast) {
             if (!recall_player(player_ptr, dice.roll() + base)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -362,7 +362,7 @@ std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell
     case 30: {
         if (cast) {
             if (!identify_fully(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;

--- a/src/realm/realm-life.h
+++ b/src/realm/realm-life.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_life_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-nature.cpp
+++ b/src/realm/realm-nature.cpp
@@ -47,9 +47,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -82,7 +82,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
 
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_beam(player_ptr, AttributeType::ELEC, dir, dice.roll());
@@ -140,7 +140,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             charm_animal(player_ptr, dir, plev);
@@ -188,7 +188,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             wall_to_mud(player_ptr, dir, base + dice.roll());
@@ -205,7 +205,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::COLD, dir, dice.roll());
         }
@@ -238,7 +238,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_bolt_or_beam(player_ptr, beam_chance(player_ptr) - 10, AttributeType::FIRE, dir, dice.roll());
         }
@@ -254,7 +254,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             msg_print(_("太陽光線が現れた。", "A line of sunlight appears."));
             lite_line(player_ptr, dir, dice.roll());
@@ -345,7 +345,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
     case 21: {
         if (cast) {
             if (!identify_fully(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -359,7 +359,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
     case 23: {
         if (cast) {
             if (!rustproof(player_ptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -393,7 +393,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::COLD, dir, dam, rad);
@@ -411,7 +411,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball(player_ptr, AttributeType::ELEC, dir, dam, rad);
             break;
@@ -429,7 +429,7 @@ std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spe
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             fire_ball(player_ptr, AttributeType::WATER, dir, dam, rad);
         }

--- a/src/realm/realm-nature.h
+++ b/src/realm/realm-nature.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_nature_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -56,9 +56,9 @@ static void start_singing(PlayerType *player_ptr, SPELL_IDX spell, int32_t song)
  * @param mode 処理内容 (NAME / SPELL_DESC / INFO / CAST / FAIL / SPELL_CONT / STOP)
  * @return
  * NAME / SPELL_DESC / INFO 時には文字列を返す.
- * CAST / FAIL / SPELL_CONT / STOP 時は std::nullopt を返す.
+ * CAST / FAIL / SPELL_CONT / STOP 時は tl::nullopt を返す.
  */
-std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -128,7 +128,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
             if (cast) {
                 const auto dir = get_aim_dir(player_ptr);
                 if (!dir) {
-                    return std::nullopt;
+                    return tl::nullopt;
                 }
 
                 fire_bolt(player_ptr, AttributeType::SOUND, dir, dice.roll());
@@ -638,7 +638,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_beam(player_ptr, AttributeType::SOUND, dir, dice.roll());
@@ -817,7 +817,7 @@ std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_ball(player_ptr, AttributeType::SOUND, dir, dice.roll(), rad);

--- a/src/realm/realm-song.h
+++ b/src/realm/realm-song.h
@@ -4,4 +4,4 @@
 #include "system/angband.h"
 
 class PlayerType;
-std::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-sorcery.cpp
+++ b/src/realm/realm-sorcery.cpp
@@ -32,9 +32,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -103,7 +103,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             confuse_monster(player_ptr, dir, power);
@@ -132,7 +132,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             sleep_monster(player_ptr, dir, plev);
@@ -148,7 +148,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
 
         if (cast) {
             if (!recharge(player_ptr, power)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -168,7 +168,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
     case 9: {
         if (cast) {
             if (!ident_spell(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -183,7 +183,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             slow_monster(player_ptr, dir, plev);
@@ -212,7 +212,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -247,7 +247,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
     case 15: {
         if (cast) {
             if (!identify_fully(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -276,7 +276,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             charm_monster(player_ptr, dir, plev);
@@ -299,7 +299,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
     case 19: {
         if (cast) {
             if (!tele_town(player_ptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -313,7 +313,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
     case 21: {
         if (cast) {
             if (!input_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)"))) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             teleport_level(player_ptr, 0);
         }
@@ -329,7 +329,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
 
         if (cast) {
             if (!recall_player(player_ptr, dice.roll() + base)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -344,7 +344,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             msg_print(_("次元の扉が開いた。目的地を選んで下さい。", "You open a dimensional gate. Choose a destination."));
             if (!dimension_door(player_ptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -378,7 +378,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fetch_item(player_ptr, dir, weight, false);
@@ -420,7 +420,7 @@ std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX sp
     case 29: {
         if (cast) {
             if (!alchemy(player_ptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;

--- a/src/realm/realm-sorcery.h
+++ b/src/realm/realm-sorcery.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_sorcery_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/realm/realm-trump.cpp
+++ b/src/realm/realm-trump.cpp
@@ -34,9 +34,9 @@
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param spell 魔法ID
  * @param mode 処理内容 (SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO / SpellProcessType::CAST)
- * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は std::nullopt を返す。
+ * @return SpellProcessType::NAME / SPELL_DESC / SpellProcessType::INFO 時には文字列を返す。SpellProcessType::CAST時は tl::nullopt を返す。
  */
-std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode)
 {
     bool info = mode == SpellProcessType::INFO;
     bool cast = mode == SpellProcessType::CAST;
@@ -81,7 +81,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 3: {
         if (cast) {
             if (!reset_recall(player_ptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -121,7 +121,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, power);
@@ -150,7 +150,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             const auto dir = get_aim_dir(player_ptr);
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             fetch_item(player_ptr, dir, weight, false);
@@ -165,7 +165,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
             if (cast) {
                 const auto pos = target_set(player_ptr, TARGET_KILL).get_position();
                 if (!pos) {
-                    return std::nullopt;
+                    return tl::nullopt;
                 }
                 x = pos->x;
                 y = pos->y;
@@ -213,7 +213,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
             target_pet = old_target_pet;
 
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             speed_monster(player_ptr, dir, plev);
@@ -223,7 +223,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 12: {
         if (cast) {
             if (!input_check(_("本当に他の階にテレポートしますか？", "Are you sure? (Teleport Level)"))) {
-                return std::nullopt;
+                return tl::nullopt;
             }
             teleport_level(player_ptr, 0);
         }
@@ -239,7 +239,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
         if (cast) {
             msg_print(_("次元の扉が開いた。目的地を選んで下さい。", "You open a dimensional gate. Choose a destination."));
             if (!dimension_door(player_ptr)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -254,7 +254,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
 
         if (cast) {
             if (!recall_player(player_ptr, dice.roll() + base)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -282,7 +282,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
             project_length = 0;
 
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             teleport_swap(player_ptr, dir);
@@ -378,7 +378,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
     case 25: {
         if (cast) {
             if (!identify_fully(player_ptr, false)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
     } break;
@@ -401,7 +401,7 @@ std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spel
             target_pet = old_target_pet;
 
             if (!dir) {
-                return std::nullopt;
+                return tl::nullopt;
             }
 
             heal_monster(player_ptr, dir, heal);

--- a/src/realm/realm-trump.h
+++ b/src/realm/realm-trump.h
@@ -2,8 +2,8 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> do_trump_spell(PlayerType *player_ptr, SPELL_IDX spell, SpellProcessType mode);

--- a/src/room/pit-nest-util.cpp
+++ b/src/room/pit-nest-util.cpp
@@ -163,7 +163,7 @@ void PitNestFilter::set_dragon_breaths()
  * @param nest_types nest定義のマップ
  * @return 選択されたnestのID、選択失敗した場合nullopt.
  */
-std::optional<NestKind> pick_nest_type(const FloorType &floor, const std::map<NestKind, nest_pit_type> &nest_types)
+tl::optional<NestKind> pick_nest_type(const FloorType &floor, const std::map<NestKind, nest_pit_type> &nest_types)
 {
     ProbabilityTable<NestKind> table;
     for (const auto &[nest_kind, nest] : nest_types) {
@@ -179,7 +179,7 @@ std::optional<NestKind> pick_nest_type(const FloorType &floor, const std::map<Ne
     }
 
     if (table.empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return table.pick_one_at_random();
@@ -191,7 +191,7 @@ std::optional<NestKind> pick_nest_type(const FloorType &floor, const std::map<Ne
  * @param pit_types pit定義のマップ
  * @return 選択されたpitのID、選択失敗した場合nullopt.
  */
-std::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitKind, nest_pit_type> &pit_types)
+tl::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitKind, nest_pit_type> &pit_types)
 {
     ProbabilityTable<PitKind> table;
     for (const auto &[pit_kind, pit] : pit_types) {
@@ -207,7 +207,7 @@ std::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitK
     }
 
     if (table.empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return table.pick_one_at_random();
@@ -221,7 +221,7 @@ std::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitK
  * @return モンスター種族ID (見つからなかったらnullopt)
  * @details Nestにはそのフロアの通常レベルより11高いモンスターを中心に選ぶ
  */
-std::optional<MonraceId> select_pit_nest_monrace_id(PlayerType *player_ptr, MonsterEntity &align, int boost)
+tl::optional<MonraceId> select_pit_nest_monrace_id(PlayerType *player_ptr, MonsterEntity &align, int boost)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &monraces = MonraceList::get_instance();
@@ -236,8 +236,8 @@ std::optional<MonraceId> select_pit_nest_monrace_id(PlayerType *player_ptr, Mons
             return monrace_id;
         }
 
-        return std::nullopt;
+        return tl::nullopt;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/room/pit-nest-util.h
+++ b/src/room/pit-nest-util.h
@@ -3,8 +3,8 @@
 #include "monster-race/race-ability-flags.h"
 #include "util/flag-group.h"
 #include <map>
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 enum class NestKind {
     CLONE = 0,
@@ -100,6 +100,6 @@ public:
 
 class FloorType;
 class MonsterEntity;
-std::optional<NestKind> pick_nest_type(const FloorType &floor, const std::map<NestKind, nest_pit_type> &np_types);
-std::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitKind, nest_pit_type> &np_types);
-std::optional<MonraceId> select_pit_nest_monrace_id(PlayerType *player_ptr, MonsterEntity &align, int boost);
+tl::optional<NestKind> pick_nest_type(const FloorType &floor, const std::map<NestKind, nest_pit_type> &np_types);
+tl::optional<PitKind> pick_pit_type(const FloorType &floor, const std::map<PitKind, nest_pit_type> &np_types);
+tl::optional<MonraceId> select_pit_nest_monrace_id(PlayerType *player_ptr, MonsterEntity &align, int boost);

--- a/src/room/rooms-city.cpp
+++ b/src/room/rooms-city.cpp
@@ -28,7 +28,7 @@ const std::vector<StoreSaleType> stores = {
 /*
  * Precalculate buildings' location of underground arcade
  */
-std::optional<std::vector<UndergroundBuilding>> precalc_ugarcade(int town_hgt, int town_wid)
+tl::optional<std::vector<UndergroundBuilding>> precalc_ugarcade(int town_hgt, int town_wid)
 {
     const auto n = std::ssize(stores);
     std::vector<UndergroundBuilding> underground_buildings(n);
@@ -54,7 +54,7 @@ std::optional<std::vector<UndergroundBuilding>> precalc_ugarcade(int town_hgt, i
     }
 
     if (i != n) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return underground_buildings;

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -16,7 +16,7 @@
 #include "wizard/wizard-messages.h"
 #include <algorithm>
 #include <array>
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 namespace {
@@ -38,14 +38,14 @@ const std::map<NestKind, nest_pit_type> nest_types = {
     { NestKind::UNDEAD, { _("アンデッド", "undead"), MonraceHook::UNDEAD, PitNestHook::NONE, 75, 5 } },
 };
 
-std::optional<std::array<NestMonsterInfo, NUM_NEST_MON_TYPE>> pick_nest_monraces(PlayerType *player_ptr, MonsterEntity &align)
+tl::optional<std::array<NestMonsterInfo, NUM_NEST_MON_TYPE>> pick_nest_monraces(PlayerType *player_ptr, MonsterEntity &align)
 {
     std::array<NestMonsterInfo, NUM_NEST_MON_TYPE> nest_mon_info_list{};
     const auto &monraces = MonraceList::get_instance();
     for (auto &nest_mon_info : nest_mon_info_list) {
         const auto monrace_id = select_pit_nest_monrace_id(player_ptr, align, 11);
         if (!monrace_id) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         const auto &monrace = monraces.get_monrace(*monrace_id);

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -75,14 +75,14 @@ const std::vector<TrappedMonster> place_table_trapped_pit = {
 };
 // clang-format on
 
-std::optional<std::array<MonraceId, NUM_PIT_MONRACES>> pick_pit_monraces(PlayerType *player_ptr, MonsterEntity &align, int boost = 0)
+tl::optional<std::array<MonraceId, NUM_PIT_MONRACES>> pick_pit_monraces(PlayerType *player_ptr, MonsterEntity &align, int boost = 0)
 {
     std::array<MonraceId, NUM_PIT_MONRACES> whats{};
     const auto &monraces = MonraceList::get_instance();
     for (auto &what : whats) {
         const auto monrace_id = select_pit_nest_monrace_id(player_ptr, align, boost);
         if (!monrace_id) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         const auto &monrace = monraces.get_monrace(*monrace_id);

--- a/src/room/space-finder.cpp
+++ b/src/room/space-finder.cpp
@@ -180,12 +180,12 @@ static bool find_space_aux(DungeonData *dd_ptr, const Pos2D &max_block_size, con
  * Return TRUE and values for the center of the room if all went well.\n
  * Otherwise, return FALSE.\n
  */
-std::optional<Pos2D> find_space(PlayerType *player_ptr, DungeonData *dd_ptr, int height, int width)
+tl::optional<Pos2D> find_space(PlayerType *player_ptr, DungeonData *dd_ptr, int height, int width)
 {
     const auto blocks_high = 1 + ((height - 1) / BLOCK_HGT);
     const auto blocks_wide = 1 + ((width - 1) / BLOCK_WID);
     if ((dd_ptr->row_rooms < blocks_high) || (dd_ptr->col_rooms < blocks_wide)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto candidates = 0;
@@ -199,7 +199,7 @@ std::optional<Pos2D> find_space(PlayerType *player_ptr, DungeonData *dd_ptr, int
     }
 
     if (candidates == 0) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto block_y = 0;

--- a/src/room/space-finder.h
+++ b/src/room/space-finder.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class DungeonData;
 class PlayerType;
-std::optional<Pos2D> find_space(PlayerType *player_ptr, DungeonData *dd_ptr, int height, int width);
+tl::optional<Pos2D> find_space(PlayerType *player_ptr, DungeonData *dd_ptr, int height, int width);

--- a/src/smith/object-smith.cpp
+++ b/src/smith/object-smith.cpp
@@ -12,8 +12,8 @@
 #include "system/item-entity.h"
 #include "system/player-type-definition.h"
 #include <algorithm>
-#include <optional>
 #include <sstream>
+#include <tl/optional.hpp>
 #include <unordered_map>
 #include <vector>
 
@@ -55,9 +55,9 @@ Smith::Smith(PlayerType *player_ptr)
  * @brief 引数で指定した鍛冶効果の鍛冶情報を得る
  *
  * @param effect 情報を得る鍛冶効果
- * @return 鍛冶情報構造体へのポインタを保持する std::optional オブジェクトを返す
+ * @return 鍛冶情報構造体へのポインタを保持する tl::optional オブジェクトを返す
  */
-std::optional<const ISmithInfo *> Smith::find_smith_info(SmithEffectType effect)
+tl::optional<const ISmithInfo *> Smith::find_smith_info(SmithEffectType effect)
 {
     // 何度も呼ぶので線形探索を避けるため鍛冶効果から鍛冶情報のテーブルを引けるmapを作成しておく。
     static std::unordered_map<SmithEffectType, const ISmithInfo *> search_map;
@@ -69,7 +69,7 @@ std::optional<const ISmithInfo *> Smith::find_smith_info(SmithEffectType effect)
 
     auto it = search_map.find(effect);
     if (it == search_map.end()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return it->second;
@@ -211,9 +211,9 @@ TrFlags Smith::get_effect_tr_flags(SmithEffectType effect)
  *
  * @param o_ptr アイテム構造体へのポインタ
  * @return アイテムに付与されている発動効果の発動ID(random_art_activation_type型)
- * 付与されている発動効果が無い場合は std::nullopt
+ * 付与されている発動効果が無い場合は tl::nullopt
  */
-std::optional<RandomArtActType> Smith::object_activation(const ItemEntity *o_ptr)
+tl::optional<RandomArtActType> Smith::object_activation(const ItemEntity *o_ptr)
 {
     return o_ptr->smith_act_idx;
 }
@@ -222,10 +222,10 @@ std::optional<RandomArtActType> Smith::object_activation(const ItemEntity *o_ptr
  * @brief アイテムに付与されている鍛冶効果を取得する
  *
  * @param o_ptr アイテム構造体へのポインタ
- * @return アイテムに付与されている鍛冶効果を保持する std::optional オブジェクト返す。
- * 鍛冶効果が付与できないアイテムか、何も付与されていなければ std::nullopt を返す。
+ * @return アイテムに付与されている鍛冶効果を保持する tl::optional オブジェクト返す。
+ * 鍛冶効果が付与できないアイテムか、何も付与されていなければ tl::nullopt を返す。
  */
-std::optional<SmithEffectType> Smith::object_effect(const ItemEntity *o_ptr)
+tl::optional<SmithEffectType> Smith::object_effect(const ItemEntity *o_ptr)
 {
     return o_ptr->smith_effect;
 }
@@ -452,7 +452,7 @@ bool Smith::add_essence(SmithEffectType effect, ItemEntity *o_ptr, int number)
  */
 void Smith::erase_essence(ItemEntity *o_ptr) const
 {
-    o_ptr->smith_act_idx = std::nullopt;
+    o_ptr->smith_act_idx = tl::nullopt;
 
     auto effect = Smith::object_effect(o_ptr);
     if (!effect) {

--- a/src/smith/object-smith.h
+++ b/src/smith/object-smith.h
@@ -5,7 +5,7 @@
 #include "object-enchant/tr-flags.h"
 
 #include <memory>
-#include <optional>
+#include <tl/optional.hpp>
 #include <unordered_map>
 
 class ItemEntity;
@@ -39,8 +39,8 @@ public:
     static int get_essence_consumption(SmithEffectType effect, const ItemEntity *o_ptr = nullptr);
     static std::unique_ptr<ItemTester> get_item_tester(SmithEffectType effect);
     static TrFlags get_effect_tr_flags(SmithEffectType effect);
-    static std::optional<RandomArtActType> object_activation(const ItemEntity *o_ptr);
-    static std::optional<SmithEffectType> object_effect(const ItemEntity *o_ptr);
+    static tl::optional<RandomArtActType> object_activation(const ItemEntity *o_ptr);
+    static tl::optional<SmithEffectType> object_effect(const ItemEntity *o_ptr);
 
     int get_essence_num_of_posessions(SmithEssenceType essence) const;
     DrainEssenceResult drain_essence(ItemEntity *o_ptr);
@@ -51,7 +51,7 @@ public:
     static constexpr int ESSENCE_AMOUNT_MAX = 20000;
 
 private:
-    static std::optional<const ISmithInfo *> find_smith_info(SmithEffectType effect);
+    static tl::optional<const ISmithInfo *> find_smith_info(SmithEffectType effect);
 
     static const std::vector<SmithEssenceType> essence_list_order;
     static const std::unordered_map<SmithEssenceType, concptr> essence_to_name;

--- a/src/smith/smith-info.cpp
+++ b/src/smith/smith-info.cpp
@@ -37,7 +37,7 @@ bool BasicSmithInfo::add_essence(PlayerType *, ItemEntity *o_ptr, int) const
 
 void BasicSmithInfo::erase_essence(ItemEntity *o_ptr) const
 {
-    o_ptr->smith_effect = std::nullopt;
+    o_ptr->smith_effect = tl::nullopt;
     if (o_ptr->get_flags().has_none_of(TR_PVAL_FLAG_MASK)) {
         o_ptr->pval = 0;
     }
@@ -104,7 +104,7 @@ bool ActivationSmithInfo::add_essence(PlayerType *, ItemEntity *o_ptr, int) cons
 
 void ActivationSmithInfo::erase_essence(ItemEntity *o_ptr) const
 {
-    o_ptr->smith_act_idx = std::nullopt;
+    o_ptr->smith_act_idx = tl::nullopt;
 }
 
 bool ActivationSmithInfo::can_give_smith_effect(const ItemEntity *o_ptr) const

--- a/src/smith/smith-info.h
+++ b/src/smith/smith-info.h
@@ -4,7 +4,7 @@
 
 #include "object-enchant/tr-flags.h"
 
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class SmithEffectType : int16_t;

--- a/src/spell-class/spells-mirror-master.cpp
+++ b/src/spell-class/spells-mirror-master.cpp
@@ -121,7 +121,7 @@ bool SpellsMirrorMaster::mirror_tunnel()
  * @brief 鏡設置処理
  * @return 設置に成功したらnullopt、失敗したらエラーメッセージ
  */
-std::optional<std::string> SpellsMirrorMaster::place_mirror()
+tl::optional<std::string> SpellsMirrorMaster::place_mirror()
 {
     const auto p_pos = this->player_ptr->get_position();
     auto &floor = *this->player_ptr->current_floor_ptr;
@@ -136,7 +136,7 @@ std::optional<std::string> SpellsMirrorMaster::place_mirror()
     note_spot(this->player_ptr, p_pos);
     lite_spot(this->player_ptr, p_pos);
     update_local_illumination(this->player_ptr, p_pos);
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!

--- a/src/spell-class/spells-mirror-master.h
+++ b/src/spell-class/spells-mirror-master.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "util/point-2d.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class Direction;
 class PlayerType;
@@ -13,7 +13,7 @@ public:
     void remove_all_mirrors(bool explode);
     void remove_mirror(int y, int x);
     bool mirror_tunnel();
-    std::optional<std::string> place_mirror();
+    tl::optional<std::string> place_mirror();
     bool mirror_concentration();
     void seal_of_mirror(const int dam);
     void seeker_ray(const Direction &dir, int dam);

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -78,7 +78,7 @@ std::vector<Pos2D> decide_collapse_positions(const FloorType &floor, std::span<c
     return pos_collapses;
 }
 
-std::optional<Pos2D> decide_player_dodge_posistion(PlayerType *player_ptr, std::span<const Pos2D> pos_collapses)
+tl::optional<Pos2D> decide_player_dodge_posistion(PlayerType *player_ptr, std::span<const Pos2D> pos_collapses)
 {
     const auto is_collapsed_pos = [&](const auto &pos) { return ranges::contains(pos_collapses, pos); };
     const auto pos_candidates =
@@ -88,7 +88,7 @@ std::optional<Pos2D> decide_player_dodge_posistion(PlayerType *player_ptr, std::
         ranges::views::filter(std::not_fn(is_collapsed_pos)) |
         ranges::to<std::vector<Pos2D>>();
 
-    return pos_candidates.empty() ? std::nullopt : std::make_optional(rand_choice(pos_candidates));
+    return pos_candidates.empty() ? tl::nullopt : tl::make_optional(rand_choice(pos_candidates));
 }
 
 std::string build_killer_on_earthquake(PlayerType *player_ptr, int m_idx)
@@ -162,10 +162,10 @@ bool can_monster_dodge_to(const FloorType &floor, const Pos2D &p_pos, const Pos2
     return can_dodge;
 }
 
-std::optional<Pos2D> decide_monster_dodge_position(const FloorType &floor, const Pos2D &p_pos, const MonsterEntity &monster, std::span<const Pos2D> pos_collapses)
+tl::optional<Pos2D> decide_monster_dodge_position(const FloorType &floor, const Pos2D &p_pos, const MonsterEntity &monster, std::span<const Pos2D> pos_collapses)
 {
     if (monster.get_monrace().behavior_flags.has(MonsterBehaviorType::NEVER_MOVE)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto pos_candidates =
@@ -174,7 +174,7 @@ std::optional<Pos2D> decide_monster_dodge_position(const FloorType &floor, const
         ranges::views::filter([&](const auto &pos) { return can_monster_dodge_to(floor, p_pos, pos, pos_collapses); }) |
         ranges::to<std::vector<Pos2D>>();
 
-    return pos_candidates.empty() ? std::nullopt : std::make_optional(rand_choice(pos_candidates));
+    return pos_candidates.empty() ? tl::nullopt : tl::make_optional(rand_choice(pos_candidates));
 }
 
 void move_monster_to(PlayerType *player_ptr, MonsterEntity &monster, const Pos2D &pos_to)

--- a/src/spell-kind/spells-launcher.cpp
+++ b/src/spell-kind/spells-launcher.cpp
@@ -23,7 +23,7 @@
  * Affect grids, objects, and monsters
  * </pre>
  */
-bool fire_ball(PlayerType *player_ptr, AttributeType typ, const Direction &dir, int dam, POSITION rad, std::optional<CapturedMonsterType *> cap_mon_ptr)
+bool fire_ball(PlayerType *player_ptr, AttributeType typ, const Direction &dir, int dam, POSITION rad, tl::optional<CapturedMonsterType *> cap_mon_ptr)
 {
     BIT_FLAGS flg = PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
     if (typ == AttributeType::CHARM_LIVING) {

--- a/src/spell-kind/spells-launcher.h
+++ b/src/spell-kind/spells-launcher.h
@@ -2,13 +2,13 @@
 
 #include "effect/attribute-types.h"
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class CapturedMonsterType;
 class Dice;
 class Direction;
 class PlayerType;
-bool fire_ball(PlayerType *player_ptr, AttributeType typ, const Direction &dir, int dam, POSITION rad, std::optional<CapturedMonsterType *> cap_mon_ptr = std::nullopt);
+bool fire_ball(PlayerType *player_ptr, AttributeType typ, const Direction &dir, int dam, POSITION rad, tl::optional<CapturedMonsterType *> cap_mon_ptr = tl::nullopt);
 bool fire_breath(PlayerType *player_ptr, AttributeType typ, const Direction &dir, int dam, POSITION rad);
 bool fire_rocket(PlayerType *player_ptr, AttributeType typ, const Direction &dir, int dam, POSITION rad);
 bool fire_ball_hide(PlayerType *player_ptr, AttributeType typ, const Direction &dir, int dam, POSITION rad);

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -360,7 +360,7 @@ void reserve_alter_reality(PlayerType *player_ptr, TIME_EFFECT turns)
  * @param col コンソールX座標
  * @return 選択されたダンジョンID、ダンジョンに全く入ったことがなかったりキャンセルしたりした場合はnullopt
  */
-static std::optional<DungeonId> choose_dungeon(std::string_view note, int row, int col)
+static tl::optional<DungeonId> choose_dungeon(std::string_view note, int row, int col)
 {
     const auto &dungeon_records = DungeonRecords::get_instance();
     if (lite_town || vanilla_town || ironman_downward) {
@@ -372,7 +372,7 @@ static std::optional<DungeonId> choose_dungeon(std::string_view note, int row, i
         constexpr auto fmt = _("まだ%sに入ったことはない。", "You haven't entered %s yet.");
         msg_format(fmt, dungeons.get_dungeon(DungeonId::ANGBAND).name.data());
         msg_erase();
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     screen_save();
@@ -392,7 +392,7 @@ static std::optional<DungeonId> choose_dungeon(std::string_view note, int row, i
         const auto key = inkey();
         if ((key == ESCAPE) || ids.empty()) {
             screen_load();
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         if ((key >= 'a') && (key < static_cast<char>('a' + ids.size()))) {

--- a/src/spell-realm/spells-hex.cpp
+++ b/src/spell-realm/spells-hex.cpp
@@ -133,13 +133,13 @@ bool SpellHex::stop_spells_with_selection()
  * Item2: 選択が完了したらtrue、キャンセルならばfalse
  * Item3: 選択した呪文番号 (a～d、lの5択)
  */
-std::pair<bool, std::optional<char>> SpellHex::select_spell_stopping(std::string_view prompt)
+std::pair<bool, tl::optional<char>> SpellHex::select_spell_stopping(std::string_view prompt)
 {
     while (true) {
         this->display_casting_spells_list();
         const auto choice_opt = input_command(prompt, true);
         if (!choice_opt) {
-            return { false, std::nullopt };
+            return { false, tl::nullopt };
         }
 
         auto choice = *choice_opt;

--- a/src/spell-realm/spells-hex.h
+++ b/src/spell-realm/spells-hex.h
@@ -2,8 +2,8 @@
 
 #include "realm/realm-hex-numbers.h"
 #include "system/angband.h"
-#include <optional>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <utility>
 
 enum class SpellHexRevengeType : byte {
@@ -45,7 +45,7 @@ private:
     std::vector<int> casting_spells;
     std::shared_ptr<spell_hex_data_type> spell_hex_data;
 
-    std::pair<bool, std::optional<char>> select_spell_stopping(std::string_view prompt);
+    std::pair<bool, tl::optional<char>> select_spell_stopping(std::string_view prompt);
     void display_casting_spells_list();
     bool process_mana_cost(const bool need_restart);
     bool check_restart();

--- a/src/spell/spells-execution.cpp
+++ b/src/spell/spells-execution.cpp
@@ -22,7 +22,7 @@
  * @param mode 求める処理
  * @return 各領域魔法に各種テキストを求めた場合は文字列参照ポインタ、そうでない場合はnullptrを返す。
  */
-std::optional<std::string> exe_spell(PlayerType *player_ptr, RealmType realm, SPELL_IDX spell, SpellProcessType mode)
+tl::optional<std::string> exe_spell(PlayerType *player_ptr, RealmType realm, SPELL_IDX spell, SpellProcessType mode)
 {
     switch (realm) {
     case RealmType::LIFE:
@@ -52,6 +52,6 @@ std::optional<std::string> exe_spell(PlayerType *player_ptr, RealmType realm, SP
     case RealmType::HEX:
         return do_hex_spell(player_ptr, i2enum<spell_hex_type>(spell), mode);
     default:
-        return std::nullopt;
+        return tl::nullopt;
     }
 }

--- a/src/spell/spells-execution.h
+++ b/src/spell/spells-execution.h
@@ -2,9 +2,9 @@
 
 #include "spell/spells-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 enum class RealmType;
 class PlayerType;
-std::optional<std::string> exe_spell(PlayerType *player_ptr, RealmType realm, SPELL_IDX spell, SpellProcessType mode);
+tl::optional<std::string> exe_spell(PlayerType *player_ptr, RealmType realm, SPELL_IDX spell, SpellProcessType mode);

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -100,11 +100,11 @@ struct AmusementRewardItemVisitor {
     {
     }
 
-    std::optional<ItemEntity> operator()(const FixedArtifactId &fa_id) const
+    tl::optional<ItemEntity> operator()(const FixedArtifactId &fa_id) const
     {
         const auto &artifact = ArtifactList::get_instance().get_artifact(fa_id);
         if (artifact.is_generated) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         ItemEntity item(artifact.bi_key);
@@ -114,14 +114,14 @@ struct AmusementRewardItemVisitor {
         return item;
     }
 
-    std::optional<ItemEntity> operator()(const BaseitemKey &bi_key) const
+    tl::optional<ItemEntity> operator()(const BaseitemKey &bi_key) const
     {
         ItemEntity item(bi_key);
         ItemMagicApplier(player_ptr, &item, 1, AM_NO_FIXED_ART).execute();
 
         if (this->flag == AmusementFlagType::NO_UNIQUE) {
             if (item.has_monrace() && item.get_monrace().kind_flags.has(MonsterKindType::UNIQUE)) {
-                return std::nullopt;
+                return tl::nullopt;
             }
         }
 

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -255,7 +255,7 @@ bool summon_kin_player(PlayerType *player_ptr, DEPTH level, POSITION y, POSITION
  * @param summoner_m_idx モンスターの召喚による場合、召喚者のモンスターID
  * @return 作用が実際にあった場合TRUEを返す
  */
-int summon_cyber(PlayerType *player_ptr, POSITION y, POSITION x, std::optional<MONSTER_IDX> summoner_m_idx)
+int summon_cyber(PlayerType *player_ptr, POSITION y, POSITION x, tl::optional<MONSTER_IDX> summoner_m_idx)
 {
     /* Summoned by a monster */
     BIT_FLAGS mode = PM_ALLOW_GROUP;

--- a/src/spell/spells-summon.h
+++ b/src/spell/spells-summon.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum summon_type : int;
 
@@ -17,6 +17,6 @@ bool cast_summon_octopus(PlayerType *player_ptr);
 bool cast_summon_greater_demon(PlayerType *player_ptr);
 bool summon_kin_player(PlayerType *player_ptr, DEPTH level, POSITION y, POSITION x, BIT_FLAGS mode);
 void mitokohmon(PlayerType *player_ptr);
-int summon_cyber(PlayerType *player_ptr, POSITION y, POSITION x, std::optional<MONSTER_IDX> summoner_m_idx = std::nullopt);
+int summon_cyber(PlayerType *player_ptr, POSITION y, POSITION x, tl::optional<MONSTER_IDX> summoner_m_idx = tl::nullopt);
 int activate_hi_summon(PlayerType *player_ptr, POSITION y, POSITION x, bool can_pet);
 void cast_invoke_spirits(PlayerType *player_ptr, const Direction &dir);

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -17,7 +17,6 @@
 #include <map>
 #include <memory>
 #include <numeric>
-#include <optional>
 #include <ostream>
 #include <queue>
 #include <random>

--- a/src/store/cmd-store.cpp
+++ b/src/store/cmd-store.cpp
@@ -55,7 +55,7 @@ void do_cmd_store(PlayerType *player_ptr)
     if (AngbandWorld::get_instance().is_wild_mode()) {
         return;
     }
-    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
+    TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, tl::nullopt);
     const auto &[wid, hgt] = term_get_size();
     xtra_stock = std::min(14 + 26, ((hgt > MAIN_TERM_MIN_ROWS) ? (hgt - MAIN_TERM_MIN_ROWS) : 0));
     store_bottom = MIN_STOCK + xtra_stock;

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -32,8 +32,8 @@
 #include "view/display-store.h"
 #include "world/world.h"
 #include <fmt/format.h>
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 /*!
  * @brief プレイヤーが購入する時の値切り処理メインルーチン /
@@ -44,7 +44,7 @@
  * @return プレイヤーの価格に対して店主が不服ならばTRUEを返す /
  * Return TRUE if purchase is NOT successful
  */
-static std::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_num)
+static tl::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_num)
 {
     auto price_ask = price_item(player_ptr, o_ptr->calc_price(), ot_ptr->inflate, false, store_num);
 
@@ -54,7 +54,7 @@ static std::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_
         return price_ask;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!
@@ -62,7 +62,7 @@ static std::optional<PRICE> prompt_to_buy(PlayerType *player_ptr, ItemEntity *o_
  * @param i 店舗インベントリストック数
  * @return 選択したらtrue、しなかったらfalse
  */
-static std::optional<short> show_store_select_item(const int i, StoreSaleType store_num)
+static tl::optional<short> show_store_select_item(const int i, StoreSaleType store_num)
 {
     std::string prompt;
     switch (store_num) {

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -49,16 +49,16 @@ static short get_rumor_num(std::string_view zz, short max_idx)
 /*!
  * @brief 噂の、町やモンスターを表すトークンを得る
  * @param rumor rumor.txt (rumor_j.txt)の1行
- * @return トークン群の配列を返す。フィールドの数が合わない場合はstd::nulloptを返す。
+ * @return トークン群の配列を返す。フィールドの数が合わない場合はtl::nulloptを返す。
  * @todo tmp_tokensを使わず単なるsplitにすればもっと簡略化できそう
  */
-static std::optional<std::vector<std::string>> get_rumor_tokens(std::string rumor)
+static tl::optional<std::vector<std::string>> get_rumor_tokens(std::string rumor)
 {
     constexpr auto num_tokens = 3;
     char *tmp_tokens[num_tokens];
     if (tokenize(rumor.data() + 2, num_tokens, tmp_tokens, TOKENIZE_CHECKQUOTE) != num_tokens) {
         msg_print(_("この情報は間違っている。", "This information is wrong."));
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     std::vector<std::string> tokens(std::begin(tmp_tokens), std::end(tmp_tokens));

--- a/src/store/sell-order.cpp
+++ b/src/store/sell-order.cpp
@@ -34,7 +34,7 @@
 #include "view/display-store.h"
 #include "view/object-describer.h"
 #include <fmt/format.h>
-#include <optional>
+#include <tl/optional.hpp>
 
 /*!
  * @brief プレイヤーが売却する時の確認プロンプト / Prompt to sell for the price
@@ -42,7 +42,7 @@
  * @param o_ptr オブジェクトの構造体参照ポインタ
  * @return 売るなら(true,売値)、売らないなら(false,0)のタプル
  */
-static std::optional<int> prompt_to_sell(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_num)
+static tl::optional<int> prompt_to_sell(PlayerType *player_ptr, ItemEntity *o_ptr, StoreSaleType store_num)
 {
     auto price_ask = price_item(player_ptr, o_ptr->calc_price(), ot_ptr->inflate, true, store_num);
 
@@ -53,7 +53,7 @@ static std::optional<int> prompt_to_sell(PlayerType *player_ptr, ItemEntity *o_p
         return price_ask;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!

--- a/src/store/store-util.cpp
+++ b/src/store/store-util.cpp
@@ -154,11 +154,11 @@ static bool store_item_sort_comp(const ItemEntity &item1, const ItemEntity &item
  * @param item 加えたいオブジェクトの構造体参照ポインタ
  * @return 収めた先の商品インデックス. 但し無価値アイテムはnullopt (店頭に並べない)
  */
-std::optional<int> Store::carry(ItemEntity &item)
+tl::optional<int> Store::carry(ItemEntity &item)
 {
     const auto value = item.calc_price();
     if (value <= 0) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     item.ident |= IDENT_FULL_KNOWN;
@@ -173,7 +173,7 @@ std::optional<int> Store::carry(ItemEntity &item)
     }
 
     if (this->stock_num >= this->stock_size) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto first = this->stock.begin();

--- a/src/store/store-util.h
+++ b/src/store/store-util.h
@@ -4,7 +4,7 @@
 #include "util/enum-converter.h"
 #include "util/enum-range.h"
 #include <memory>
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 constexpr DEPTH STORE_OBJ_STD_LEVEL = 5; //!< 通常店舗の標準階層レベル / Magic Level for normal stores
@@ -54,7 +54,7 @@ public:
     void optimize_item(short i_idx);
     void delete_item();
     std::vector<short> collect_same_magic_device_pvals(ItemEntity &item);
-    std::optional<int> carry(ItemEntity &item);
+    tl::optional<int> carry(ItemEntity &item);
 };
 
 extern Store *st_ptr;

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -150,7 +150,7 @@ int store_check_num(const ItemEntity *o_ptr, StoreSaleType store_num)
  * @return アイテムを選択したらそのインデックス ('a'等)、キャンセルしたらnullopt
  * 繰り返しコマンドの時は前回の前回のインデックス
  */
-std::optional<short> input_stock(std::string_view fmt, int min, int max, [[maybe_unused]] StoreSaleType store_num)
+tl::optional<short> input_stock(std::string_view fmt, int min, int max, [[maybe_unused]] StoreSaleType store_num)
 {
     const auto code = repeat_pull();
     if ((code >= min) && (code <= max)) {
@@ -167,14 +167,14 @@ std::optional<short> input_stock(std::string_view fmt, int min, int max, [[maybe
     const auto prompt = format("(Items %c-%c, ESC to exit) %s", lo, hi, fmt.data());
 #endif
 
-    std::optional<char> command;
+    tl::optional<char> command;
     while (true) {
         const auto command_alpha = input_command(prompt);
         if (!command_alpha) {
             break;
         }
 
-        std::optional<int> command_num;
+        tl::optional<int> command_num;
         if (islower(*command_alpha)) {
             command_num = A2I(*command_alpha);
         } else if (isupper(*command_alpha)) {
@@ -191,7 +191,7 @@ std::optional<short> input_stock(std::string_view fmt, int min, int max, [[maybe
 
     prt("", 0, 0);
     if (!command) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     repeat_push(*command);

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -2,8 +2,8 @@
 
 #include "store/store-util.h"
 #include "system/angband.h"
-#include <optional>
 #include <string_view>
+#include <tl/optional.hpp>
 
 /* Store constants */
 #define STORE_INVEN_MAX 24 /* Max number of discrete objs in inven */
@@ -31,4 +31,4 @@ void store_maintenance(PlayerType *player_ptr, int town_num, StoreSaleType store
 void store_init(int town_num, StoreSaleType store_num);
 void store_examine(PlayerType *player_ptr, StoreSaleType store_num);
 int store_check_num(const ItemEntity *o_ptr, StoreSaleType store_num);
-std::optional<short> input_stock(std::string_view fmt, int min, int max, StoreSaleType store_num);
+tl::optional<short> input_stock(std::string_view fmt, int min, int max, StoreSaleType store_num);

--- a/src/system/artifact-type-definition.cpp
+++ b/src/system/artifact-type-definition.cpp
@@ -38,22 +38,22 @@ bool ArtifactType::can_generate(const BaseitemKey &generaing_bi_key) const
  * @param fa_id 固定アーティファクトID
  * @return 生成に成功したらそのアイテム、失敗したらnullopt
  */
-std::optional<BaseitemKey> ArtifactType::try_make_instant_artifact(int making_level) const
+tl::optional<BaseitemKey> ArtifactType::try_make_instant_artifact(int making_level) const
 {
     if (!this->can_make_instant_artifact()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (!this->evaluate_shallow_instant_artifact(making_level)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (!this->evaluate_rarity()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (!this->evaluate_shallow_baseitem(making_level)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return this->bi_key;
@@ -173,7 +173,7 @@ void ArtifactList::reset_generated_flags()
     }
 }
 
-std::optional<ItemEntity> ArtifactList::try_make_instant_artifact(int making_level) const
+tl::optional<ItemEntity> ArtifactList::try_make_instant_artifact(int making_level) const
 {
     for (const auto &[fa_id, artifact] : this->artifacts) {
         const auto bi_key = artifact.try_make_instant_artifact(making_level);
@@ -184,5 +184,5 @@ std::optional<ItemEntity> ArtifactList::try_make_instant_artifact(int making_lev
         }
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/system/artifact-type-definition.h
+++ b/src/system/artifact-type-definition.h
@@ -45,7 +45,7 @@ public:
     RandomArtActType act_idx{}; /*! 発動能力ID / Activative ability index */
 
     bool can_generate(const BaseitemKey &bi_key) const;
-    std::optional<BaseitemKey> try_make_instant_artifact(int making_level) const;
+    tl::optional<BaseitemKey> try_make_instant_artifact(int making_level) const;
 
 private:
     bool can_make_instant_artifact() const;
@@ -70,7 +70,7 @@ public:
     bool order(const FixedArtifactId id1, const FixedArtifactId id2) const;
     void emplace(const FixedArtifactId fa_id, ArtifactType &&artifact);
     void reset_generated_flags();
-    std::optional<ItemEntity> try_make_instant_artifact(int making_level) const;
+    tl::optional<ItemEntity> try_make_instant_artifact(int making_level) const;
 
 private:
     ArtifactList() = default;

--- a/src/system/baseitem/baseitem-key.cpp
+++ b/src/system/baseitem/baseitem-key.cpp
@@ -48,7 +48,7 @@ ItemKindType BaseitemKey::tval() const
     return this->type_value;
 }
 
-std::optional<int> BaseitemKey::sval() const
+tl::optional<int> BaseitemKey::sval() const
 {
     return this->subtype_value;
 }

--- a/src/system/baseitem/baseitem-key.h
+++ b/src/system/baseitem/baseitem-key.h
@@ -7,18 +7,18 @@
 #pragma once
 
 #include "object/tval-types.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 enum class ItemKindType : short;
 class BaseitemKey {
 public:
     constexpr BaseitemKey()
         : type_value(ItemKindType::NONE)
-        , subtype_value(std::nullopt)
+        , subtype_value(tl::nullopt)
     {
     }
 
-    constexpr BaseitemKey(const ItemKindType type_value, const std::optional<int> &subtype_value = std::nullopt)
+    constexpr BaseitemKey(const ItemKindType type_value, const tl::optional<int> &subtype_value = tl::nullopt)
         : type_value(type_value)
         , subtype_value(subtype_value)
     {
@@ -47,7 +47,7 @@ public:
     }
 
     ItemKindType tval() const;
-    std::optional<int> sval() const;
+    tl::optional<int> sval() const;
     bool is_valid() const;
     bool is(ItemKindType tval) const;
     ItemKindType get_arrow_kind() const;
@@ -88,7 +88,7 @@ public:
 
 private:
     ItemKindType type_value;
-    std::optional<int> subtype_value;
+    tl::optional<int> subtype_value;
 
     bool is_mushrooms() const;
 };

--- a/src/system/baseitem/baseitem-list.h
+++ b/src/system/baseitem/baseitem-list.h
@@ -8,7 +8,7 @@
 
 #include "util/abstract-vector-wrapper.h"
 #include <map>
-#include <optional>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class ItemKindType : short;

--- a/src/system/dungeon/dungeon-data-definition.h
+++ b/src/system/dungeon/dungeon-data-definition.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "util/point-2d.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 /*
@@ -43,5 +43,5 @@ public:
     int alloc_object_num = 0;
     int alloc_monster_num = 0;
 
-    std::optional<std::string> why;
+    tl::optional<std::string> why;
 };

--- a/src/system/dungeon/dungeon-definition.cpp
+++ b/src/system/dungeon/dungeon-definition.cpp
@@ -153,7 +153,7 @@ int DungeonDefinition::calc_cavern_terrains() const
  * @param threshold 川生成の確率閾値 (深いフロアほど生成率が高い)
  * @return 川地形の生成条件が満たされたら地形タグの組み合わせ (深/浅)、満たされなかったらnullopt
  */
-std::optional<std::pair<TerrainTag, TerrainTag>> DungeonDefinition::decide_river_terrains(int threshold) const
+tl::optional<std::pair<TerrainTag, TerrainTag>> DungeonDefinition::decide_river_terrains(int threshold) const
 {
     if (this->flags.has(DungeonFeatureType::WATER_RIVER) && (randint1(MAX_DEPTH * 2) - 1 > threshold)) {
         return std::make_pair<TerrainTag, TerrainTag>(TerrainTag::DEEP_WATER, TerrainTag::SHALLOW_WATER);
@@ -173,7 +173,7 @@ std::optional<std::pair<TerrainTag, TerrainTag>> DungeonDefinition::decide_river
     }
 
     if (tags.empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return rand_choice(tags);

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -19,8 +19,8 @@
 #include "util/flag-group.h"
 #include "util/point-2d.h"
 #include "util/probability-table.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <utility>
 #include <vector>
 
@@ -98,7 +98,7 @@ public:
     std::string build_entrance_message() const;
     std::string describe_depth() const;
     int calc_cavern_terrains() const;
-    std::optional<std::pair<TerrainTag, TerrainTag>> decide_river_terrains(int threshold) const;
+    tl::optional<std::pair<TerrainTag, TerrainTag>> decide_river_terrains(int threshold) const;
     DoorKind select_door_kind() const;
     short select_floor_terrain_id() const;
     short select_wall_terrain_id() const;

--- a/src/system/dungeon/dungeon-record.cpp
+++ b/src/system/dungeon/dungeon-record.cpp
@@ -42,8 +42,8 @@ void DungeonRecord::set_max_level(int level)
 
 void DungeonRecord::reset()
 {
-    this->max_level = std::nullopt;
-    this->max_max_level = std::nullopt;
+    this->max_level = tl::nullopt;
+    this->max_max_level = tl::nullopt;
 }
 
 DungeonRecords DungeonRecords::instance{};

--- a/src/system/dungeon/dungeon-record.h
+++ b/src/system/dungeon/dungeon-record.h
@@ -9,8 +9,8 @@
 #include "util/abstract-map-wrapper.h"
 #include <map>
 #include <memory>
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 class DungeonRecord {
@@ -23,8 +23,8 @@ public:
     void reset();
 
 private:
-    std::optional<int> max_max_level; //!< @details 将来の拡張. 帰還時に浅いフロアを指定しても維持する.
-    std::optional<int> max_level; //!< @details 帰還時に浅いフロアを指定すると書き換わる.
+    tl::optional<int> max_max_level; //!< @details 将来の拡張. 帰還時に浅いフロアを指定しても維持する.
+    tl::optional<int> max_level; //!< @details 帰還時に浅いフロアを指定すると書き換わる.
 };
 
 enum class DungeonId;

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -113,7 +113,7 @@ const DungeonDefinition &FloorType::get_dungeon_definition() const
  * @param level 検索対象になる階
  * @return クエストIDを返す。該当がない場合0を返す。
  */
-QuestId FloorType::get_random_quest_id(std::optional<int> level_opt) const
+QuestId FloorType::get_random_quest_id(tl::optional<int> level_opt) const
 {
     if (this->dungeon_id != DungeonId::ANGBAND) {
         return QuestId::NONE;
@@ -354,7 +354,7 @@ bool FloorType::can_drop_item_at(const Pos2D &pos) const
  * @return 財宝データで初期化したアイテム
  * @details 生成レベルが0になったら1に補正する
  */
-ItemEntity FloorType::make_gold(std::optional<BaseitemKey> bi_key) const
+ItemEntity FloorType::make_gold(tl::optional<BaseitemKey> bi_key) const
 {
     ItemEntity item;
     if (bi_key) {
@@ -375,10 +375,10 @@ ItemEntity FloorType::make_gold(std::optional<BaseitemKey> bi_key) const
  * @details 地上生成は禁止、生成制限がある場合も禁止、個々のアーティファクト生成条件及び生成確率を潜り抜けなければ生成失敗とする
  * 最初に潜り抜けたINSTA_ART型の固定アーティファクトを生成し、以後はチェックせずスキップする
  */
-std::optional<ItemEntity> FloorType::try_make_instant_artifact() const
+tl::optional<ItemEntity> FloorType::try_make_instant_artifact() const
 {
     if (!this->is_underground() || (select_baseitem_id_hook != nullptr)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return ArtifactList::get_instance().try_make_instant_artifact(this->object_level);
@@ -526,7 +526,7 @@ void FloorType::reset_mproc_max()
  * @param mte モンスターの時限ステータスID
  * @return 残りターン値
  */
-std::optional<int> FloorType::get_mproc_index(short m_idx, MonsterTimedEffect mte)
+tl::optional<int> FloorType::get_mproc_index(short m_idx, MonsterTimedEffect mte)
 {
     const auto &cur_mproc_list = this->mproc_list[mte];
     for (auto i = this->mproc_max[mte] - 1; i >= 0; i--) {
@@ -535,7 +535,7 @@ std::optional<int> FloorType::get_mproc_index(short m_idx, MonsterTimedEffect mt
         }
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -9,7 +9,7 @@
 #include "util/point-2d.h"
 #include <array>
 #include <map>
-#include <optional>
+#include <tl/optional.hpp>
 #include <utility>
 #include <vector>
 
@@ -112,7 +112,7 @@ public:
     void set_dungeon_index(DungeonId id);
     void reset_dungeon_index();
     const DungeonDefinition &get_dungeon_definition() const; //!< @details 定義データなので非const 版の使用は禁止.
-    QuestId get_random_quest_id(std::optional<int> level_opt = std::nullopt) const;
+    QuestId get_random_quest_id(tl::optional<int> level_opt = tl::nullopt) const;
     QuestId get_quest_id(const int bonus = 0) const;
     bool has_los_at(const Pos2D &pos) const;
     bool has_los_terrain_at(const Pos2D &pos) const;
@@ -132,8 +132,8 @@ public:
     bool can_block_disintegration_at(const Pos2D &pos) const;
     bool can_drop_item_at(const Pos2D &pos) const;
 
-    ItemEntity make_gold(std::optional<BaseitemKey> bi_key = std::nullopt) const;
-    std::optional<ItemEntity> try_make_instant_artifact() const;
+    ItemEntity make_gold(tl::optional<BaseitemKey> bi_key = tl::nullopt) const;
+    tl::optional<ItemEntity> try_make_instant_artifact() const;
     short select_baseitem_id(int level_initial, uint32_t mode) const;
     bool filter_monrace_terrain(MonraceId monrace_id, MonraceHookTerrain hook) const;
     TerrainTag select_random_trap() const;
@@ -144,7 +144,7 @@ public:
     void leave_dungeon(bool state);
     void reset_mproc();
     void reset_mproc_max();
-    std::optional<int> get_mproc_index(short m_idx, MonsterTimedEffect mte);
+    tl::optional<int> get_mproc_index(short m_idx, MonsterTimedEffect mte);
     void add_mproc(short m_idx, MonsterTimedEffect mte);
     void remove_mproc(short m_idx, MonsterTimedEffect mte);
 

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -758,7 +758,7 @@ bool ItemEntity::is_corpse() const
 
 bool ItemEntity::is_inscribed() const
 {
-    return this->inscription != std::nullopt;
+    return this->inscription != tl::nullopt;
 }
 
 /*!

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -17,8 +17,8 @@
 #include "util/dice.h"
 #include "util/flag-group.h"
 #include "util/point-2d.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class FixedArtifactId : short;
@@ -63,8 +63,8 @@ public:
 
     byte smith_hit = 0; /*!< 鍛冶をした結果上昇した命中値 */
     byte smith_damage = 0; /*!< 鍛冶をした結果上昇したダメージ */
-    std::optional<SmithEffectType> smith_effect; //!< 鍛冶で付与された効果
-    std::optional<RandomArtActType> smith_act_idx; //!< 鍛冶で付与された発動効果のID
+    tl::optional<SmithEffectType> smith_effect; //!< 鍛冶で付与された効果
+    tl::optional<RandomArtActType> smith_act_idx; //!< 鍛冶で付与された発動効果のID
 
     HIT_PROB to_h{}; /*!< Plusses to hit */
     int to_d{}; /*!< Plusses to damage */
@@ -75,8 +75,8 @@ public:
     TIME_EFFECT timeout{}; /*!< Timeout Counter */
     byte ident{}; /*!< Special flags  */
     EnumClassFlagGroup<OmType> marked{}; /*!< Object is marked */
-    std::optional<std::string> inscription{}; /*!< Inscription */
-    std::optional<std::string> randart_name{}; /*!< Artifact name (random artifacts) */
+    tl::optional<std::string> inscription{}; /*!< Inscription */
+    tl::optional<std::string> randart_name{}; /*!< Artifact name (random artifacts) */
     byte feeling{}; /*!< Game generated inscription number (eg, pseudo-id) */
 
     TrFlags art_flags{}; /*!< Extra Flags for ego and artifacts */

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -156,7 +156,7 @@ std::string MonraceDefinition::get_died_message() const
     return is_explodable ? _("は爆発して粉々になった。", " explodes into tiny shreds.") : _("を倒した。", " is destroyed.");
 }
 
-std::optional<bool> MonraceDefinition::order_level(const MonraceDefinition &other) const
+tl::optional<bool> MonraceDefinition::order_level(const MonraceDefinition &other) const
 {
     if (this->level > other.level) {
         return true;
@@ -166,7 +166,7 @@ std::optional<bool> MonraceDefinition::order_level(const MonraceDefinition &othe
         return false;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 bool MonraceDefinition::order_level_strictly(const MonraceDefinition &other) const
@@ -174,7 +174,7 @@ bool MonraceDefinition::order_level_strictly(const MonraceDefinition &other) con
     return this->level > other.level;
 }
 
-std::optional<bool> MonraceDefinition::order_pet(const MonraceDefinition &other) const
+tl::optional<bool> MonraceDefinition::order_pet(const MonraceDefinition &other) const
 {
     if (this->kind_flags.has(MonsterKindType::UNIQUE) && other.kind_flags.has_not(MonsterKindType::UNIQUE)) {
         return true;
@@ -332,7 +332,7 @@ bool MonraceDefinition::has_reinforce() const
     return it != end;
 }
 
-std::optional<std::string> MonraceDefinition::get_message(std::string_view monster_name, const MonsterMessageType message_type) const
+tl::optional<std::string> MonraceDefinition::get_message(std::string_view monster_name, const MonsterMessageType message_type) const
 {
     return MonraceMessageList::get_instance().get_message((int)this->idx, monster_name, message_type);
 }
@@ -677,7 +677,7 @@ void MonraceDefinition::init_sex(uint32_t value)
     this->sex = sex_tmp;
 }
 
-std::optional<std::string> MonraceDefinition::probe_lore()
+tl::optional<std::string> MonraceDefinition::probe_lore()
 {
     auto n = false;
     if (this->r_wake != MAX_UCHAR) {
@@ -750,7 +750,7 @@ std::optional<std::string> MonraceDefinition::probe_lore()
 
     this->r_can_evolve = true;
     if (n == 0) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
 #ifdef JP

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -20,9 +20,9 @@
 #include "util/dice.h"
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 
 /*! モンスターが1ターンに攻撃する最大回数 (射撃を含む) / The maximum number of times a monster can attack in a turn (including SHOOT) */
@@ -151,9 +151,9 @@ public:
     bool is_angel_superficially() const;
     bool symbol_char_is_any_of(std::string_view symbol_characters) const;
     std::string get_died_message() const;
-    std::optional<bool> order_level(const MonraceDefinition &other) const;
+    tl::optional<bool> order_level(const MonraceDefinition &other) const;
     bool order_level_strictly(const MonraceDefinition &other) const;
-    std::optional<bool> order_pet(const MonraceDefinition &other) const;
+    tl::optional<bool> order_pet(const MonraceDefinition &other) const;
     std::string get_pronoun_of_summoned_kin() const;
     const MonraceDefinition &get_next() const;
     bool is_bounty(bool unachieved_only) const;
@@ -162,7 +162,7 @@ public:
     int calc_capture_value() const;
     std::string build_eldritch_horror_message(std::string_view description) const;
     bool has_reinforce() const;
-    std::optional<std::string> get_message(std::string_view monster_name, const MonsterMessageType message_type) const;
+    tl::optional<std::string> get_message(std::string_view monster_name, const MonsterMessageType message_type) const;
     const std::vector<DropArtifact> &get_drop_artifacts() const;
     const std::vector<Reinforce> &get_reinforces() const;
     bool can_generate() const;
@@ -207,7 +207,7 @@ public:
     bool is_suitable_for_evil_nest(char symbol) const;
 
     void init_sex(uint32_t value);
-    std::optional<std::string> probe_lore();
+    tl::optional<std::string> probe_lore();
     void make_lore_treasure(int num_item, int num_drop);
     void emplace_drop_artifact(FixedArtifactId fa_id, int percentage);
     void emplace_reinforce(MonraceId monrace_id, const Dice &dice);

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -502,7 +502,7 @@ void MonraceList::reset_all_visuals()
     }
 }
 
-std::optional<std::string> MonraceList::probe_lore(MonraceId monrace_id)
+tl::optional<std::string> MonraceList::probe_lore(MonraceId monrace_id)
 {
     if (LoreTracker::get_instance().is_tracking(monrace_id)) {
         RedrawingFlagsUpdater::get_instance().set_flag(SubWindowRedrawingFlag::MONSTER_LORE);

--- a/src/system/monrace/monrace-list.h
+++ b/src/system/monrace/monrace-list.h
@@ -9,9 +9,9 @@
 #include "util/abstract-map-wrapper.h"
 #include <functional>
 #include <map>
-#include <optional>
 #include <set>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class MonraceId : short;
@@ -57,7 +57,7 @@ public:
 
     void reset_current_numbers();
     void reset_all_visuals();
-    std::optional<std::string> probe_lore(MonraceId monrace_id);
+    tl::optional<std::string> probe_lore(MonraceId monrace_id);
     void kill_unique_monster(MonraceId monrace_id);
 
 private:

--- a/src/system/monrace/monrace-message.cpp
+++ b/src/system/monrace/monrace-message.cpp
@@ -2,7 +2,6 @@
 #include "locale/language-switcher.h"
 #include "term/z-rand.h"
 #include "util/string-processor.h"
-#include <optional>
 #include <tl/optional.hpp>
 #include <vector>
 
@@ -13,13 +12,13 @@ MonsterMessage::MonsterMessage(int chance, bool use_name, std::string_view messa
 {
 }
 
-std::optional<std::string_view> MonsterMessage::get_message() const
+tl::optional<std::string_view> MonsterMessage::get_message() const
 {
     if (this->chance < 1) {
-        return std::nullopt;
+        return tl::nullopt;
     }
     if (!one_in_(this->chance)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
     return this->message;
 }
@@ -71,17 +70,17 @@ MonraceMessageList &MonraceMessageList::get_instance()
     return instance;
 }
 
-std::optional<std::string> MonraceMessageList::get_message(const int monrace_id, std::string_view monrace_name, const MonsterMessageType message_type)
+tl::optional<std::string> MonraceMessageList::get_message(const int monrace_id, std::string_view monrace_name, const MonsterMessageType message_type)
 {
     auto message_obj = this->get_message_obj(monrace_id, message_type);
 
     if (!message_obj) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto message_str = message_obj->get_message();
     if (!message_str) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (message_obj->start_with_monname()) {

--- a/src/system/monrace/monrace-message.h
+++ b/src/system/monrace/monrace-message.h
@@ -2,7 +2,6 @@
 
 #include "monster-race/race-speak-flags.h"
 #include <map>
-#include <optional>
 #include <string>
 #include <string_view>
 #include <tl/optional.hpp>
@@ -11,7 +10,7 @@
 class MonsterMessage {
 public:
     MonsterMessage(int chance, bool use_name, std::string_view message);
-    std::optional<std::string_view> get_message() const;
+    tl::optional<std::string_view> get_message() const;
     bool start_with_monname() const;
 
 private:
@@ -48,7 +47,7 @@ public:
     ~MonraceMessageList() = default;
 
     static MonraceMessageList &get_instance();
-    std::optional<std::string> get_message(const int monrace_id, std::string_view monrace_name, const MonsterMessageType message_type);
+    tl::optional<std::string> get_message(const int monrace_id, std::string_view monrace_name, const MonsterMessageType message_type);
     void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
     void emplace_default(const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
 

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -329,7 +329,7 @@ std::string MonsterEntity::get_died_message() const
  * @brief モンスターにダメージを与えた際の述語メッセージを返す
  * @return ダメージを受けたモンスターの述語
  */
-std::optional<std::string> MonsterEntity::get_pain_message(std::string_view monster_name, int damage) const
+tl::optional<std::string> MonsterEntity::get_pain_message(std::string_view monster_name, int damage) const
 {
     auto &monrace = this->get_monrace();
     return MonsterPainDescriber(monrace.idx, monrace.symbol_definition.character, monster_name).describe(this->hp, damage, this->ml);
@@ -365,7 +365,7 @@ std::pair<TERM_COLOR, int> MonsterEntity::get_hp_bar_data() const
     return { TERM_RED, len };
 }
 
-std::optional<bool> MonsterEntity::order_pet_whistle(const MonsterEntity &other) const
+tl::optional<bool> MonsterEntity::order_pet_whistle(const MonsterEntity &other) const
 {
     const auto is_ordered_name = this->order_pet_named(other);
     if (is_ordered_name) {
@@ -382,7 +382,7 @@ std::optional<bool> MonsterEntity::order_pet_whistle(const MonsterEntity &other)
     return this->order_pet_hp(other);
 }
 
-std::optional<bool> MonsterEntity::order_pet_dismission(const MonsterEntity &other) const
+tl::optional<bool> MonsterEntity::order_pet_dismission(const MonsterEntity &other) const
 {
     const auto is_ordered_name = this->order_pet_named(other);
     if (is_ordered_name) {
@@ -476,7 +476,7 @@ void MonsterEntity::make_lore_treasure(int num_item, int num_gold) const
     }
 }
 
-std::optional<bool> MonsterEntity::order_pet_named(const MonsterEntity &other) const
+tl::optional<bool> MonsterEntity::order_pet_named(const MonsterEntity &other) const
 {
     if (this->is_named() && !other.is_named()) {
         return true;
@@ -486,10 +486,10 @@ std::optional<bool> MonsterEntity::order_pet_named(const MonsterEntity &other) c
         return false;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
-std::optional<bool> MonsterEntity::order_pet_hp(const MonsterEntity &other) const
+tl::optional<bool> MonsterEntity::order_pet_hp(const MonsterEntity &other) const
 {
     if (this->hp > other.hp) {
         return true;
@@ -499,7 +499,7 @@ std::optional<bool> MonsterEntity::order_pet_hp(const MonsterEntity &other) cons
         return false;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 /*!

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -103,9 +103,9 @@ public:
     std::string get_died_message() const;
     std::pair<TERM_COLOR, int> get_hp_bar_data() const;
     std::string get_pronoun_of_summoned_kin() const;
-    std::optional<std::string> get_pain_message(std::string_view monster_name, int damage) const;
-    std::optional<bool> order_pet_whistle(const MonsterEntity &other) const;
-    std::optional<bool> order_pet_dismission(const MonsterEntity &other) const;
+    tl::optional<std::string> get_pain_message(std::string_view monster_name, int damage) const;
+    tl::optional<bool> order_pet_whistle(const MonsterEntity &other) const;
+    tl::optional<bool> order_pet_dismission(const MonsterEntity &other) const;
     bool is_riding() const;
     Pos2D get_position() const;
     Pos2D get_target_position() const;
@@ -125,8 +125,8 @@ private:
     MonsterEntity(const MonsterEntity &) = default;
     MonsterEntity &operator=(const MonsterEntity &) = default;
 
-    std::optional<bool> order_pet_named(const MonsterEntity &other) const;
-    std::optional<bool> order_pet_hp(const MonsterEntity &other) const;
+    tl::optional<bool> order_pet_named(const MonsterEntity &other) const;
+    tl::optional<bool> order_pet_hp(const MonsterEntity &other) const;
     std::string build_damage_description() const;
     std::string build_attitude_description() const;
 };

--- a/src/system/services/baseitem-monrace-service.cpp
+++ b/src/system/services/baseitem-monrace-service.cpp
@@ -47,7 +47,7 @@ EnumClassFlagGroup<MonsterDropType> make_fixed_gold_drop_flags()
  * @param flags ドロップ関連フラグリスト
  * @return 特定の財宝を落とすならそのアイテムのBaseitemKey、一般的な財宝ドロップならばnullopt
  */
-std::optional<BaseitemKey> BaseitemMonraceService::lookup_fixed_gold_drop(const EnumClassFlagGroup<MonsterDropType> &flags)
+tl::optional<BaseitemKey> BaseitemMonraceService::lookup_fixed_gold_drop(const EnumClassFlagGroup<MonsterDropType> &flags)
 {
     for (const auto &pair : FIXED_GOLD_DROPS) {
         if (flags.has_not(pair.first)) {
@@ -56,10 +56,10 @@ std::optional<BaseitemKey> BaseitemMonraceService::lookup_fixed_gold_drop(const 
         return pair.second;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }
 
-std::optional<std::string> BaseitemMonraceService::check_specific_drop_gold_flags_duplication()
+tl::optional<std::string> BaseitemMonraceService::check_specific_drop_gold_flags_duplication()
 {
     const auto specific_gold_drop_flags = make_fixed_gold_drop_flags();
 
@@ -74,5 +74,5 @@ std::optional<std::string> BaseitemMonraceService::check_specific_drop_gold_flag
         }
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/system/services/baseitem-monrace-service.h
+++ b/src/system/services/baseitem-monrace-service.h
@@ -10,12 +10,12 @@
 #include "monster-race/race-drop-flags.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "util/flag-group.h"
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 
 class BaseitemMonraceService {
 public:
     BaseitemMonraceService() = delete;
-    static std::optional<BaseitemKey> lookup_fixed_gold_drop(const EnumClassFlagGroup<MonsterDropType> &flags);
-    static std::optional<std::string> check_specific_drop_gold_flags_duplication();
+    static tl::optional<BaseitemKey> lookup_fixed_gold_drop(const EnumClassFlagGroup<MonsterDropType> &flags);
+    static tl::optional<std::string> check_specific_drop_gold_flags_duplication();
 };

--- a/src/system/services/dungeon-service.cpp
+++ b/src/system/services/dungeon-service.cpp
@@ -67,11 +67,11 @@ int DungeonService::find_max_level()
     return max_level;
 }
 
-std::optional<std::string> DungeonService::check_first_entrance(DungeonId dungeon_id)
+tl::optional<std::string> DungeonService::check_first_entrance(DungeonId dungeon_id)
 {
     const auto &record = DungeonRecords::get_instance().get_record(dungeon_id);
     if (record.has_entered()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return DungeonList::get_instance().get_dungeon(dungeon_id).build_entrance_message();

--- a/src/system/services/dungeon-service.h
+++ b/src/system/services/dungeon-service.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class DungeonMessageFormat {
@@ -26,6 +26,6 @@ public:
     DungeonService() = delete;
     static int decide_gradiator_level();
     static int find_max_level();
-    static std::optional<std::string> check_first_entrance(DungeonId dungeon_id);
+    static tl::optional<std::string> check_first_entrance(DungeonId dungeon_id);
     static std::vector<std::string> build_known_dungeons(DungeonMessageFormat dmf);
 };

--- a/src/system/spell-info-list.cpp
+++ b/src/system/spell-info-list.cpp
@@ -15,7 +15,7 @@ SpellInfoList &SpellInfoList::get_instance()
     return instance;
 }
 
-std::optional<short> SpellInfoList::get_spell_id(RealmType realm, std::string_view spell_tag) const
+tl::optional<short> SpellInfoList::get_spell_id(RealmType realm, std::string_view spell_tag) const
 {
     const auto &spells = this->spell_list[enum2i(realm)];
     const auto result = std::find_if(spells.begin(), spells.end(), [spell_tag](auto &spell_info) {
@@ -23,7 +23,7 @@ std::optional<short> SpellInfoList::get_spell_id(RealmType realm, std::string_vi
     });
 
     if (result == spells.end()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
     return (*result).idx;
 }

--- a/src/system/spell-info-list.h
+++ b/src/system/spell-info-list.h
@@ -3,9 +3,9 @@
 #include "external-lib/include-json.h"
 #include "realm/realm-types.h"
 #include "system/angband.h"
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <unordered_map>
 #include <vector>
 
@@ -53,7 +53,7 @@ public:
 
     static SpellInfoList &get_instance();
 
-    std::optional<short> get_spell_id(RealmType realm, std::string_view spell_tag) const;
+    tl::optional<short> get_spell_id(RealmType realm, std::string_view spell_tag) const;
     const SpellInfo &get_spell_info(RealmType realm, int spell_id) const;
 
 private:

--- a/src/system/terrain/terrain-list.cpp
+++ b/src/system/terrain/terrain-list.cpp
@@ -114,12 +114,12 @@ void TerrainList::emplace_tags()
 /*!
  * @brief 地形タグからIDを得る
  * @param tag タグ文字列のオフセット
- * @return 地形ID。該当がないならstd::nullopt
+ * @return 地形ID。該当がないならtl::nullopt
  */
-std::optional<short> TerrainList::search_real_terrain(std::string_view tag) const
+tl::optional<short> TerrainList::search_real_terrain(std::string_view tag) const
 {
     if (tag.empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return this->get_terrain_id(tag);

--- a/src/system/terrain/terrain-list.h
+++ b/src/system/terrain/terrain-list.h
@@ -8,8 +8,8 @@
 
 #include "util/abstract-vector-wrapper.h"
 #include <map>
-#include <optional>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 
 enum class TerrainTag;
@@ -46,5 +46,5 @@ private:
         return this->terrains;
     }
 
-    std::optional<short> search_real_terrain(std::string_view tag) const;
+    tl::optional<short> search_real_terrain(std::string_view tag) const;
 };

--- a/src/target/grid-selector.cpp
+++ b/src/target/grid-selector.cpp
@@ -70,7 +70,7 @@ static std::vector<Pos2D> tgt_pt_prepare(PlayerType *player_ptr)
     return positions;
 }
 
-static std::optional<Pos2D> select_building_pos(const FloorType &floor)
+static tl::optional<Pos2D> select_building_pos(const FloorType &floor)
 {
     const auto is_building_pos = [&](const Pos2D &pos) {
         return floor.get_grid(pos).has(TerrainCharacteristics::BLDG);
@@ -81,7 +81,7 @@ static std::optional<Pos2D> select_building_pos(const FloorType &floor)
         ranges::to<std::vector>();
 
     if (pos_buildings.size() <= 1) {
-        return pos_buildings.empty() ? std::nullopt : std::make_optional(pos_buildings.front());
+        return pos_buildings.empty() ? tl::nullopt : tl::make_optional(pos_buildings.front());
     }
 
     CandidateSelector cs(_("施設を選択してください:", "Select a building:"), 15);
@@ -92,7 +92,7 @@ static std::optional<Pos2D> select_building_pos(const FloorType &floor)
     };
 
     const auto choice = cs.select(pos_buildings, describer);
-    return choice != pos_buildings.end() ? std::make_optional(*choice) : std::nullopt;
+    return choice != pos_buildings.end() ? tl::make_optional(*choice) : tl::nullopt;
 }
 
 /*!
@@ -196,7 +196,7 @@ void tgt_pt_info::move_to_symbol(PlayerType *player_ptr)
  * @param player_ptr プレイヤー情報への参照ポインタ
  * @return 指定したらその座標、キャンセルしたらnullopt
  */
-std::optional<Pos2D> point_target(PlayerType *player_ptr)
+tl::optional<Pos2D> point_target(PlayerType *player_ptr)
 {
     tgt_pt_info info;
     info.pos = player_ptr->get_position();
@@ -208,7 +208,7 @@ std::optional<Pos2D> point_target(PlayerType *player_ptr)
 
     info.ch = 0;
     info.n = 0;
-    std::optional<Pos2D> pos_target;
+    tl::optional<Pos2D> pos_target;
     while ((info.ch != ESCAPE) && !pos_target) {
         prt(_("場所を選んでスペースキーを押して下さい。", "Select a point and press space."), 0, 0);
         auto move_fast = false;

--- a/src/target/grid-selector.h
+++ b/src/target/grid-selector.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "util/point-2d.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<Pos2D> point_target(PlayerType *player_ptr);
+tl::optional<Pos2D> point_target(PlayerType *player_ptr);

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -27,7 +27,7 @@
 #include "util/string-processor.h"
 #include "window/display-sub-windows.h"
 #include "window/main-window-util.h"
-#include <optional>
+#include <tl/optional.hpp>
 #include <tuple>
 #include <vector>
 
@@ -41,16 +41,16 @@ public:
     }
 
 private:
-    std::optional<int> pick_nearest_interest_target(const Pos2D &pos, const Direction &dir);
+    tl::optional<int> pick_nearest_interest_target(const Pos2D &pos, const Direction &dir);
     std::string describe_projectablity() const;
-    char examine_target_grid(std::string_view info, std::optional<target_type> append_mode = std::nullopt) const;
+    char examine_target_grid(std::string_view info, tl::optional<target_type> append_mode = tl::nullopt) const;
     void change_interest_index(int amount);
     Direction switch_target_input();
-    std::optional<int> check_panel_changed(const Direction &dir);
-    std::optional<int> sweep_targets(const Direction &dir, int panel_row_min_initial, int panel_col_min_initial);
+    tl::optional<int> check_panel_changed(const Direction &dir);
+    tl::optional<int> sweep_targets(const Direction &dir, int panel_row_min_initial, int panel_col_min_initial);
     bool set_target_grid();
     std::string describe_grid_wizard() const;
-    std::optional<std::pair<Direction, bool>> switch_next_grid_command();
+    tl::optional<std::pair<Direction, bool>> switch_next_grid_command();
     void decide_change_panel(const Direction &dir, bool move_fast);
 
     PlayerType *player_ptr;
@@ -58,7 +58,7 @@ private:
     Pos2D pos_target;
     bool done = false;
     std::vector<Pos2D> pos_interests; // "interesting" な座標一覧を記録する配列
-    std::optional<int> interest_index = 0; // "interesting" な座標一覧のうち現在ターゲットしているもののインデックス
+    tl::optional<int> interest_index = 0; // "interesting" な座標一覧のうち現在ターゲットしているもののインデックス
     Target target = Target::none();
 };
 
@@ -124,26 +124,26 @@ static bool change_panel_xy(PlayerType *player_ptr, const Pos2D &pos)
  * @param pos_from 基準の座標
  * @param pos_to 目標の座標
  * @param dir 方向
- * @return 距離。目標の座標が dir の方向±45°の範囲にない場合 std::nullopt
+ * @return 距離。目標の座標が dir の方向±45°の範囲にない場合 tl::nullopt
  */
-static std::optional<int> calc_target_distance(const Pos2D &pos_from, const Pos2D &pos_to, const Direction &dir)
+static tl::optional<int> calc_target_distance(const Pos2D &pos_from, const Pos2D &pos_to, const Direction &dir)
 {
     const auto [dy, dx] = dir.vec();
     const auto vec = pos_to - pos_from;
     const Pos2DVec vec_abs(std::abs(vec.y), std::abs(vec.x));
 
     if (dx != 0 && (vec.x * dx <= 0)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
     if (dy != 0 && (vec.y * dy <= 0)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (dy != 0 && dx == 0 && (vec_abs.x > vec_abs.y)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
     if (dx != 0 && dy == 0 && (vec_abs.y > vec_abs.x)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     // ターゲット選択用に独自の距離計算を行う
@@ -158,12 +158,12 @@ static std::optional<int> calc_target_distance(const Pos2D &pos_from, const Pos2
  * @brief "interesting" な座標一覧のうち、pos から dir 方向にある最も近いもののインデックスを得る。
  * @param pos 基準座標
  * @param dir 基準座標からの向き
- * @return 最も近い座標のインデックス。適切なものがない場合 std::nullopt
+ * @return 最も近い座標のインデックス。適切なものがない場合 tl::nullopt
  */
-std::optional<int> TargetSetter::pick_nearest_interest_target(const Pos2D &pos, const Direction &dir)
+tl::optional<int> TargetSetter::pick_nearest_interest_target(const Pos2D &pos, const Direction &dir)
 {
-    std::optional<int> nearest_interest_index;
-    std::optional<int> nearest_distance;
+    tl::optional<int> nearest_interest_index;
+    tl::optional<int> nearest_distance;
 
     for (auto i = 0; i < std::ssize(this->pos_interests); i++) {
         const auto distance = calc_target_distance(pos, this->pos_interests[i], dir);
@@ -214,7 +214,7 @@ std::string TargetSetter::describe_projectablity() const
     return info.append(cheatinfo);
 }
 
-char TargetSetter::examine_target_grid(std::string_view info, std::optional<target_type> append_mode) const
+char TargetSetter::examine_target_grid(std::string_view info, tl::optional<target_type> append_mode) const
 {
     const auto target_mode = append_mode ? i2enum<target_type>(this->mode | *append_mode) : this->mode;
     while (true) {
@@ -228,7 +228,7 @@ char TargetSetter::examine_target_grid(std::string_view info, std::optional<targ
 void TargetSetter::change_interest_index(int amount)
 {
     if (!this->interest_index || this->pos_interests.empty()) {
-        this->interest_index = std::nullopt;
+        this->interest_index = tl::nullopt;
         return;
     }
     *this->interest_index += amount;
@@ -289,7 +289,7 @@ Direction TargetSetter::switch_target_input()
     }
         [[fallthrough]];
     case 'o':
-        this->interest_index = std::nullopt;
+        this->interest_index = tl::nullopt;
         return Direction::none();
     case 'm':
         return Direction::none();
@@ -315,9 +315,9 @@ Direction TargetSetter::switch_target_input()
 
 /*!
  * @brief カーソル移動に伴い、描画範囲、"interesting" 座標リスト、現在のターゲットを更新する。
- * @return カーソル移動によって "interesting" な座標が選択されたらそのインデックス、そうでなければ std::nullopt
+ * @return カーソル移動によって "interesting" な座標が選択されたらそのインデックス、そうでなければ tl::nullopt
  */
-std::optional<int> TargetSetter::check_panel_changed(const Direction &dir)
+tl::optional<int> TargetSetter::check_panel_changed(const Direction &dir)
 {
     // 描画範囲が変化した場合、"interesting" 座標リストおよび現在のターゲットを更新する必要がある。
 
@@ -335,9 +335,9 @@ std::optional<int> TargetSetter::check_panel_changed(const Direction &dir)
 /*!
  * @brief カーソル移動方向に "interesting" な座標がなかったとき、画面外まで探す。
  *
- * @return 画面外を探し "interesting" な座標が見つかった場合はそのインデックス、それでも見つからなければ std::nullopt
+ * @return 画面外を探し "interesting" な座標が見つかった場合はそのインデックス、それでも見つからなければ tl::nullopt
  */
-std::optional<int> TargetSetter::sweep_targets(const Direction &dir, int panel_row_min_initial, int panel_col_min_initial)
+tl::optional<int> TargetSetter::sweep_targets(const Direction &dir, int panel_row_min_initial, int panel_col_min_initial)
 {
     auto [dy, dx] = dir.vec();
     while (change_panel(this->player_ptr, dy, dx)) {
@@ -382,7 +382,7 @@ std::optional<int> TargetSetter::sweep_targets(const Direction &dir, int panel_r
     const auto &floor = *this->player_ptr->current_floor_ptr;
     x = std::clamp(x, 1, floor.width - 2);
     y = std::clamp(y, 1, floor.height - 2);
-    return std::nullopt;
+    return tl::nullopt;
 }
 
 bool TargetSetter::set_target_grid()
@@ -427,9 +427,9 @@ std::string TargetSetter::describe_grid_wizard() const
 /*!
  * @brief 隣接マスへのターゲット切り替えモードでのコマンドを処理する
  *
- * @return 移動方向と早く移動するかどうかのペア。移動しない場合はstd::nullopt
+ * @return 移動方向と早く移動するかどうかのペア。移動しない場合はtl::nullopt
  */
-std::optional<std::pair<Direction, bool>> TargetSetter::switch_next_grid_command()
+tl::optional<std::pair<Direction, bool>> TargetSetter::switch_next_grid_command()
 {
     std::string info = _("q止 t決 p自 m近 +次 -前", "q,t,p,m,+,-,<dir>");
     if (any_bits(this->mode, TARGET_LOOK)) {
@@ -441,14 +441,14 @@ std::optional<std::pair<Direction, bool>> TargetSetter::switch_next_grid_command
     case ESCAPE:
     case 'q':
         this->done = true;
-        return std::nullopt;
+        return tl::nullopt;
     case 't':
     case '.':
     case '5':
     case '0':
         this->target = Target::create_grid_target(this->player_ptr, this->pos_target);
         this->done = true;
-        return std::nullopt;
+        return tl::nullopt;
     case 'p': {
         verify_panel(this->player_ptr);
         auto &rfu = RedrawingFlagsUpdater::get_instance();
@@ -458,12 +458,12 @@ std::optional<std::pair<Direction, bool>> TargetSetter::switch_next_grid_command
         handle_stuff(this->player_ptr);
         this->pos_interests = target_set_prepare(this->player_ptr, this->mode);
         this->pos_target = this->player_ptr->get_position();
-        return std::nullopt;
+        return tl::nullopt;
     }
     case 'o':
         // ターゲット時の「m近」「o現」の切り替え
         // すでに「o現」の時にoを押してもなにも起きない
-        return std::nullopt;
+        return tl::nullopt;
     case ' ':
     case '*':
     case '+':
@@ -477,19 +477,19 @@ std::optional<std::pair<Direction, bool>> TargetSetter::switch_next_grid_command
         if (interest != end) {
             this->interest_index = std::distance(this->pos_interests.begin(), interest);
         } else {
-            this->interest_index = std::nullopt;
+            this->interest_index = tl::nullopt;
         }
 
-        return std::nullopt;
+        return tl::nullopt;
     }
     case 'g':
         this->done = set_travel_goal(this->player_ptr, this->pos_target);
-        return std::nullopt;
+        return tl::nullopt;
     default:
         const auto dir = get_keymap_dir(query);
         if (!dir) {
             bell();
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         const auto move_fast = isupper(query) != 0;

--- a/src/target/target.cpp
+++ b/src/target/target.cpp
@@ -48,15 +48,15 @@ public:
         : player_ptr(player_ptr)
     {
     }
-    std::optional<Pos2D> operator()(std::monostate) const
+    tl::optional<Pos2D> operator()(std::monostate) const
     {
-        return std::nullopt;
+        return tl::nullopt;
     }
-    std::optional<Pos2D> operator()(const TargetGrid &target_grid) const
+    tl::optional<Pos2D> operator()(const TargetGrid &target_grid) const
     {
         return target_grid.pos;
     }
-    std::optional<Pos2D> operator()(const TargetMonster &target_monster) const
+    tl::optional<Pos2D> operator()(const TargetMonster &target_monster) const
     {
         const auto &monster = this->player_ptr->current_floor_ptr->m_list[target_monster.m_idx];
         return monster.get_position();
@@ -70,15 +70,15 @@ class MonsterIndexGetter {
 public:
     MonsterIndexGetter() = default;
 
-    std::optional<short> operator()(std::monostate) const
+    tl::optional<short> operator()(std::monostate) const
     {
-        return std::nullopt;
+        return tl::nullopt;
     }
-    std::optional<short> operator()(const TargetGrid &) const
+    tl::optional<short> operator()(const TargetGrid &) const
     {
-        return std::nullopt;
+        return tl::nullopt;
     }
-    std::optional<short> operator()(const TargetMonster &target_monster) const
+    tl::optional<short> operator()(const TargetMonster &target_monster) const
     {
         return target_monster.m_idx;
     }
@@ -190,14 +190,14 @@ bool Target::is_okay() const
 /*!
  * @brief ターゲットの座標を取得する
  * @return
- * なにもターゲットしていない場合はstd::nullopt
+ * なにもターゲットしていない場合はtl::nullopt
  * 特定のマスをターゲットしている場合はその座標
- * モンスターをターゲットしている場合target_able()==trueであればモンスターの座標、そうでなければstd::nullopt
+ * モンスターをターゲットしている場合target_able()==trueであればモンスターの座標、そうでなければtl::nullopt
  */
-std::optional<Pos2D> Target::get_position() const
+tl::optional<Pos2D> Target::get_position() const
 {
     if (!this->is_okay()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
     return std::visit(PositionGettor(this->impl->player_ptr), this->impl->target);
 }
@@ -205,10 +205,10 @@ std::optional<Pos2D> Target::get_position() const
 /*!
  * @brief ターゲットのモンスター参照IDを取得する
  * @return
- * モンスターをターゲットしていない場合はstd::nullopt
+ * モンスターをターゲットしていない場合はtl::nullopt
  * モンスターをターゲットしている場合はそのモンスター参照ID
  */
-std::optional<short> Target::get_m_idx() const
+tl::optional<short> Target::get_m_idx() const
 {
     return std::visit(MonsterIndexGetter(), this->impl->target);
 }

--- a/src/target/target.h
+++ b/src/target/target.h
@@ -2,7 +2,7 @@
 
 #include "util/point-2d.h"
 #include <memory>
-#include <optional>
+#include <tl/optional.hpp>
 
 class PlayerType;
 class Target {
@@ -20,8 +20,8 @@ public:
     static void clear_last_target();
 
     bool is_okay() const;
-    std::optional<Pos2D> get_position() const;
-    std::optional<short> get_m_idx() const;
+    tl::optional<Pos2D> get_position() const;
+    tl::optional<short> get_m_idx() const;
 
 private:
     Target();

--- a/src/term/screen-processor.cpp
+++ b/src/term/screen-processor.cpp
@@ -230,7 +230,7 @@ void roff(std::string_view str)
 void clear_from(int row)
 {
     for (int y = row; y < game_term->hgt; y++) {
-        TermOffsetSetter tos(0, std::nullopt);
+        TermOffsetSetter tos(0, tl::nullopt);
         term_erase(0, y);
     }
 }

--- a/src/term/z-rand.cpp
+++ b/src/term/z-rand.cpp
@@ -15,8 +15,8 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <optional>
 #include <random>
+#include <tl/optional.hpp>
 
 /*
  * Angband 2.7.9 introduced a new (optimized) random number generator,
@@ -134,7 +134,7 @@ int32_t Rand_external(int32_t m)
         return 0;
     }
 
-    static std::optional<Xoshiro128StarStar> urbg_external;
+    static tl::optional<Xoshiro128StarStar> urbg_external;
 
     if (!urbg_external) {
         /* Initialize with new seed */

--- a/src/term/z-term.cpp
+++ b/src/term/z-term.cpp
@@ -40,12 +40,12 @@ term_type *game_term = nullptr;
  *
  * 引数でずらすX座標オフセット、Y座標オフセットをそれぞれ指定する。
  * 正方向のオフセットのみ有効。負の値が指定された場合、オフセット位置は 0 とする。
- * 指定された座標が std::nullopt の場合、現在のオフセットを維持する。
+ * 指定された座標が tl::nullopt の場合、現在のオフセットを維持する。
  *
  * @param x X座標オフセット
  * @param y Y座標オフセット
  */
-TermOffsetSetter::TermOffsetSetter(std::optional<TERM_LEN> x, std::optional<TERM_LEN> y)
+TermOffsetSetter::TermOffsetSetter(tl::optional<TERM_LEN> x, tl::optional<TERM_LEN> y)
     : term(game_term)
     , orig_offset_x(game_term != nullptr ? game_term->offset_x : 0)
     , orig_offset_y(game_term != nullptr ? game_term->offset_y : 0)
@@ -78,15 +78,15 @@ TermOffsetSetter::~TermOffsetSetter()
  * 表示に使用する領域の大きさを指定し、その領域が画面中央に表示されるように座標をずらす。
  * 引数で領域の横幅、縦幅をそれぞれ指定する。
  * 画面の幅より大きな値が指定された場合はオフセット 0 になる。
- * 指定された幅が std::nullopt の場合、画面の幅全体を使用する（オフセット 0 になる）。
+ * 指定された幅が tl::nullopt の場合、画面の幅全体を使用する（オフセット 0 になる）。
  *
  * @param width 表示に使用する領域の横幅
  * @param height 表示に使用する領域の縦幅
  */
-TermCenteredOffsetSetter::TermCenteredOffsetSetter(std::optional<TERM_LEN> width, std::optional<TERM_LEN> height)
+TermCenteredOffsetSetter::TermCenteredOffsetSetter(tl::optional<TERM_LEN> width, tl::optional<TERM_LEN> height)
     : term(game_term)
-    , orig_centered_wid(game_term != nullptr ? game_term->centered_wid : std::nullopt)
-    , orig_centered_hgt(game_term != nullptr ? game_term->centered_hgt : std::nullopt)
+    , orig_centered_wid(game_term != nullptr ? game_term->centered_wid : tl::nullopt)
+    , orig_centered_hgt(game_term != nullptr ? game_term->centered_hgt : tl::nullopt)
 {
     if (game_term == nullptr) {
         return;
@@ -96,8 +96,8 @@ TermCenteredOffsetSetter::TermCenteredOffsetSetter(std::optional<TERM_LEN> width
     const auto offset_y = height ? (game_term->hgt - *height) / 2 : 0;
     this->tos.emplace(offset_x, offset_y);
 
-    game_term->centered_wid = (width < game_term->wid) ? width : std::nullopt;
-    game_term->centered_hgt = (height < game_term->hgt) ? height : std::nullopt;
+    game_term->centered_wid = (width < game_term->wid) ? width : tl::nullopt;
+    game_term->centered_hgt = (height < game_term->hgt) ? height : tl::nullopt;
 }
 
 TermCenteredOffsetSetter::~TermCenteredOffsetSetter()
@@ -1504,7 +1504,7 @@ errr term_putstr(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR a, std::string_view s
 /*
  * Place cursor at (x,y), and clear the next "n" chars
  */
-errr term_erase(TERM_LEN x, TERM_LEN y, std::optional<int> n_opt)
+errr term_erase(TERM_LEN x, TERM_LEN y, tl::optional<int> n_opt)
 {
     TERM_LEN w = game_term->wid;
     /* int h = Term->hgt; */

--- a/src/term/z-term.h
+++ b/src/term/z-term.h
@@ -11,9 +11,9 @@
 #include "system/angband.h"
 #include "system/h-basic.h"
 #include <memory>
-#include <optional>
 #include <stack>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <utility>
 #include <vector>
 
@@ -75,8 +75,8 @@ struct term_type {
     TERM_LEN wid{}; //!< Window Width(max 255)
     TERM_LEN hgt{}; //!< Window Height(max 255)
 
-    std::optional<TERM_LEN> centered_wid{};
-    std::optional<TERM_LEN> centered_hgt{};
+    tl::optional<TERM_LEN> centered_wid{};
+    tl::optional<TERM_LEN> centered_hgt{};
 
     TERM_LEN offset_x{};
     TERM_LEN offset_y{};
@@ -119,7 +119,7 @@ struct term_type {
 
 class TermOffsetSetter {
 public:
-    TermOffsetSetter(std::optional<TERM_LEN> x, std::optional<TERM_LEN> y);
+    TermOffsetSetter(tl::optional<TERM_LEN> x, tl::optional<TERM_LEN> y);
     ~TermOffsetSetter();
     TermOffsetSetter(const TermOffsetSetter &) = delete;
     TermOffsetSetter &operator=(const TermOffsetSetter &) = delete;
@@ -134,7 +134,7 @@ private:
 
 class TermCenteredOffsetSetter {
 public:
-    TermCenteredOffsetSetter(std::optional<TERM_LEN> width, std::optional<TERM_LEN> height);
+    TermCenteredOffsetSetter(tl::optional<TERM_LEN> width, tl::optional<TERM_LEN> height);
     ~TermCenteredOffsetSetter();
     TermCenteredOffsetSetter(const TermCenteredOffsetSetter &) = delete;
     TermCenteredOffsetSetter &operator=(const TermCenteredOffsetSetter &) = delete;
@@ -142,10 +142,10 @@ public:
     TermCenteredOffsetSetter &operator=(TermCenteredOffsetSetter &&) = delete;
 
 private:
-    std::optional<TermOffsetSetter> tos;
+    tl::optional<TermOffsetSetter> tos;
     term_type *term;
-    std::optional<TERM_LEN> orig_centered_wid;
-    std::optional<TERM_LEN> orig_centered_hgt;
+    tl::optional<TERM_LEN> orig_centered_wid;
+    tl::optional<TERM_LEN> orig_centered_hgt;
 };
 
 /**** Available Constants ****/
@@ -209,7 +209,7 @@ void term_add_bigch(const DisplaySymbol &symbol);
 errr term_addstr(int n, TERM_COLOR a, std::string_view sv);
 void term_putch(TERM_LEN x, TERM_LEN y, const DisplaySymbol &symbol);
 errr term_putstr(TERM_LEN x, TERM_LEN y, int n, TERM_COLOR a, std::string_view sv);
-errr term_erase(TERM_LEN x, TERM_LEN y, std::optional<int> n_opt = std::nullopt);
+errr term_erase(TERM_LEN x, TERM_LEN y, tl::optional<int> n_opt = tl::nullopt);
 errr term_clear();
 errr term_redraw();
 errr term_redraw_section(TERM_LEN x1, TERM_LEN y1, TERM_LEN x2, TERM_LEN y2);

--- a/src/util/angband-files.cpp
+++ b/src/util/angband-files.cpp
@@ -263,9 +263,9 @@ FILE *angband_fopen_temp(char *buf, int max)
  * @brief ファイルから改行かEOFまでの文字列を読み取り、システムのエンコーディングに変換した結果を返す
  *
  * @param fp ファイルポインタ
- * @return 読み取った文字列。1バイトも読み取らずファイルの終端に達した場合はstd::nullopt
+ * @return 読み取った文字列。1バイトも読み取らずファイルの終端に達した場合はtl::nullopt
  */
-static std::optional<std::string> read_line(FILE *fp)
+static tl::optional<std::string> read_line(FILE *fp)
 {
     std::string line_buf;
 
@@ -280,7 +280,7 @@ static std::optional<std::string> read_line(FILE *fp)
     }
 
     if (line_buf.empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (line_buf.back() == '\n') {
@@ -313,16 +313,16 @@ static std::optional<std::string> read_line(FILE *fp)
  * @param n 読み込む文字列の最大サイズ。
  * 呼び出し側で終端文字を扱う可能性を考慮し、文字列長としては最大n-1バイトまでの文字列を返す。
  * デフォルト引数（std::string::npos）の場合は巨大な値であるため実質的にサイズ制限なし。
- * @return 読み取った文字列。1バイトも読み取らずファイルの終端に達した場合はstd::nullopt
+ * @return 読み取った文字列。1バイトも読み取らずファイルの終端に達した場合はtl::nullopt
  */
-std::optional<std::string> angband_fgets(FILE *fp, size_t n)
+tl::optional<std::string> angband_fgets(FILE *fp, size_t n)
 {
     // Reserve for null termination
     --n;
 
     const auto line = read_line(fp);
     if (!line) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     std::string str;

--- a/src/util/angband-files.h
+++ b/src/util/angband-files.h
@@ -2,9 +2,9 @@
 
 #include "system/angband.h"
 #include <filesystem>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 
 /* Force definitions -- see fd_seek() */
 #ifndef SEEK_SET
@@ -47,7 +47,7 @@ std::filesystem::path path_parse(const std::filesystem::path &path);
 std::filesystem::path path_build(const std::filesystem::path &path, std::string_view file);
 FILE *angband_fopen(const std::filesystem::path &path, const FileOpenMode mode, const bool is_binary = false);
 FILE *angband_fopen_temp(char *buf, int max);
-std::optional<std::string> angband_fgets(FILE *fp, size_t n = std::string::npos);
+tl::optional<std::string> angband_fgets(FILE *fp, size_t n = std::string::npos);
 errr angband_fclose(FILE *fff);
 void fd_kill(const std::filesystem::path &path);
 void fd_move(const std::filesystem::path &path_from, const std::filesystem::path &path_to);

--- a/src/util/candidate-selector.cpp
+++ b/src/util/candidate-selector.cpp
@@ -26,7 +26,7 @@ CandidateSelector::CandidateSelector(const std::string &prompt, int start_col)
     this->set_max_per_page();
 }
 
-std::pair<size_t, std::optional<size_t>> CandidateSelector::process_input(char cmd, size_t current_page, size_t page_max)
+std::pair<size_t, tl::optional<size_t>> CandidateSelector::process_input(char cmd, size_t current_page, size_t page_max)
 {
     switch (cmd) {
     case ' ':
@@ -48,7 +48,7 @@ std::pair<size_t, std::optional<size_t>> CandidateSelector::process_input(char c
         current_page %= page_max;
     }
 
-    return { current_page, std::nullopt };
+    return { current_page, tl::nullopt };
 }
 
 /*!

--- a/src/util/candidate-selector.h
+++ b/src/util/candidate-selector.h
@@ -6,9 +6,9 @@
 #include <array>
 #include <concepts>
 #include <limits>
-#include <optional>
 #include <sstream>
 #include <string>
+#include <tl/optional.hpp>
 
 /// @note clang-formatによるconceptの整形が安定していないので抑制しておく
 // clang-format off
@@ -96,7 +96,7 @@ public:
     }
 
 private:
-    static std::pair<size_t, std::optional<size_t>> process_input(char cmd, size_t current_page, size_t page_max);
+    static std::pair<size_t, tl::optional<size_t>> process_input(char cmd, size_t current_page, size_t page_max);
 
     template <SizedContainer Candidates, Describer<typename Candidates::value_type> F>
     void display_page(size_t page, const Candidates &candidates, F &&describe_candidate)

--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -5,7 +5,7 @@
 #include <concepts>
 #include <cstdint>
 #include <iterator>
-#include <optional>
+#include <tl/optional.hpp>
 #include <type_traits>
 
 template <typename T>
@@ -516,9 +516,9 @@ public:
     /**
      * @brief フラグ集合のONになっているフラグのうち最初のフラグを返す
      *
-     * @return フラグ集合のONになっているフラグのうち最初のフラグ。但し一つもONになっているフラグがなければ std::nullopt
+     * @return フラグ集合のONになっているフラグのうち最初のフラグ。但し一つもONになっているフラグがなければ tl::nullopt
      */
-    [[nodiscard]] std::optional<FlagType> first() const noexcept
+    [[nodiscard]] tl::optional<FlagType> first() const noexcept
     {
         for (size_t i = 0; i < bs_.size(); i++) {
             if (bs_.test(i)) {
@@ -526,7 +526,7 @@ public:
             }
         }
 
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     /**

--- a/src/util/probability-table.h
+++ b/src/util/probability-table.h
@@ -5,9 +5,9 @@
 #include <algorithm>
 #include <exception>
 #include <numeric>
-#include <optional>
 #include <random>
 #include <stdexcept>
+#include <tl/optional.hpp>
 #include <tuple>
 #include <vector>
 
@@ -148,5 +148,5 @@ private:
     /** 項目のIDと確率のセットを格納する配列 */
     std::vector<std::tuple<IdType, int>> item_list_;
 
-    mutable std::optional<std::discrete_distribution<>> dist_;
+    mutable tl::optional<std::discrete_distribution<>> dist_;
 };

--- a/src/util/sha256.cpp
+++ b/src/util/sha256.cpp
@@ -288,13 +288,13 @@ void SHA256::Impl::pad_message(std::byte pad_byte)
  * @brief ファイルのSHA-256ハッシュ値を計算する
  *
  * @param path ファイルパス
- * @return ハッシュ値を返す。ファイルの読み込みに失敗した場合はstd::nulloptを返す。
+ * @return ハッシュ値を返す。ファイルの読み込みに失敗した場合はtl::nulloptを返す。
  */
-std::optional<SHA256::Digest> SHA256::compute_filehash(const std::filesystem::path &path)
+tl::optional<SHA256::Digest> SHA256::compute_filehash(const std::filesystem::path &path)
 {
     std::ifstream ifs(path, std::ios::binary);
     if (!ifs) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     SHA256 hash;
@@ -306,7 +306,7 @@ std::optional<SHA256::Digest> SHA256::compute_filehash(const std::filesystem::pa
     }
 
     if (ifs.bad()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return hash.digest();

--- a/src/util/sha256.h
+++ b/src/util/sha256.h
@@ -46,9 +46,9 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 
 namespace util {
 
@@ -74,7 +74,7 @@ public:
     void final_bits(std::byte message_bits, size_t length);
     Digest digest();
 
-    static std::optional<Digest> compute_filehash(const std::filesystem::path &path);
+    static tl::optional<Digest> compute_filehash(const std::filesystem::path &path);
 
 private:
     struct Impl;

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -2,10 +2,10 @@
 
 #include <cstdint>
 #include <map>
-#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 
 size_t angband_strcpy(char *buf, std::string_view src, size_t bufsize);

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -341,12 +341,12 @@ DisplaySymbolPair map_info(PlayerType *player_ptr, const Pos2D &pos)
  * - プレイヤーが無敵状態もしくは時間停止スキルを使用中: TERM_WHITE
  * - プレイヤーが幽体化スキルを使用中: TERM_L_DARK
  *
- * @return 単色表示色。単色表示を行わない場合はstd::nullopt
+ * @return 単色表示色。単色表示を行わない場合はtl::nullopt
  */
-std::optional<uint8_t> get_monochrome_display_color(PlayerType *player_ptr)
+tl::optional<uint8_t> get_monochrome_display_color(PlayerType *player_ptr)
 {
     if (use_graphics) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (AngbandWorld::get_instance().timewalk_m_idx) {
@@ -359,5 +359,5 @@ std::optional<uint8_t> get_monochrome_display_color(PlayerType *player_ptr)
         return TERM_L_DARK;
     }
 
-    return std::nullopt;
+    return tl::nullopt;
 }

--- a/src/view/display-map.h
+++ b/src/view/display-map.h
@@ -2,11 +2,11 @@
 
 #include "util/point-2d.h"
 #include <cstdint>
-#include <optional>
+#include <tl/optional.hpp>
 
 extern uint8_t display_autopick;
 
 class DisplaySymbolPair;
 class PlayerType;
 DisplaySymbolPair map_info(PlayerType *player_ptr, const Pos2D &pos);
-std::optional<uint8_t> get_monochrome_display_color(PlayerType *player_ptr);
+tl::optional<uint8_t> get_monochrome_display_color(PlayerType *player_ptr);

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -71,7 +71,7 @@ static bool display_player_info(PlayerType *player_ptr, int mode)
     }
 
     if (mode == 5) {
-        TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, std::nullopt);
+        TermCenteredOffsetSetter tcos(MAIN_TERM_MIN_COLS, tl::nullopt);
         do_cmd_knowledge_mutations(player_ptr);
         return true;
     }
@@ -168,11 +168,11 @@ static void display_player_stats(PlayerType *player_ptr)
  * @param statmsg メッセージバッファ
  * @return 生きていたらFALSE、死んでいたらTRUE
  */
-static std::optional<std::string> search_death_cause(PlayerType *player_ptr)
+static tl::optional<std::string> search_death_cause(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     if (!player_ptr->is_dead) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     if (AngbandWorld::get_instance().total_winner) {
@@ -220,11 +220,11 @@ static std::optional<std::string> search_death_cause(PlayerType *player_ptr)
  * @param statmsg メッセージバッファ
  * @return クエスト内であればTRUE、いなければFALSE
  */
-static std::optional<std::string> decide_death_in_quest(PlayerType *player_ptr)
+static tl::optional<std::string> decide_death_in_quest(PlayerType *player_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     if (!floor.is_in_quest() || !QuestType::is_fixed(floor.quest_number)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     quest_text_lines.clear();
@@ -279,7 +279,7 @@ static std::string decide_current_floor(PlayerType *player_ptr)
  * Mode 4 = mutations.
  * Mode 5 = ??? (コード上の定義より6で割った余りは5になりうるが元のコメントに記載なし).
  */
-std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
+tl::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
 {
     auto has_any_mutation = (player_ptr->muta.any() || has_good_luck(player_ptr)) && display_mutations;
     auto mode = has_any_mutation ? tmp_mode % 6 : tmp_mode % 5;
@@ -288,7 +288,7 @@ std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
         clear_from(0);
     }
     if (display_player_info(player_ptr, mode)) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     display_player_basic_info(player_ptr);
@@ -302,7 +302,7 @@ std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
     if (mode == 0) {
         display_player_middle(player_ptr);
         display_player_various(player_ptr);
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     put_str(_("(キャラクターの生い立ち)", "(Character Background)"), 11, 25);
@@ -312,7 +312,7 @@ std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
 
     auto statmsg = decide_current_floor(player_ptr);
     if (statmsg.empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     constexpr auto chars_per_line = 60;

--- a/src/view/display-player.h
+++ b/src/view/display-player.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "system/angband.h"
-#include <optional>
+#include <tl/optional.hpp>
 
 class PlayerType;
-std::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode);
+tl::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode);
 void display_player_equippy(PlayerType *player_ptr, TERM_LEN y, TERM_LEN x, BIT_FLAGS16 mode);

--- a/src/window/main-window-left-frame.cpp
+++ b/src/window/main-window-left-frame.cpp
@@ -335,7 +335,7 @@ static std::vector<condition_layout_info> get_condition_layout_info(const Monste
  */
 void print_health(PlayerType *player_ptr, bool riding)
 {
-    std::optional<short> monster_idx;
+    tl::optional<short> monster_idx;
     int row, col;
 
     if (riding) {

--- a/src/wizard/wizard-game-modifier.cpp
+++ b/src/wizard/wizard-game-modifier.cpp
@@ -155,7 +155,7 @@ void wiz_restore_monster_max_num(MonraceId monrace_id)
     }
 
     auto &monrace = monraces.get_monrace(monrace_id);
-    std::optional<int> max_num;
+    tl::optional<int> max_num;
     if (monrace.kind_flags.has(MonsterKindType::UNIQUE)) {
         max_num = MAX_UNIQUE_NUM;
     } else if (monrace.population_flags.has(MonsterPopulationType::NAZGUL)) {

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -547,7 +547,7 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 }
 
-static std::optional<ItemEntity> wiz_apply_magic_to_item(PlayerType *player_ptr, char command, short bi_id)
+static tl::optional<ItemEntity> wiz_apply_magic_to_item(PlayerType *player_ptr, char command, short bi_id)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
     switch (tolower(command)) {
@@ -586,7 +586,7 @@ static std::optional<ItemEntity> wiz_apply_magic_to_item(PlayerType *player_ptr,
         return item;
     }
     default:
-        return std::nullopt;
+        return tl::nullopt;
     }
 }
 

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -77,9 +77,9 @@
 #include "world/world.h"
 #include <algorithm>
 #include <fstream>
-#include <optional>
 #include <span>
 #include <sstream>
+#include <tl/optional.hpp>
 #include <tuple>
 #include <vector>
 
@@ -97,15 +97,15 @@ void wiz_cure_all(PlayerType *player_ptr)
     msg_print("You're fully cured by wizard command.");
 }
 
-static std::optional<tval_desc> wiz_select_tval()
+static tl::optional<tval_desc> wiz_select_tval()
 {
     CandidateSelector cs(_("アイテム種別を選んで下さい", "Get what type of object? "), 15);
     const auto choice = cs.select(tval_desc_list, [](const auto &tval) { return tval.desc; });
 
-    return (choice != tval_desc_list.end()) ? std::make_optional(*choice) : std::nullopt;
+    return (choice != tval_desc_list.end()) ? tl::make_optional(*choice) : tl::nullopt;
 }
 
-static std::optional<short> wiz_select_sval(const tval_desc &td)
+static tl::optional<short> wiz_select_sval(const tval_desc &td)
 {
     std::vector<short> bi_ids;
     for (const auto &baseitem : BaseitemList::get_instance()) {
@@ -122,7 +122,7 @@ static std::optional<short> wiz_select_sval(const tval_desc &td)
     const auto &baseitems = BaseitemList::get_instance();
     const auto choice = cs.select(bi_ids,
         [&baseitems](short bi_id) { return baseitems.get_baseitem(bi_id).stripped_name(); });
-    return (choice != bi_ids.end()) ? std::make_optional(*choice) : std::nullopt;
+    return (choice != bi_ids.end()) ? tl::make_optional(*choice) : tl::nullopt;
 }
 
 /*!
@@ -134,11 +134,11 @@ static std::optional<short> wiz_select_sval(const tval_desc &td)
  * This function returns the bi_id of an object type, or zero if failed
  * List up to 50 choices in three columns
  */
-static std::optional<short> wiz_create_itemtype()
+static tl::optional<short> wiz_create_itemtype()
 {
     auto selection = wiz_select_tval();
     if (!selection) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return wiz_select_sval(*selection);
@@ -201,15 +201,15 @@ static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArt
  * @brief 固定アーティファクトをリストから選択する
  *
  * @param fa_ids 選択する候補となる固定アーティファクトのIDのリスト
- * @return 選択した固定アーティファクトのIDを返す。但しキャンセルした場合は std::nullopt を返す。
+ * @return 選択した固定アーティファクトのIDを返す。但しキャンセルした場合は tl::nullopt を返す。
  */
-static std::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *player_ptr, const std::vector<FixedArtifactId> &fa_ids)
+static tl::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *player_ptr, const std::vector<FixedArtifactId> &fa_ids)
 {
     CandidateSelector cs("Which artifact: ", 15);
 
     auto describe_artifact = [player_ptr](FixedArtifactId fa_id) { return wiz_make_named_artifact_desc(player_ptr, fa_id); };
     const auto it = cs.select(fa_ids, describe_artifact);
-    return (it != fa_ids.end()) ? std::make_optional(*it) : std::nullopt;
+    return (it != fa_ids.end()) ? tl::make_optional(*it) : tl::nullopt;
 }
 
 /**
@@ -246,7 +246,7 @@ void wiz_create_named_art(PlayerType *player_ptr)
         put_str(ss.str(), i + 1, 15);
     }
 
-    std::optional<FixedArtifactId> created_fa_id;
+    tl::optional<FixedArtifactId> created_fa_id;
     while (!created_fa_id) {
         const auto command = input_command("Kind of artifact: ");
         if (!command) {
@@ -434,7 +434,7 @@ void wiz_create_feature(PlayerType *player_ptr)
  * @brief デバッグ帰還のダンジョンを選ぶ
  * @param player_ptr プレイヤーへの参照ポインタ
  */
-static std::optional<DungeonId> select_debugging_dungeon()
+static tl::optional<DungeonId> select_debugging_dungeon()
 {
     const auto &dungeons = DungeonList::get_instance();
     auto describer = [&](DungeonId id) { return dungeons.get_dungeon(id).name; };
@@ -442,7 +442,7 @@ static std::optional<DungeonId> select_debugging_dungeon()
     CandidateSelector cs("Jump to which dungeon: ", 15);
     const auto choice = cs.select(DUNGEON_IDS, describer);
 
-    return (choice != DUNGEON_IDS.end()) ? std::make_optional(*choice) : std::nullopt;
+    return (choice != DUNGEON_IDS.end()) ? tl::make_optional(*choice) : tl::nullopt;
 }
 
 /*
@@ -451,7 +451,7 @@ static std::optional<DungeonId> select_debugging_dungeon()
  * @param dungeon_id ダンジョン番号
  * @return レベルを選択したらその値、キャンセルならnullopt
  */
-static std::optional<int> select_debugging_floor(const FloorType &floor, DungeonId dungeon_id)
+static tl::optional<int> select_debugging_floor(const FloorType &floor, DungeonId dungeon_id)
 {
     const auto &dungeon = DungeonList::get_instance().get_dungeon(dungeon_id);
     const auto max_depth = dungeon.maxdepth;
@@ -561,16 +561,16 @@ static void change_birth_flags()
     rfu.set_flags(flags_mwrf);
 }
 
-static std::optional<ElementRealmType> wiz_select_element_realm()
+static tl::optional<ElementRealmType> wiz_select_element_realm()
 {
     constexpr EnumRange element_realms(ElementRealmType::FIRE, ElementRealmType::MAX);
     CandidateSelector cs("Which realm: ", 15);
 
     const auto chosen_realm = cs.select(element_realms, get_element_title);
-    return (chosen_realm != element_realms.end()) ? std::make_optional(*chosen_realm) : std::nullopt;
+    return (chosen_realm != element_realms.end()) ? tl::make_optional(*chosen_realm) : tl::nullopt;
 }
 
-static std::optional<RealmType> wiz_select_realm(const RealmChoices &choices, const std::string &msg)
+static tl::optional<RealmType> wiz_select_realm(const RealmChoices &choices, const std::string &msg)
 {
     if (choices.count() <= 1) {
         return choices.first().value_or(RealmType::NONE);
@@ -582,15 +582,15 @@ static std::optional<RealmType> wiz_select_realm(const RealmChoices &choices, co
 
     CandidateSelector cs(msg, 15);
     const auto choice = cs.select(candidates, describe_realm);
-    return (choice != candidates.end()) ? std::make_optional(*choice) : std::nullopt;
+    return (choice != candidates.end()) ? tl::make_optional(*choice) : tl::nullopt;
 }
 
-static std::optional<std::tuple<RealmType, RealmType, ElementRealmType>> wiz_select_realms(PlayerClassType pclass)
+static tl::optional<std::tuple<RealmType, RealmType, ElementRealmType>> wiz_select_realms(PlayerClassType pclass)
 {
     if (pclass == PlayerClassType::ELEMENTALIST) {
         const auto realm = wiz_select_element_realm();
         if (!realm) {
-            return std::nullopt;
+            return tl::nullopt;
         }
 
         return std::make_tuple(RealmType::NONE, RealmType::NONE, *realm);
@@ -598,7 +598,7 @@ static std::optional<std::tuple<RealmType, RealmType, ElementRealmType>> wiz_sel
 
     const auto realm1 = wiz_select_realm(PlayerRealm::get_realm1_choices(pclass), "1st realm: ");
     if (!realm1) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto realm2_choices = PlayerRealm::get_realm2_choices(pclass).reset(*realm1);
@@ -612,7 +612,7 @@ static std::optional<std::tuple<RealmType, RealmType, ElementRealmType>> wiz_sel
 
     const auto realm2 = wiz_select_realm(realm2_choices, "2nd realm: ");
     if (!realm2) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     return std::make_tuple(*realm1, *realm2, ElementRealmType::NONE);

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -74,7 +74,7 @@ std::vector<MonraceId> wiz_collect_monster_candidates(char symbol)
     return monraces.search_by_symbol(symbol, false);
 }
 
-std::optional<MonraceId> wiz_select_summon_monrace_id(MonraceId monrace_id)
+tl::optional<MonraceId> wiz_select_summon_monrace_id(MonraceId monrace_id)
 {
     if (MonraceList::is_valid(monrace_id)) {
         return monrace_id;
@@ -84,7 +84,7 @@ std::optional<MonraceId> wiz_select_summon_monrace_id(MonraceId monrace_id)
     const auto skey = inkey_special(false);
     prt("", 0, 0);
     if ((skey & SKEY_MASK) || skey == ESCAPE) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     const auto &monraces = MonraceList::get_instance();
@@ -94,7 +94,7 @@ std::optional<MonraceId> wiz_select_summon_monrace_id(MonraceId monrace_id)
 
     const auto monrace_ids = wiz_collect_monster_candidates(static_cast<char>(skey));
     if (monrace_ids.empty()) {
-        return std::nullopt;
+        return tl::nullopt;
     }
 
     auto describer = [&](MonraceId id) {
@@ -103,7 +103,7 @@ std::optional<MonraceId> wiz_select_summon_monrace_id(MonraceId monrace_id)
     CandidateSelector cs("Witch monster: ", 15);
     const auto choice = cs.select(monrace_ids, describer);
 
-    return (choice != monrace_ids.end()) ? std::make_optional(*choice) : std::nullopt;
+    return (choice != monrace_ids.end()) ? tl::make_optional(*choice) : tl::nullopt;
 }
 }
 


### PR DESCRIPTION
ある型の有効値か無効値のどちらかを持つ optional 型について、std::optinal と tl::optional の混在を避け tl::optional に統一する。

Resolves #5136 

ソースコードで以下の単純置換を行いました。（ただし、 `src/external-lib` ディレクトリ以下のファイルは除く）

- `std::optional` → `tl::optional`
- `std::nullopt` → `tl::nullopt`
- `std::make_optional` → `tl::make_optional`
- `#include <optional>` → `#include <tl/optional.hpp>`

## gemini code assist
Please write all summary and review comments in Japanese.