### PR TITLE
[Refactor] ベースアイテム生成の制約処理

### DIFF
--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -238,7 +238,7 @@ void QuestCompletionChecker::make_reward(const Pos2D pos)
         while (true) {
             item.wipe();
             const auto &monrace = this->m_ptr->get_monrace();
-            (void)make_object(this->player_ptr, &item, AM_GOOD | AM_GREAT, monrace.level);
+            (void)make_object(this->player_ptr, &item, AM_GOOD | AM_GREAT, nullptr, monrace.level);
             if (!this->check_quality(item)) {
                 continue;
             }

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -2,6 +2,7 @@
 
 #include "object/item-tester-hooker.h"
 #include "system/angband.h"
+#include "system/baseitem/baseitem-allocation.h"
 #include "util/point-2d.h"
 #include <tl/optional.hpp>
 #include <vector>
@@ -12,7 +13,7 @@ class FloorType;
 class ItemEntity;
 class PlayerType;
 class ItemTester;
-bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, tl::optional<int> rq_mon_level = tl::nullopt);
+bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, BaseitemRestrict restrict = nullptr, tl::optional<int> rq_mon_level = tl::nullopt);
 void delete_all_items_from_floor(PlayerType *player_ptr, const Pos2D &pos);
 void floor_item_increase(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER num);
 void floor_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx);

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -46,9 +46,10 @@ void place_gold(PlayerType *player_ptr, const Pos2D &pos)
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param pos 配置したい座標
  * @param mode オプションフラグ
+ * @param restrict ベースアイテム制約関数。see BaseitemAllocationTable::set_restriction()
  * @return 生成に成功したらTRUEを返す。
  */
-void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode)
+void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode, BaseitemRestrict restrict)
 {
     auto &floor = *player_ptr->current_floor_ptr;
     auto &grid = floor.get_grid(pos);
@@ -63,7 +64,7 @@ void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode)
 
     auto &item = *floor.o_list[item_idx];
     item.wipe();
-    if (!make_object(player_ptr, &item, mode)) {
+    if (!make_object(player_ptr, &item, mode, restrict)) {
         return;
     }
 

--- a/src/grid/object-placer.h
+++ b/src/grid/object-placer.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "system/baseitem/baseitem-allocation.h"
 #include "util/point-2d.h"
 #include <cstdint>
 
 class PlayerType;
 void place_gold(PlayerType *player_ptr, const Pos2D &pos);
-void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode);
+void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode, BaseitemRestrict restrict = nullptr);

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -128,8 +128,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
         }
 
         /* Place a potion */
-        select_baseitem_id_hook = kind_is_potion;
-        place_object(player_ptr, *center, AM_NO_FIXED_ART);
+        place_object(player_ptr, *center, AM_NO_FIXED_ART, kind_is_potion);
         floor.get_grid(*center).info |= CAVE_ICKY;
     } break;
 
@@ -198,15 +197,11 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
 
         /* Place two potions */
         if (one_in_(2)) {
-            select_baseitem_id_hook = kind_is_potion;
-            place_object(player_ptr, *center + Direction(4).vec(), AM_NO_FIXED_ART);
-            select_baseitem_id_hook = kind_is_potion;
-            place_object(player_ptr, *center + Direction(6).vec(), AM_NO_FIXED_ART);
+            place_object(player_ptr, *center + Direction(4).vec(), AM_NO_FIXED_ART, kind_is_potion);
+            place_object(player_ptr, *center + Direction(6).vec(), AM_NO_FIXED_ART, kind_is_potion);
         } else {
-            select_baseitem_id_hook = kind_is_potion;
-            place_object(player_ptr, *center + Direction(8).vec(), AM_NO_FIXED_ART);
-            select_baseitem_id_hook = kind_is_potion;
-            place_object(player_ptr, *center + Direction(2).vec(), AM_NO_FIXED_ART);
+            place_object(player_ptr, *center + Direction(8).vec(), AM_NO_FIXED_ART, kind_is_potion);
+            place_object(player_ptr, *center + Direction(2).vec(), AM_NO_FIXED_ART, kind_is_potion);
         }
 
         for (auto y = center->y - 2; y <= center->y + 2; y++) {

--- a/src/system/baseitem/baseitem-allocation.cpp
+++ b/src/system/baseitem/baseitem-allocation.cpp
@@ -134,16 +134,27 @@ bool BaseitemAllocationTable::order_level(int index1, int index2) const
 
 /*!
  * @brief オブジェクト生成テーブルに生成制約を加える
- * @todo select_baseitem_id_hook グローバル関数ポインタは引数化して除去する
+ * @param restrict 制約を加える関数。この関数がtrueを返すベースアイテムのみを生成対象とする。
+ *                 nullptrを指定した場合は制約なしで生成する(reset_restriction()と実質同じ)。
  */
-void BaseitemAllocationTable::prepare_allocation()
+void BaseitemAllocationTable::set_restriction(BaseitemRestrict restrict)
 {
     for (auto &entry : this->entries) {
-        if (!select_baseitem_id_hook || (*select_baseitem_id_hook)(entry.index)) {
+        if (!restrict || restrict(entry.index)) {
             entry.prob2 = entry.prob1;
         } else {
             entry.prob2 = 0;
         }
+    }
+}
+
+/*!
+ * @brief オブジェクト生成テーブルの生成制約を解除する
+ */
+void BaseitemAllocationTable::reset_restriction()
+{
+    for (auto &entry : this->entries) {
+        entry.prob2 = entry.prob1;
     }
 }
 

--- a/src/system/baseitem/baseitem-allocation.h
+++ b/src/system/baseitem/baseitem-allocation.h
@@ -8,6 +8,9 @@
 
 #include "util/abstract-vector-wrapper.h"
 #include "util/probability-table.h"
+#include <functional>
+
+using BaseitemRestrict = std::function<bool(short bi_id)>;
 
 /*
  * An entry for the object/monster allocation functions
@@ -50,7 +53,8 @@ public:
     short draw_lottery(int level, uint32_t mode, int count) const;
     bool order_level(int index1, int index2) const;
 
-    void prepare_allocation();
+    void set_restriction(BaseitemRestrict restrict);
+    void reset_restriction();
 
 private:
     static BaseitemAllocationTable instance;

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -372,12 +372,12 @@ ItemEntity FloorType::make_gold(tl::optional<BaseitemKey> bi_key) const
 /*!
  * @brief INSTA_ART型の固定アーティファクトの生成を確率に応じて試行する
  * @return 生成したアイテム (失敗したらnullopt)
- * @details 地上生成は禁止、生成制限がある場合も禁止、個々のアーティファクト生成条件及び生成確率を潜り抜けなければ生成失敗とする
+ * @details 地上生成は禁止、個々のアーティファクト生成条件及び生成確率を潜り抜けなければ生成失敗とする
  * 最初に潜り抜けたINSTA_ART型の固定アーティファクトを生成し、以後はチェックせずスキップする
  */
 tl::optional<ItemEntity> FloorType::try_make_instant_artifact() const
 {
-    if (!this->is_underground() || (select_baseitem_id_hook != nullptr)) {
+    if (!this->is_underground()) {
         return tl::nullopt;
     }
 

--- a/src/system/system-variables.cpp
+++ b/src/system/system-variables.cpp
@@ -25,8 +25,3 @@ concptr ANGBAND_SYS = "xxx";
 concptr ANGBAND_KEYBOARD = _("JAPAN", "0");
 concptr ANGBAND_GRAF = "ascii";
 init_flags_type init_flags; //!< @todo このグローバル変数何とかしたい
-
-/*!
- * Function hook to restrict "get_obj_index_prep()" function
- */
-bool (*select_baseitem_id_hook)(short bi_id);

--- a/src/system/system-variables.h
+++ b/src/system/system-variables.h
@@ -28,5 +28,3 @@ extern init_flags_type init_flags;
 extern concptr ANGBAND_SYS;
 extern concptr ANGBAND_KEYBOARD;
 extern concptr ANGBAND_GRAF;
-
-extern bool (*select_baseitem_id_hook)(short bi_id);


### PR DESCRIPTION
ベースアイテム生成でベースアイテムの種別を制約するための関数を指定するグローバルな関数ポインタ select_baseitem_id_hook を廃止する。
代わりに制約関数は引数で引き渡すようにする。

## gemini code assist
Please write all summary and review comments in Japanese.
すべての日本語でコメントしてください。