### PR TITLE
[Fix] GCC 13の -Waggressive-loop-optimization による警告対策

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -267,7 +267,8 @@ void delete_items(PlayerType *player_ptr, std::vector<OBJECT_IDX> delete_i_idx_l
  */
 void delete_items(PlayerType *player_ptr, ObjectIndexList &o_idx_list)
 {
-    delete_items(player_ptr, o_idx_list | ranges::to_vector);
+    auto delete_i_idx_list = o_idx_list | ranges::to_vector;
+    delete_items(player_ptr, std::move(delete_i_idx_list));
 }
 
 /*!

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -146,8 +146,8 @@ void delete_all_items_from_floor(PlayerType *player_ptr, const Pos2D &pos)
         return;
     }
 
-    const auto &grid = floor.get_grid(pos);
-    delete_items(player_ptr, grid.o_idx_list | ranges::to_vector);
+    auto &grid = floor.get_grid(pos);
+    delete_items(player_ptr, grid.o_idx_list);
 
     lite_spot(player_ptr, pos);
 }
@@ -258,6 +258,16 @@ void delete_items(PlayerType *player_ptr, std::vector<OBJECT_IDX> delete_i_idx_l
     for (const auto delete_i_idx : delete_i_idx_list) {
         delete_object_idx(player_ptr, delete_i_idx);
     }
+}
+
+/*!
+ * @brief ObjectIndexListが管理しているアイテムをすべて削除する
+ * @param o_idx_list 管理しているアイテムをすべて削除するObjectIndexListオブジェクト
+ * @details 結果としてo_idx_listは空になるので、あえて引数は非const参照としている
+ */
+void delete_items(PlayerType *player_ptr, ObjectIndexList &o_idx_list)
+{
+    delete_items(player_ptr, o_idx_list | ranges::to_vector);
 }
 
 /*!

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -20,6 +20,7 @@ void floor_item_optimize(PlayerType *player_ptr, INVENTORY_IDX i_idx);
 void delete_object_idx(PlayerType *player_ptr, OBJECT_IDX o_idx);
 void excise_object_idx(FloorType &floor, OBJECT_IDX o_idx);
 void delete_items(PlayerType *player_ptr, std::vector<OBJECT_IDX> delete_i_idx_list);
+void delete_items(PlayerType *player_ptr, ObjectIndexList &o_idx_list);
 ObjectIndexList &get_o_idx_list_contains(FloorType &floor, OBJECT_IDX o_idx);
 short drop_near(PlayerType *player_ptr, ItemEntity *o_ptr, const Pos2D &pos, tl::optional<int> chance = tl::nullopt);
 void floor_item_charges(const FloorType &floor, INVENTORY_IDX i_idx);

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -14,7 +14,6 @@
 #include "system/redrawing-flags-updater.h"
 #include "target/target-checker.h"
 #include "tracking/health-bar-tracker.h"
-#include <range/v3/view.hpp>
 
 /*!
  * @brief モンスター配列からモンスターを消去する
@@ -74,7 +73,7 @@ void delete_monster_idx(PlayerType *player_ptr, short m_idx)
     }
 
     floor.get_grid(m_pos).m_idx = 0;
-    delete_items(player_ptr, monster.hold_o_idx_list | ranges::to_vector);
+    delete_items(player_ptr, monster.hold_o_idx_list);
 
     // 召喚元のモンスターが消滅した時は、召喚されたモンスターのparent_m_idxが
     // 召喚されたモンスター自身のm_idxを指すようにする

--- a/src/spell-kind/spells-polymorph.cpp
+++ b/src/spell-kind/spells-polymorph.cpp
@@ -19,7 +19,6 @@
 #include "target/target-checker.h"
 #include "tracking/health-bar-tracker.h"
 #include "util/bit-flags-calculator.h"
-#include <range/v3/view.hpp>
 
 /*!
  * @brief 変身処理向けにモンスターの近隣レベル帯モンスターを返す
@@ -84,7 +83,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
         return false;
     }
 
-    const auto back_m = monster.clone();
+    auto back_m = monster.clone();
     new_r_idx = select_polymorph_monrace_id(player_ptr, old_r_idx);
     if (new_r_idx == old_r_idx) {
         return false;
@@ -129,7 +128,7 @@ bool polymorph_monster(PlayerType *player_ptr, POSITION y, POSITION x)
             o_ptr->held_m_idx = *m_idx;
         }
     } else {
-        delete_items(player_ptr, back_m.hold_o_idx_list | ranges::to_vector);
+        delete_items(player_ptr, back_m.hold_o_idx_list);
     }
 
     if (targeted) {


### PR DESCRIPTION
GCC 13で最適化オプション -O3 を指定すると -Waggressive-loop-optimizations による警告が出る。理由は不明だが
一旦変数で受けておくと警告が出なくなるのでワークアラウンドとしてそのように修正する。

Fix #5162

## gemini code assist
Please write all summary comments and review comments in Japanese.