### PR TITLE
[Fix] `r_info_flagsr` の冷気耐性のトークン組付け先が火炎耐性になっていた。

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -57162,6 +57162,7 @@
         "FORCE_MAXHP",
         "DROP_1D2",
         "SMART",
+        "RES_COLD",
         "DROP_CORPSE",
         "DROP_SKELETON",
         "CAN_SWIM"

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -226,7 +226,7 @@ const std::unordered_map<std::string_view, MonsterResistanceType> r_info_flagsr 
     { "RES_FIRE", MonsterResistanceType::RESIST_FIRE },
     { "IM_FIRE", MonsterResistanceType::IMMUNE_FIRE },
     { "HURT_COLD", MonsterResistanceType::HURT_COLD },
-    { "RES_COLD", MonsterResistanceType::RESIST_FIRE },
+    { "RES_COLD", MonsterResistanceType::RESIST_COLD },
     { "IM_COLD", MonsterResistanceType::IMMUNE_COLD },
     { "HURT_POIS", MonsterResistanceType::HURT_POISON },
     { "RES_POIS", MonsterResistanceType::RESIST_POISON },


### PR DESCRIPTION
単純修正。