### PR TITLE
[Fix] 自動拾いエディタで条件分岐の結果が正しく表示されない

### DIFF
--- a/src/autopick/autopick-drawer.cpp
+++ b/src/autopick/autopick-drawer.cpp
@@ -27,12 +27,14 @@ static void process_dirty_expression(PlayerType *player_ptr, text_body_type *tb)
     byte state = 0;
     for (auto y = 0; tb->lines_list[y]; y++) {
         std::string_view s(*tb->lines_list[y]);
-        tb->states[y] = state;
         if (!s.starts_with("?:")) {
+            tb->states[y] = state;
             continue;
         }
 
-        if (s.substr(2) == "$AUTOREGISTER") {
+        s.remove_prefix(2);
+
+        if (s == "$AUTOREGISTER") {
             state |= LSTAT_AUTOREGISTER;
         }
 


### PR DESCRIPTION
f3051295 で自動拾いの条件分岐を判定する文字列の開始位置が意図せず変わってしまったため、条件分岐を正しく判定できず条件分岐の結果の表示がおかしくなってしまっている。
元と同じく先頭の2文字（?:）は飛ばすようにする。

Fix #5155 

## gemini code assist
Please write all comments in Japanese.