### PR TITLE
[Refactor] ユニーク感知時のメッセージを外部読込化

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -54282,7 +54282,18 @@
       "flavor": {
         "ja": "彼はモルゴスの最も強力な召使で、恐るべき呪文を使いこなす上に高い防御力も持っている。一つの指輪を創造したのは彼である。その瞳は力に輝き、冒険者の魂を破壊しようと狙っている。また彼は多くの手下を従えており、滅多に単独では戦わない。",
         "en": "Mighty in spells and enchantments, he created the One Ring.  His eyes glow with power and his gaze seeks to destroy your soul.  He has many servants, and rarely fights without them."
-      }
+      },
+      "message": [
+        {
+          "action": "MESSAGE_DETECT_UNIQUE",
+          "chance": 1,
+          "use_name": false,
+          "message": {
+            "ja": "あなたは一瞬、瞼なき御目に凝視される感覚に襲われた！",
+            "en": "For a moment, you had the horrible sensation of being stared at by the lidless eye!"
+          }
+        }
+      ]
     },
     //#JZ#
     {
@@ -55917,6 +55928,15 @@
           "message": {
             "ja": "「『ザ・ワールド』！　時は止まった！」",
             "en": "Dio Brando yells 'The World! Time has stopped!'"
+          }
+        },
+        {
+          "action": "MESSAGE_DETECT_UNIQUE",
+          "chance": 1,
+          "use_name": false,
+          "message": {
+            "ja": "きさま！　見ているなッ！",
+            "en": "You bastard! You're watching me, well watch this!"
           }
         }
       ]

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -723,7 +723,8 @@
                                         "MESSAGE_TIMESTART",
                                         "MESSAGE_BREATH_SOUND",
                                         "MESSAGE_BREATH_SHARDS",
-                                        "MESSAGE_BREATH_FORCE"
+                                        "MESSAGE_BREATH_FORCE",
+                                        "MESSAGE_DETECT_UNIQUE"
                                     ]
                                 },
                                 "chance": {

--- a/schema/MonsterMessages.schema.json
+++ b/schema/MonsterMessages.schema.json
@@ -60,7 +60,8 @@
                                         "MESSAGE_TIMESTART",
                                         "MESSAGE_BREATH_SOUND",
                                         "MESSAGE_BREATH_SHARDS",
-                                        "MESSAGE_BREATH_FORCE"
+                                        "MESSAGE_BREATH_FORCE",
+                                        "MESSAGE_DETECT_UNIQUE"
                                     ]
                                 },
                                 "chance": {

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -425,6 +425,7 @@ const std::unordered_map<std::string_view, MonsterMessageType> r_info_message_fl
     { "MESSAGE_BREATH_SOUND", MonsterMessageType::MESSAGE_BREATH_SOUND },
     { "MESSAGE_BREATH_SHARDS", MonsterMessageType::MESSAGE_BREATH_SHARDS },
     { "MESSAGE_BREATH_FORCE", MonsterMessageType::MESSAGE_BREATH_FORCE },
+    { "MESSAGE_DETECT_UNIQUE", MonsterMessageType::MESSAGE_DETECT_UNIQUE },
 };
 
 const std::unordered_map<std::string_view, MonsterBrightnessType> r_info_brightness_flags = {

--- a/src/monster-race/race-speak-flags.h
+++ b/src/monster-race/race-speak-flags.h
@@ -27,5 +27,6 @@ enum class MonsterMessageType {
     MESSAGE_BREATH_SOUND = 13,
     MESSAGE_BREATH_SHARDS = 14,
     MESSAGE_BREATH_FORCE = 15,
+    MESSAGE_DETECT_UNIQUE = 16,
     MAX
 };

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -176,13 +176,9 @@ bool activate_unique_detection(PlayerType *player_ptr)
             msg_format(_("%s． ", "%s. "), monrace.name.data());
         }
 
-        if (monster.r_idx == MonraceId::DIO) {
-            msg_print(_("きさま！　見ているなッ！", "You bastard! You're watching me, well watch this!"));
-        }
-
-        if (monster.r_idx == MonraceId::SAURON) {
-            msg_print(_("あなたは一瞬、瞼なき御目に凝視される感覚に襲われた！",
-                "For a moment, you had the horrible sensation of being stared at by the lidless eye!"));
+        const auto message = monrace.get_message(monrace.name, MonsterMessageType::MESSAGE_DETECT_UNIQUE);
+        if (message) {
+            msg_print(*message);
         }
     }
 


### PR DESCRIPTION
パランティアの石発動時などのユニーク感知時に特定ユニークが発生させるメッセージをハードコード解消した。