### PR TITLE
[Refactor] make_object()のシグネチャ

### DIFF
--- a/src/dungeon/quest-completion-checker.cpp
+++ b/src/dungeon/quest-completion-checker.cpp
@@ -232,18 +232,15 @@ Pos2D QuestCompletionChecker::make_stairs(const bool create_stairs)
 
 void QuestCompletionChecker::make_reward(const Pos2D pos)
 {
-    auto dun_level = this->player_ptr->current_floor_ptr->dun_level;
-    for (auto i = 0; i < (dun_level / 15) + 1; i++) {
-        ItemEntity item;
-        while (true) {
-            item.wipe();
-            const auto &monrace = this->m_ptr->get_monrace();
-            (void)make_object(this->player_ptr, &item, AM_GOOD | AM_GREAT, nullptr, monrace.level);
-            if (!this->check_quality(item)) {
+    const auto drop_num = this->player_ptr->current_floor_ptr->dun_level / 15 + 1;
+    const auto &monrace = this->m_ptr->get_monrace();
+    for (auto i = 0; i < drop_num; i++) {
+        while (auto item = make_object(this->player_ptr, AM_GOOD | AM_GREAT, nullptr, monrace.level)) {
+            if (!this->check_quality(*item)) {
                 continue;
             }
 
-            (void)drop_near(this->player_ptr, &item, pos);
+            (void)drop_near(this->player_ptr, &*item, pos);
             break;
         }
     }

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -13,7 +13,7 @@ class FloorType;
 class ItemEntity;
 class PlayerType;
 class ItemTester;
-bool make_object(PlayerType *player_ptr, ItemEntity *j_ptr, BIT_FLAGS mode, BaseitemRestrict restrict = nullptr, tl::optional<int> rq_mon_level = tl::nullopt);
+tl::optional<ItemEntity> make_object(PlayerType *player_ptr, BIT_FLAGS mode, BaseitemRestrict restrict = nullptr, tl::optional<int> rq_mon_level = tl::nullopt);
 void delete_all_items_from_floor(PlayerType *player_ptr, const Pos2D &pos);
 void floor_item_increase(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER num);
 void floor_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx);

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -47,7 +47,6 @@ void place_gold(PlayerType *player_ptr, const Pos2D &pos)
  * @param pos 配置したい座標
  * @param mode オプションフラグ
  * @param restrict ベースアイテム制約関数。see BaseitemAllocationTable::set_restriction()
- * @return 生成に成功したらTRUEを返す。
  */
 void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode, BaseitemRestrict restrict)
 {
@@ -62,14 +61,14 @@ void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode, Basei
         return;
     }
 
-    auto &item = *floor.o_list[item_idx];
-    item.wipe();
-    if (!make_object(player_ptr, &item, mode, restrict)) {
+    auto item = make_object(player_ptr, mode, restrict);
+    if (!item) {
         return;
     }
 
-    item.iy = pos.y;
-    item.ix = pos.x;
+    item->iy = pos.y;
+    item->ix = pos.x;
+    *floor.o_list[item_idx] = std::move(*item);
     grid.o_idx_list.add(floor, item_idx);
 
     note_spot(player_ptr, pos);

--- a/src/monster-floor/monster-death.cpp
+++ b/src/monster-floor/monster-death.cpp
@@ -276,21 +276,18 @@ static void drop_items_golds(PlayerType *player_ptr, MonsterDeath *md_ptr, int d
     auto &floor = *player_ptr->current_floor_ptr;
     const auto &monraces = MonraceList::get_instance();
     for (auto i = 0; i < drop_numbers; i++) {
-        ItemEntity item;
         if (md_ptr->do_gold && (!md_ptr->do_item || one_in_(2))) {
             const auto &monrace = monraces.get_monrace(md_ptr->m_ptr->r_idx);
             const auto bi_key = BaseitemMonraceService::lookup_fixed_gold_drop(monrace.drop_flags);
-            item = floor.make_gold(bi_key);
+            auto item = floor.make_gold(bi_key);
+            (void)drop_near(player_ptr, &item, md_ptr->get_position());
             dump_gold++;
         } else {
-            if (!make_object(player_ptr, &item, md_ptr->mo_mode)) {
-                continue;
+            if (auto item = make_object(player_ptr, md_ptr->mo_mode)) {
+                (void)drop_near(player_ptr, &*item, md_ptr->get_position());
+                dump_item++;
             }
-
-            dump_item++;
         }
-
-        (void)drop_near(player_ptr, &item, md_ptr->get_position());
     }
 
     floor.object_level = floor.base_level;

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -73,8 +73,12 @@ void Chest::open(bool scatter, const Pos2D &pos, short item_idx)
         ItemEntity item_inner_chest;
         if (small && one_in_(4)) {
             item_inner_chest = floor.make_gold();
-        } else if (!make_object(this->player_ptr, &item_inner_chest, mode)) {
-            continue;
+        } else {
+            auto item = make_object(this->player_ptr, mode);
+            if (!item) {
+                continue;
+            }
+            item_inner_chest = std::move(*item);
         }
 
         if (!scatter) {

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -331,7 +331,7 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
             if (preserve_mode || in_generate) {
                 /* Scan all objects in the grid */
                 for (const auto this_o_idx : grid.o_idx_list) {
-                    const auto &item = *floor.o_list[this_o_idx];
+                    auto &item = *floor.o_list[this_o_idx];
                     if (item.is_fixed_artifact() && (!item.is_known() || in_generate)) {
                         item.get_fixed_artifact().is_generated = false;
 

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -184,12 +184,9 @@ void acquirement(PlayerType *player_ptr, POSITION y1, POSITION x1, int num, bool
     const Pos2D pos(y1, x1);
     auto mode = AM_GOOD | (great ? AM_GREAT : AM_NONE);
     for (auto i = 0; i < num; i++) {
-        ItemEntity item;
-        if (!make_object(player_ptr, &item, mode)) {
-            continue;
+        if (auto item = make_object(player_ptr, mode)) {
+            (void)drop_near(player_ptr, &*item, pos);
         }
-
-        (void)drop_near(player_ptr, &item, pos);
     }
 }
 

--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -834,7 +834,12 @@ EgoItemDefinition &ItemEntity::get_ego() const
     return egos_info.at(this->ego_idx);
 }
 
-ArtifactType &ItemEntity::get_fixed_artifact() const
+ArtifactType &ItemEntity::get_fixed_artifact()
+{
+    return ArtifactList::get_instance().get_artifact(this->fa_id);
+}
+
+const ArtifactType &ItemEntity::get_fixed_artifact() const
 {
     return ArtifactList::get_instance().get_artifact(this->fa_id);
 }

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -157,7 +157,8 @@ public:
     bool is_target_of(QuestId quest_id) const;
     BaseitemDefinition &get_baseitem() const;
     EgoItemDefinition &get_ego() const;
-    ArtifactType &get_fixed_artifact() const;
+    ArtifactType &get_fixed_artifact();
+    const ArtifactType &get_fixed_artifact() const;
     TrFlags get_flags() const;
     TrFlags get_flags_known() const;
     std::string explain_activation() const;

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -37,8 +37,8 @@ class MonraceDefinition;
 class ItemEntity {
 public:
     ItemEntity();
-    ItemEntity(short bi_id);
-    ItemEntity(const BaseitemKey &bi_key);
+    explicit ItemEntity(short bi_id);
+    explicit ItemEntity(const BaseitemKey &bi_key);
     ItemEntity(ItemEntity &&) = default;
     ItemEntity &operator=(ItemEntity &&) = default;
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -118,22 +118,22 @@ static void wiz_item_drop(PlayerType *player_ptr, const int num_items, const Enu
     }
 
     for (auto i = 0; i < num_items; i++) {
-        ItemEntity item;
-        if (!make_object(player_ptr, &item, mode)) {
+        auto item = make_object(player_ptr, mode);
+        if (!item) {
             continue;
         }
 
-        if (is_cursed && !item.is_cursed()) {
+        if (is_cursed && !item->is_cursed()) {
             i--;
             continue;
         }
 
-        if (appliance.has(ItemMagicAppliance::EGO) && !item.is_ego()) {
+        if (appliance.has(ItemMagicAppliance::EGO) && !item->is_ego()) {
             i--;
             continue;
         }
 
-        if (!drop_near(player_ptr, &item, player_ptr->get_position())) {
+        if (!drop_near(player_ptr, &*item, player_ptr->get_position())) {
             msg_print_wizard(player_ptr, 0, "No item dropping space!");
             return;
         }
@@ -512,26 +512,26 @@ static void wiz_statistics(PlayerType *player_ptr, ItemEntity *o_ptr)
                 term_fresh();
             }
 
-            ItemEntity item;
-            if (!make_object(player_ptr, &item, mode)) {
+            auto item = make_object(player_ptr, mode);
+            if (!item) {
                 continue;
             }
 
-            if (item.is_fixed_artifact()) {
-                item.get_fixed_artifact().is_generated = false;
+            if (item->is_fixed_artifact()) {
+                item->get_fixed_artifact().is_generated = false;
             }
 
-            if (o_ptr->bi_key != item.bi_key) {
+            if (o_ptr->bi_key != item->bi_key) {
                 continue;
             }
 
             correct++;
-            const auto is_same_fixed_artifact_idx = o_ptr->is_specific_artifact(item.fa_id);
-            if ((item.pval == o_ptr->pval) && (item.to_a == o_ptr->to_a) && (item.to_h == o_ptr->to_h) && (item.to_d == o_ptr->to_d) && is_same_fixed_artifact_idx) {
+            const auto is_same_fixed_artifact_idx = o_ptr->is_specific_artifact(item->fa_id);
+            if ((item->pval == o_ptr->pval) && (item->to_a == o_ptr->to_a) && (item->to_h == o_ptr->to_h) && (item->to_d == o_ptr->to_d) && is_same_fixed_artifact_idx) {
                 matches++;
-            } else if ((item.pval >= o_ptr->pval) && (item.to_a >= o_ptr->to_a) && (item.to_h >= o_ptr->to_h) && (item.to_d >= o_ptr->to_d)) {
+            } else if ((item->pval >= o_ptr->pval) && (item->to_a >= o_ptr->to_a) && (item->to_h >= o_ptr->to_h) && (item->to_d >= o_ptr->to_d)) {
                 better++;
-            } else if ((item.pval <= o_ptr->pval) && (item.to_a <= o_ptr->to_a) && (item.to_h <= o_ptr->to_h) && (item.to_d <= o_ptr->to_d)) {
+            } else if ((item->pval <= o_ptr->pval) && (item->to_a <= o_ptr->to_a) && (item->to_h <= o_ptr->to_h) && (item->to_d <= o_ptr->to_d)) {
                 worse++;
             } else {
                 other++;


### PR DESCRIPTION
make_object()のシグネチャを、戻り値として生成の成否・出力引数に生成したアイテムを格納する形から、戻り値に生成したアイテムを保持するoptional型を返す形に変更する。
また、シグネチャ変更によるリファクタリングの副産物として #5115 が修正される。

Resolves #5160 
Fix #5115 

## gemini code assist
Please all summary and review comments in Japanese.
すべて日本語でコメントしてください。