### PR TITLE
Update hengband.spec for 3.0.1.28

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,5 +1,5 @@
 %define version 3.0.1.27
-%define release 1
+%define release 2
 
 Summary: hengband %{version}
 Name: hengband
@@ -12,7 +12,7 @@ Source: hengband-%{version}.tar.gz
 Requires: ncurses-libs libstdc++ libcurl libX11
 BuildRequires: autoconf automake gcc-c++ ncurses-devel libcurl-devel nkf libX11-devel
 
-Requires: %{name}-data
+Requires: %{name}-data = %{version}
 
 %package data
 
@@ -21,7 +21,7 @@ Summary: %{name}-data %{version}
 %package en
 
 Requires: ncurses-libs libstdc++ libcurl libX11
-Requires: %{name}-data
+Requires: %{name}-data = %{version}
 Summary: %{name}-en %{version}
 
 %description
@@ -154,6 +154,9 @@ exit 0
 %license lib/help/jlicense.txt THIRD-PARTY-NOTICES.txt
 
 %changelog
+* Mon May 26 2025 whitehara <white@vx-xv.com>
+- Add specified version dependencies between hengband,en and hengband-data
+
 * Wed May 21 2025 whitehara <white@vx-xv.com>
 - hengband RPM 3.0.1.27(Beta)
 

--- a/hengband.spec
+++ b/hengband.spec
@@ -1,5 +1,5 @@
-%define version 3.0.1.27
-%define release 2
+%define version 3.0.1.28
+%define release 1
 
 Summary: hengband %{version}
 Name: hengband
@@ -154,6 +154,9 @@ exit 0
 %license lib/help/jlicense.txt THIRD-PARTY-NOTICES.txt
 
 %changelog
+* Mon Jun 16 2025 whitehara <white@vx-xv.com>
+- hengband RPM 3.0.1.28(Beta)
+
 * Mon May 26 2025 whitehara <white@vx-xv.com>
 - Add specified version dependencies between hengband,en and hengband-data
 


### PR DESCRIPTION
- hengband.specのバージョンを3.0.1.28に変更
- 同バージョンのrpmをCoprにて配布開始 https://copr.fedorainfracloud.org/coprs/whitehara/hengband/
- hengband-dataパッケージ（実行バイナリ以外のデータファイル一式）が古いまま、新しいhengband,hengband-enパッケージ（実行バイナリ）をインストールでき、結果として起動時にエラーとなる問題を修正。
  - 具体的にはデータパッケージとバイナリパッケージが同一バージョンとなるように依存関係を追加した。