### PR TITLE
[Refactor] projectableのシグネチャから p_pos を削除

### DIFF
--- a/src/blue-magic/blue-magic-caster.cpp
+++ b/src/blue-magic/blue-magic-caster.cpp
@@ -51,7 +51,7 @@ static bool cast_blue_dispel(PlayerType *player_ptr)
     const auto &grid = floor.get_grid(*pos);
     const auto m_idx = grid.m_idx;
     const auto p_pos = player_ptr->get_position();
-    if ((m_idx == 0) || !grid.has_los() || !projectable(floor, p_pos, p_pos, *pos)) {
+    if ((m_idx == 0) || !grid.has_los() || !projectable(floor, p_pos, *pos)) {
         return true;
     }
 
@@ -103,7 +103,7 @@ static tl::optional<std::string> exe_blue_teleport_back(PlayerType *player_ptr, 
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
     const auto p_pos = player_ptr->get_position();
-    if (!grid.has_monster() || !grid.has_los() || !projectable(floor, p_pos, p_pos, pos)) {
+    if (!grid.has_monster() || !grid.has_los() || !projectable(floor, p_pos, pos)) {
         return tl::nullopt;
     }
 

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -403,7 +403,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         const auto p_pos = player_ptr->get_position();
         auto should_dispel = m_idx == 0;
         should_dispel &= grid.has_los();
-        should_dispel &= projectable(floor, p_pos, p_pos, *pos);
+        should_dispel &= projectable(floor, p_pos, *pos);
         if (!should_dispel) {
             break;
         }
@@ -747,7 +747,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         const auto p_pos = player_ptr->get_position();
         auto should_teleport = grid_target.has_monster();
         should_teleport &= grid_target.has_los();
-        should_teleport &= projectable(floor, p_pos, p_pos, *pos);
+        should_teleport &= projectable(floor, p_pos, *pos);
         if (!should_teleport) {
             break;
         }

--- a/src/effect/effect-player.cpp
+++ b/src/effect/effect-player.cpp
@@ -99,7 +99,7 @@ static bool process_bolt_reflection(PlayerType *player_ptr, EffectPlayerType *ep
             const Pos2DVec vec(randint1(3) - 1, randint1(3) - 1);
             pos = monster.get_position() + vec;
             max_attempts--;
-        } while (max_attempts && floor.contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE) && !projectable(floor, p_pos, p_pos, pos));
+        } while (max_attempts && floor.contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE) && !projectable(floor, p_pos, pos));
 
         if (max_attempts < 1) {
             pos = monster.get_position();

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -241,7 +241,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
     const auto p_pos = player_ptr->get_position();
     if (flag & PROJECT_KILL) {
         see_s_msg = is_monster(src_idx) ? is_seen(player_ptr, floor.m_list[src_idx])
-                                        : (is_player(src_idx) ? true : (player_can_see_bold(player_ptr, pos_source.y, pos_source.x) && projectable(floor, p_pos, p_pos, pos_source)));
+                                        : (is_player(src_idx) ? true : (player_can_see_bold(player_ptr, pos_source.y, pos_source.x) && projectable(floor, p_pos, pos_source)));
     }
 
     if (flag & (PROJECT_GRID)) {
@@ -282,7 +282,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                         pos_reflection.y = pos_source.y - 1 + randint1(3);
                         pos_reflection.x = pos_source.x - 1 + randint1(3);
                         max_attempts--;
-                    } while (max_attempts && floor.contains(pos_reflection, FloorBoundary::OUTER_WALL_INCLUSIVE) && !projectable(floor, p_pos, pos, pos_reflection));
+                    } while (max_attempts && floor.contains(pos_reflection, FloorBoundary::OUTER_WALL_INCLUSIVE) && !projectable(floor, pos, pos_reflection));
 
                     if (max_attempts < 1) {
                         pos_reflection = pos_source;

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -65,9 +65,9 @@ static bool check_pet_preservation_conditions(PlayerType *player_ptr, const Mons
     const auto should_preserve = monster.is_named();
     const auto &floor = *player_ptr->current_floor_ptr;
     auto sight_from_player = floor.has_los_at(m_pos);
-    sight_from_player &= projectable(floor, p_pos, p_pos, m_pos);
+    sight_from_player &= projectable(floor, p_pos, m_pos);
     auto sight_from_monster = los(floor, m_pos, p_pos);
-    sight_from_monster &= projectable(floor, p_pos, m_pos, p_pos);
+    sight_from_monster &= projectable(floor, m_pos, p_pos);
     if (should_preserve && (sight_from_player || sight_from_monster)) {
         return dis > 3;
     }

--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -309,7 +309,6 @@ short drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, const Pos2D &pos, tl:
     auto bs = -1;
     auto bn = 0;
     auto &floor = *player_ptr->current_floor_ptr;
-    const auto p_pos = player_ptr->get_position();
     auto has_floor_space = false;
     for (auto dy = -3; dy <= 3; dy++) {
         for (auto dx = -3; dx <= 3; dx++) {
@@ -324,7 +323,7 @@ short drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, const Pos2D &pos, tl:
             if (!floor.contains(pos_target)) {
                 continue;
             }
-            if (!projectable(floor, p_pos, pos, pos_target)) {
+            if (!projectable(floor, pos, pos_target)) {
                 continue;
             }
 

--- a/src/floor/floor-util.cpp
+++ b/src/floor/floor-util.cpp
@@ -148,7 +148,6 @@ void wipe_o_list(FloorType &floor)
 Pos2D scatter(PlayerType *player_ptr, const Pos2D &pos, int d, uint32_t mode)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    const auto p_pos = player_ptr->get_position();
     while (true) {
         const auto ny = rand_spread(pos.y, d);
         const auto nx = rand_spread(pos.x, d);
@@ -167,7 +166,7 @@ Pos2D scatter(PlayerType *player_ptr, const Pos2D &pos, int d, uint32_t mode)
             continue;
         }
 
-        if (projectable(floor, p_pos, pos, pos_neighbor)) {
+        if (projectable(floor, pos, pos_neighbor)) {
             return pos_neighbor;
         }
     }

--- a/src/floor/geometry.cpp
+++ b/src/floor/geometry.cpp
@@ -141,6 +141,6 @@ bool is_seen(PlayerType *player_ptr, const MonsterEntity &monster)
     is_inside_view |= AngbandSystem::get_instance().is_phase_out();
     const auto p_pos = player_ptr->get_position();
     const auto m_pos = monster.get_position();
-    is_inside_view |= player_can_see_bold(player_ptr, m_pos.y, m_pos.x) && projectable(*player_ptr->current_floor_ptr, p_pos, p_pos, m_pos);
+    is_inside_view |= player_can_see_bold(player_ptr, m_pos.y, m_pos.x) && projectable(*player_ptr->current_floor_ptr, p_pos, m_pos);
     return monster.ml && is_inside_view;
 }

--- a/src/grid/trap.cpp
+++ b/src/grid/trap.cpp
@@ -445,7 +445,7 @@ void hit_trap(PlayerType *player_ptr, bool break_trap)
                 }
 
                 /* Require line of projection */
-                if (!projectable(floor, p_pos, p_pos, pos)) {
+                if (!projectable(floor, p_pos, pos)) {
                     continue;
                 }
 

--- a/src/melee/melee-spell-flags-checker.cpp
+++ b/src/melee/melee-spell-flags-checker.cpp
@@ -34,7 +34,7 @@ static void decide_melee_spell_target(PlayerType *player_ptr, melee_spell_type *
     ms_ptr->target_idx = player_ptr->pet_t_m_idx;
     const auto &floor = *player_ptr->current_floor_ptr;
     ms_ptr->t_ptr = &floor.m_list[ms_ptr->target_idx];
-    if ((ms_ptr->m_idx == ms_ptr->target_idx) || !projectable(floor, player_ptr->get_position(), ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position())) {
+    if ((ms_ptr->m_idx == ms_ptr->target_idx) || !projectable(floor, ms_ptr->m_ptr->get_position(), ms_ptr->t_ptr->get_position())) {
         ms_ptr->target_idx = 0;
     }
 }
@@ -59,7 +59,7 @@ static void decide_indirection_melee_spell(PlayerType *player_ptr, melee_spell_t
         return;
     }
 
-    if (projectable(floor, player_ptr->get_position(), monster_from.get_position(), monster_to.get_position())) {
+    if (projectable(floor, monster_from.get_position(), monster_to.get_position())) {
         return;
     }
 
@@ -84,7 +84,6 @@ static bool check_melee_spell_projection(PlayerType *player_ptr, melee_spell_typ
         start = floor.m_max + 1;
     }
 
-    const auto p_pos = player_ptr->get_position();
     for (int i = start; ((i < start + floor.m_max) && (i > start - floor.m_max)); i += plus) {
         short dummy = i % floor.m_max;
         if (dummy == 0) {
@@ -96,7 +95,7 @@ static bool check_melee_spell_projection(PlayerType *player_ptr, melee_spell_typ
         const auto &monster_from = *ms_ptr->m_ptr;
         const auto &monster_to = *ms_ptr->t_ptr;
         const auto is_enemies = monster_from.is_hostile_to_melee(monster_to);
-        const auto is_projectable = projectable(floor, p_pos, monster_from.get_position(), monster_to.get_position());
+        const auto is_projectable = projectable(floor, monster_from.get_position(), monster_to.get_position());
         if (!monster_to.is_valid() || (ms_ptr->m_idx == ms_ptr->target_idx) || !is_enemies || !is_projectable) {
             continue;
         }
@@ -164,7 +163,7 @@ static void check_melee_spell_distance(PlayerType *player_ptr, melee_spell_type 
     const auto p_pos = player_ptr->get_position();
     const auto m_pos = ms_ptr->m_ptr->get_position();
     const auto pos_real = get_project_point(floor, p_pos, m_pos, ms_ptr->get_position(), 0L);
-    auto should_preserve = !projectable(floor, p_pos, pos_real, p_pos);
+    auto should_preserve = !projectable(floor, pos_real, p_pos);
     should_preserve &= ms_ptr->ability_flags.has(MonsterAbilityType::BA_LITE);
     should_preserve &= Grid::calc_distance(pos_real, p_pos) <= 4;
     should_preserve &= los(*player_ptr->current_floor_ptr, pos_real, p_pos);
@@ -207,7 +206,7 @@ static void check_melee_spell_rocket(PlayerType *player_ptr, melee_spell_type *m
     const auto p_pos = player_ptr->get_position();
     const auto m_pos = ms_ptr->m_ptr->get_position();
     const auto pos_real = get_project_point(floor, p_pos, m_pos, ms_ptr->get_position(), PROJECT_STOP);
-    if (projectable(floor, p_pos, pos_real, p_pos) && (Grid::calc_distance(pos_real, p_pos) <= 2)) {
+    if (projectable(floor, pos_real, p_pos) && (Grid::calc_distance(pos_real, p_pos) <= 2)) {
         ms_ptr->ability_flags.reset(MonsterAbilityType::ROCKET);
     }
 }

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -341,7 +341,7 @@ bool cast_force_spell(PlayerType *player_ptr, MindForceTrainerType spell)
         const auto &grid = floor.get_grid(*pos);
         const auto m_idx = grid.m_idx;
         const auto p_pos = player_ptr->get_position();
-        const auto is_projectable = projectable(floor, p_pos, p_pos, *pos);
+        const auto is_projectable = projectable(floor, p_pos, *pos);
         if ((m_idx == 0) || !grid.has_los() || !is_projectable) {
             break;
         }

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -88,7 +88,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
         }
 
         const auto dist = Grid::calc_distance(p_pos, pos);
-        const auto is_projectable = projectable(floor, p_pos, p_pos, pos);
+        const auto is_projectable = projectable(floor, p_pos, pos);
         if ((dist == 0) || (dist > max_range) || !grid.has_los() || !is_projectable) {
             continue;
         }
@@ -147,7 +147,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
                 continue;
             }
 
-            if (floor.has_los_at(pos) && projectable(floor, p_pos, p_pos, pos)) {
+            if (floor.has_los_at(pos) && projectable(floor, p_pos, pos)) {
                 if (!(player_ptr->effects()->blindness().is_blind()) && panel_contains(y, x)) {
                     print_bolt_pict(player_ptr, y, x, y, x, AttributeType::MANA);
                     move_cursor_relative(y, x);
@@ -173,7 +173,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
                 continue;
             }
 
-            if (floor.has_los_at(pos) && projectable(floor, p_pos, p_pos, pos)) {
+            if (floor.has_los_at(pos) && projectable(floor, p_pos, pos)) {
                 (void)affect_feature(player_ptr, 0, 0, y, x, dam, AttributeType::MANA);
             }
         }
@@ -194,7 +194,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
                 continue;
             }
 
-            if (floor.has_los_at(pos) && projectable(floor, p_pos, p_pos, pos)) {
+            if (floor.has_los_at(pos) && projectable(floor, p_pos, pos)) {
                 (void)affect_item(player_ptr, 0, 0, y, x, dam, AttributeType::MANA);
             }
         }
@@ -215,7 +215,7 @@ bool binding_field(PlayerType *player_ptr, int dam)
                 continue;
             }
 
-            if (floor.has_los_at(pos) && projectable(floor, p_pos, p_pos, pos)) {
+            if (floor.has_los_at(pos) && projectable(floor, p_pos, pos)) {
                 constexpr auto flags = PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL | PROJECT_JUMP;
                 (void)affect_monster(player_ptr, 0, 0, y, x, dam, AttributeType::MANA, flags, true);
             }

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -57,7 +57,6 @@ static bool decide_pet_approch_direction(PlayerType *player_ptr, const MonsterEn
 static void decide_enemy_approch_direction(PlayerType *player_ptr, MONSTER_IDX m_idx, int start, int plus, POSITION *y, POSITION *x)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    const auto p_pos = player_ptr->get_position();
     const auto &monster_from = floor.m_list[m_idx];
     const auto &monrace = monster_from.get_monrace();
     for (int i = start; ((i < start + floor.m_max) && (i > start - floor.m_max)); i += plus) {
@@ -90,7 +89,7 @@ static void decide_enemy_approch_direction(PlayerType *player_ptr, MONSTER_IDX m
                 continue;
             }
         } else {
-            if (!projectable(floor, p_pos, m_pos_from, m_pos_to)) {
+            if (!projectable(floor, m_pos_from, m_pos_to)) {
                 continue;
             }
         }

--- a/src/monster-floor/monster-generator.cpp
+++ b/src/monster-floor/monster-generator.cpp
@@ -62,7 +62,7 @@ tl::optional<Pos2D> mon_scatter(PlayerType *player_ptr, MonraceId monrace_id, co
                 continue;
             }
 
-            if (!projectable(floor, p_pos, pos, pos_neighbor)) {
+            if (!projectable(floor, pos, pos_neighbor)) {
                 continue;
             }
 

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -471,7 +471,7 @@ bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr
         const auto &apparent_monrace = monster.get_appearance_monrace();
         const auto p_pos = player_ptr->get_position(); //!< @details 関数が長すぎてプレイヤーの座標が不変であることを保証できない.
         const auto m_pos = monster.get_position();
-        const auto is_projectable = projectable(floor, p_pos, p_pos, m_pos);
+        const auto is_projectable = projectable(floor, p_pos, m_pos);
         const auto can_see = disturb_near && monster.mflag.has(MonsterTemporaryFlagType::VIEW) && is_projectable;
         const auto is_high_level = disturb_high && (apparent_monrace.r_tkills > 0) && (apparent_monrace.level >= player_ptr->lev);
         const auto is_unknown_level = disturb_unknown && (apparent_monrace.r_tkills == 0);
@@ -610,7 +610,7 @@ void process_speak(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSIT
     const auto &monrace = monster.get_monrace();
     const auto p_pos = player_ptr->get_position();
     const auto can_speak = monster.get_appearance_monrace().speak_flags.any();
-    if (!can_speak || !aware || !floor.has_los_at({ oy, ox }) || !projectable(floor, p_pos, pos, p_pos)) {
+    if (!can_speak || !aware || !floor.has_los_at({ oy, ox }) || !projectable(floor, pos, p_pos)) {
         return;
     }
 

--- a/src/monster-floor/monster-runaway.cpp
+++ b/src/monster-floor/monster-runaway.cpp
@@ -64,7 +64,7 @@ static void escape_monster(PlayerType *player_ptr, turn_flags *turn_flags_ptr, c
         const auto p_pos = player_ptr->get_position();
         const auto m_pos = monster.get_position();
         speak &= player_ptr->current_floor_ptr->has_los_at(m_pos);
-        speak &= projectable(floor, p_pos, m_pos, p_pos);
+        speak &= projectable(floor, m_pos, p_pos);
         if (speak) {
             msg_format(_("%s^「ピンチだ！退却させてもらう！」", "%s^ says 'It is the pinch! I will retreat'."), m_name);
         }

--- a/src/monster-floor/monster-safety-hiding.cpp
+++ b/src/monster-floor/monster-safety-hiding.cpp
@@ -55,7 +55,7 @@ static coordinate_candidate sweep_safe_coordinate(PlayerType *player_ptr, MONSTE
             }
         }
 
-        if (projectable(floor, p_pos, p_pos, pos)) {
+        if (projectable(floor, p_pos, pos)) {
             continue;
         }
 
@@ -126,7 +126,7 @@ static void sweep_hiding_candidate(
         if (!monster_can_enter(player_ptr, pos.y, pos.x, monrace, 0)) {
             continue;
         }
-        if (projectable(floor, p_pos, p_pos, pos) || !clean_shot(player_ptr, monster.fy, monster.fx, pos.y, pos.x, false)) {
+        if (projectable(floor, p_pos, pos) || !clean_shot(player_ptr, monster.fy, monster.fx, pos.y, pos.x, false)) {
             continue;
         }
 

--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -171,7 +171,7 @@ public:
         const auto is_enemies = monster.is_hostile_to_melee(floor.m_list[t_m_idx]);
         const auto m_pos = monster.get_position();
         const auto is_los = los(floor, m_pos, pos_target);
-        const auto is_projectable = projectable(floor, this->player_ptr->get_position(), m_pos, pos_target);
+        const auto is_projectable = projectable(floor, m_pos, pos_target);
         if (is_enemies && is_los && is_projectable) {
             return pos_target;
         }
@@ -295,7 +295,7 @@ public:
         const auto &monrace = monster.get_monrace();
         const auto p_pos = this->player_ptr->get_position();
         const auto m_pos = monster.get_position();
-        if (projectable(floor, p_pos, m_pos, p_pos)) {
+        if (projectable(floor, m_pos, p_pos)) {
             return tl::nullopt;
         }
 
@@ -344,7 +344,7 @@ public:
                 continue;
             }
 
-            if (!projectable(floor, p_pos, pos_neighbor, p_pos)) {
+            if (!projectable(floor, pos_neighbor, p_pos)) {
                 continue;
             }
 
@@ -467,8 +467,8 @@ public:
         const auto no_flow = monster.mflag2.has(MonsterConstantFlagType::NOFLOW) && (m_grid.get_cost(gf) > 2);
         const auto can_pass_wall = monrace.feature_flags.has(MonsterFeatureType::PASS_WALL) && (!monster.is_riding() || has_pass_wall(player_ptr));
         const auto can_kill_wall = monrace.feature_flags.has(MonsterFeatureType::KILL_WALL) && !monster.is_riding();
-        const auto is_visible_from_player = m_grid.has_los() && projectable(floor, p_pos, p_pos, m_pos);
-        const auto can_see_player = los(floor, m_pos, p_pos) && projectable(floor, p_pos, m_pos, p_pos);
+        const auto is_visible_from_player = m_grid.has_los() && projectable(floor, p_pos, m_pos);
+        const auto can_see_player = los(floor, m_pos, p_pos) && projectable(floor, m_pos, p_pos);
 
         std::vector<std::unique_ptr<const MonsterMoveGridDecider>> deciders;
 

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -560,7 +560,7 @@ bool cast_spell(PlayerType *player_ptr, MONSTER_IDX m_idx, bool aware)
         const auto t_m_idx = floor.get_grid(pos_to).m_idx;
         const auto &monster_to = floor.m_list[t_m_idx];
         const auto pos_from = monster_from.get_position();
-        const auto is_projectable = projectable(floor, player_ptr->get_position(), pos_from, pos_to);
+        const auto is_projectable = projectable(floor, pos_from, pos_to);
         if (t_m_idx && monster_from.is_hostile_to_melee(monster_to) && is_projectable) {
             counter_attack = true;
         }

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -386,7 +386,7 @@ bool set_monster_timewalk(PlayerType *player_ptr, MONSTER_IDX m_idx, int num, bo
     const auto p_pos = player_ptr->get_position();
     const auto m_pos = monster.get_position();
     auto should_output_message = floor.has_los_at(m_pos);
-    should_output_message &= projectable(floor, p_pos, p_pos, m_pos);
+    should_output_message &= projectable(floor, p_pos, m_pos);
     if (vs_player || should_output_message) {
         const auto m_name = monster_desc(player_ptr, monster, 0);
         const auto time_message = monrace.get_message(m_name, MonsterMessageType::MESSAGE_TIMESTART);

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -512,8 +512,8 @@ static void update_invisible_monster(PlayerType *player_ptr, um_type *um_ptr, MO
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto p_pos = player_ptr->get_position();
     const auto m_pos = monster.get_position();
-    const auto projectable_from_monster = projectable(floor, p_pos, m_pos, p_pos);
-    const auto projectable_from_player = projectable(floor, p_pos, p_pos, m_pos);
+    const auto projectable_from_monster = projectable(floor, m_pos, p_pos);
+    const auto projectable_from_player = projectable(floor, p_pos, m_pos);
     if (disturb_near && projectable_from_monster && projectable_from_player) {
         if (disturb_pets || monster.is_hostile()) {
             disturb(player_ptr, true, true);

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -53,7 +53,7 @@ bool summon_possible(PlayerType *player_ptr, POSITION y1, POSITION x1)
                 continue;
             }
 
-            if (floor.is_empty_at(pos) && (pos != p_pos) && projectable(floor, p_pos, pos1, pos) && projectable(floor, p_pos, pos, pos1)) {
+            if (floor.is_empty_at(pos) && (pos != p_pos) && projectable(floor, pos1, pos) && projectable(floor, pos, pos1)) {
                 return true;
             }
         }
@@ -71,7 +71,6 @@ bool summon_possible(PlayerType *player_ptr, POSITION y1, POSITION x1)
  */
 bool raise_possible(PlayerType *player_ptr, const MonsterEntity &monster)
 {
-    const auto p_pos = player_ptr->get_position();
     const auto m_pos = monster.get_position();
     const auto &floor = *player_ptr->current_floor_ptr;
     for (auto xx = m_pos.x - 5; xx <= m_pos.x + 5; xx++) {
@@ -83,7 +82,7 @@ bool raise_possible(PlayerType *player_ptr, const MonsterEntity &monster)
             if (!los(floor, m_pos, pos)) {
                 continue;
             }
-            if (!projectable(floor, p_pos, m_pos, pos)) {
+            if (!projectable(floor, m_pos, pos)) {
                 continue;
             }
 

--- a/src/mspell/mspell-checker.cpp
+++ b/src/mspell/mspell-checker.cpp
@@ -125,7 +125,7 @@ bool raise_possible(PlayerType *player_ptr, const MonsterEntity &monster)
 bool clean_shot(PlayerType *player_ptr, POSITION y1, POSITION x1, POSITION y2, POSITION x2, bool is_friend)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    ProjectionPath grid_g(floor, AngbandSystem::get_instance().get_max_range(), player_ptr->get_position(), { y1, x1 }, { y2, x2 }, 0);
+    ProjectionPath grid_g(floor, AngbandSystem::get_instance().get_max_range(), { y1, x1 }, { y2, x2 });
     if (grid_g.path_num() == 0) {
         return false;
     }

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -137,10 +137,10 @@ bool breath_direct(PlayerType *player_ptr, const Pos2D &pos_source, const Pos2D 
                 hityou = true;
             }
         } else {
-            if (projectable(floor, p_pos, pos_source, pos_target) && (Grid::calc_distance(pos_source, pos_target) <= rad)) {
+            if (projectable(floor, pos_source, pos_target) && (Grid::calc_distance(pos_source, pos_target) <= rad)) {
                 hit2 = true;
             }
-            if (projectable(floor, p_pos, pos_source, p_pos) && (Grid::calc_distance(pos_source, p_pos) <= rad)) {
+            if (projectable(floor, pos_source, p_pos) && (Grid::calc_distance(pos_source, p_pos) <= rad)) {
                 hityou = true;
             }
         }

--- a/src/mspell/mspell-lite.cpp
+++ b/src/mspell/mspell-lite.cpp
@@ -58,7 +58,6 @@ static tl::optional<Pos2D> adjacent_grid_check(PlayerType *player_ptr, const Mon
     }
 
     const auto &floor = *player_ptr->current_floor_ptr;
-    const auto p_pos = player_ptr->get_position();
     const auto m_pos = monster.get_position();
     for (const auto direction : directions.at(next)) {
         const auto pos_next = pos + Direction(direction).vec();
@@ -69,7 +68,7 @@ static tl::optional<Pos2D> adjacent_grid_check(PlayerType *player_ptr, const Mon
         bool check_result;
         switch (tc) {
         case TerrainCharacteristics::PROJECTION:
-            check_result = projectable(floor, p_pos, m_pos, pos_next);
+            check_result = projectable(floor, m_pos, pos_next);
             break;
         case TerrainCharacteristics::LOS:
             check_result = los(floor, m_pos, pos_next);
@@ -146,7 +145,7 @@ static void check_lite_area_by_mspell(PlayerType *player_ptr, msa_type *msa_ptr)
     const auto m_pos = msa_ptr->m_ptr->get_position();
     const auto &floor = *player_ptr->current_floor_ptr;
     light_by_disintegration &= in_disintegration_range(floor, m_pos, pos);
-    light_by_disintegration &= one_in_(10) || (projectable(floor, p_pos, pos, m_pos) && one_in_(2));
+    light_by_disintegration &= one_in_(10) || (projectable(floor, pos, m_pos) && one_in_(2));
     if (light_by_disintegration) {
         msa_ptr->do_spell = DO_SPELL_BR_DISI;
         msa_ptr->success = true;
@@ -209,7 +208,7 @@ static void decide_lite_breath(msa_type *msa_ptr)
 bool decide_lite_projection(PlayerType *player_ptr, msa_type *msa_ptr)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    if (projectable(floor, player_ptr->get_position(), msa_ptr->m_ptr->get_position(), msa_ptr->get_position())) {
+    if (projectable(floor, msa_ptr->m_ptr->get_position(), msa_ptr->get_position())) {
         feature_projection(floor, msa_ptr);
         return true;
     }

--- a/src/object-activation/activation-others.cpp
+++ b/src/object-activation/activation-others.cpp
@@ -435,7 +435,7 @@ bool activate_dispel_magic(PlayerType *player_ptr)
     }
 
     const auto p_pos = player_ptr->get_position();
-    if (!floor.has_los_at(*pos) || !projectable(floor, p_pos, p_pos, *pos)) {
+    if (!floor.has_los_at(*pos) || !projectable(floor, p_pos, *pos)) {
         return true;
     }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -339,7 +339,6 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
     static int old_damage = 0;
 
     auto &floor = *player_ptr->current_floor_ptr;
-    const auto p_pos = player_ptr->get_position();
     const auto &dungeon = floor.get_dungeon_definition();
     for (auto mx = xx - warning_aware_range; mx < xx + warning_aware_range + 1; mx++) {
         for (auto my = yy - warning_aware_range; my < yy + warning_aware_range + 1; my++) {
@@ -367,7 +366,7 @@ bool process_warning(PlayerType *player_ptr, POSITION xx, POSITION yy)
             const auto &monrace = monster.get_monrace();
 
             /* Monster spells (only powerful ones)*/
-            if (projectable(floor, p_pos, pos_neighbor, pos)) {
+            if (projectable(floor, pos_neighbor, pos)) {
                 const auto flags = monrace.ability_flags;
 
                 if (dungeon.flags.has_not(DungeonFeatureType::NO_MAGIC)) {

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -649,7 +649,7 @@ tl::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX sp
             const auto p_pos = player_ptr->get_position();
             const auto is_teleportable = cave_player_teleportable_bold(player_ptr, pos->y, pos->x, TELEPORT_SPONTANEOUS);
             const auto dist = Grid::calc_distance(*pos, p_pos);
-            if (!is_teleportable || (dist > MAX_PLAYER_SIGHT / 2) || !projectable(*player_ptr->current_floor_ptr, p_pos, p_pos, *pos)) {
+            if (!is_teleportable || (dist > MAX_PLAYER_SIGHT / 2) || !projectable(*player_ptr->current_floor_ptr, p_pos, *pos)) {
                 msg_print(_("失敗！", "You cannot move to that place!"));
                 break;
             }

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -131,7 +131,7 @@ bool fetch_monster(PlayerType *player_ptr)
 
     const auto m_name = monster_desc(player_ptr, monster, 0);
     msg_print(_("{}を引き戻した。", "You pull back {}."), m_name);
-    ProjectionPath path_g(floor, AngbandSystem::get_instance().get_max_range(), p_pos, *pos, p_pos, 0);
+    ProjectionPath path_g(floor, AngbandSystem::get_instance().get_max_range(), *pos, p_pos);
     Pos2D pos_target = *pos;
     for (const auto &pos_path : path_g) {
         const auto &grid = floor.get_grid(pos_path);

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -64,7 +64,7 @@ void fetch_item(PlayerType *player_ptr, const Direction &dir, WEIGHT wgt, bool r
             if (!floor.has_los_at(pos)) {
                 msg_print(_("そこはあなたの視界に入っていません。", "You have no direct line of sight to that location."));
                 return;
-            } else if (!projectable(floor, p_pos, p_pos, pos)) {
+            } else if (!projectable(floor, p_pos, pos)) {
                 msg_print(_("そこは壁の向こうです。", "You have no direct line of sight to that location."));
                 return;
             }
@@ -125,7 +125,7 @@ bool fetch_monster(PlayerType *player_ptr)
     }
 
     const auto p_pos = player_ptr->get_position();
-    if (!projectable(floor, p_pos, p_pos, *pos)) {
+    if (!projectable(floor, p_pos, *pos)) {
         return false;
     }
 

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -53,7 +53,7 @@ bool project_all_los(PlayerType *player_ptr, AttributeType typ, int dam)
         }
 
         const auto m_pos = monster.get_position();
-        if (!floor.has_los_at(m_pos) || !projectable(floor, p_pos, p_pos, m_pos)) {
+        if (!floor.has_los_at(m_pos) || !projectable(floor, p_pos, m_pos)) {
             continue;
         }
 

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -236,7 +236,7 @@ bool teleport_level_other(PlayerType *player_ptr)
     }
 
     const auto p_pos = player_ptr->get_position();
-    if (!projectable(floor, p_pos, p_pos, *pos)) {
+    if (!projectable(floor, p_pos, *pos)) {
         return true;
     }
 

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -205,7 +205,7 @@ void cast_meteor(PlayerType *player_ptr, int dam, POSITION rad)
                 continue;
             }
 
-            const auto is_projectable = projectable(floor, p_pos, p_pos, pos);
+            const auto is_projectable = projectable(floor, p_pos, pos);
             if (!is_projectable || !floor.has_terrain_characteristics(pos, TerrainCharacteristics::PROJECTION)) {
                 continue;
             }

--- a/src/spell/range-calc.cpp
+++ b/src/spell/range-calc.cpp
@@ -26,7 +26,7 @@ bool is_prevent_blast(PlayerType *player_ptr, const Pos2D &center, const Pos2D &
         return !in_disintegration_range(floor, center, pos);
     default:
         /* Others are stopped by walls */
-        return !projectable(floor, player_ptr->get_position(), center, pos);
+        return !projectable(floor, center, pos);
     }
 }
 }

--- a/src/spell/spells-summon.cpp
+++ b/src/spell/spells-summon.cpp
@@ -312,7 +312,7 @@ void mitokohmon(PlayerType *player_ptr)
             if (!los(floor, m_pos, p_pos)) {
                 continue;
             }
-            if (!projectable(floor, p_pos, m_pos, p_pos)) {
+            if (!projectable(floor, m_pos, p_pos)) {
                 continue;
             }
             count++;

--- a/src/target/projection-path-calculator.cpp
+++ b/src/target/projection-path-calculator.cpp
@@ -238,19 +238,22 @@ ProjectionPath::ProjectionPath(const FloorType &floor, int range, const Pos2D &p
 }
 
 /*
- * Determine if a bolt spell cast from (y1,x1) to (y2,x2) will arrive
+ * Determine if a bolt spell cast from pos_src to pos_dst will arrive
  * at the final destination, assuming no monster gets in the way.
  *
- * This is slightly (but significantly) different from "los(y1,x1,y2,x2)".
+ * This is slightly (but significantly) different from "los(floor, pos_src, pos_dst)".
  */
-bool projectable(const FloorType &floor, const Pos2D &p_pos, const Pos2D &pos1, const Pos2D &pos2)
+bool projectable(const FloorType &floor, const Pos2D &pos_src, const Pos2D &pos_dst)
 {
     const auto range = project_length ? project_length : AngbandSystem::get_instance().get_max_range();
-    ProjectionPath grid_g(floor, range, p_pos, pos1, pos2, 0);
+    // ProjectionPathのp_posはflagにPROJECT_STOPが設定されている時のみ使用される
+    // ここではflagが0なのでダミーを渡せば良い
+    constexpr auto p_pos_dummy = Pos2D(0, 0);
+    ProjectionPath grid_g(floor, range, p_pos_dummy, pos_src, pos_dst, 0);
     if (grid_g.path_num() == 0) {
         return true;
     }
 
     const auto &pos = grid_g.back();
-    return pos == pos2;
+    return pos == pos_dst;
 }

--- a/src/target/projection-path-calculator.cpp
+++ b/src/target/projection-path-calculator.cpp
@@ -212,8 +212,9 @@ static void calc_diagonal_projection(const FloorType &floor, const Pos2D &p_pos,
 
 /*!
  * @brief 始点から終点への直線経路を返す
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param range 距離
+ * @param p_pos プレイヤーの座標
  * @param pos_src 始点座標
  * @param pos_dst 終点座標
  * @param flag フラグ群
@@ -237,6 +238,20 @@ ProjectionPath::ProjectionPath(const FloorType &floor, int range, const Pos2D &p
     calc_diagonal_projection(floor, p_pos, &pph);
 }
 
+/*!
+ * @brief 始点から終点への直線経路を返す(フラグ指定なし)
+ * @param floor フロアへの参照
+ * @param range 距離
+ * @param pos_src 始点座標
+ * @param pos_dst 終点座標
+ * @details プレイヤーの座標はPROJECT_STOPフラグが設定されている時のみ使用されるため、フラグ指定無しの場合は不要。
+ * したがってダミー座標を渡しておく。
+ */
+ProjectionPath::ProjectionPath(const FloorType &floor, int range, const Pos2D &pos_src, const Pos2D &pos_dst)
+    : ProjectionPath(floor, range, { 0, 0 } /* dummy */, pos_src, pos_dst, 0)
+{
+}
+
 /*
  * Determine if a bolt spell cast from pos_src to pos_dst will arrive
  * at the final destination, assuming no monster gets in the way.
@@ -246,10 +261,7 @@ ProjectionPath::ProjectionPath(const FloorType &floor, int range, const Pos2D &p
 bool projectable(const FloorType &floor, const Pos2D &pos_src, const Pos2D &pos_dst)
 {
     const auto range = project_length ? project_length : AngbandSystem::get_instance().get_max_range();
-    // ProjectionPathのp_posはflagにPROJECT_STOPが設定されている時のみ使用される
-    // ここではflagが0なのでダミーを渡せば良い
-    constexpr auto p_pos_dummy = Pos2D(0, 0);
-    ProjectionPath grid_g(floor, range, p_pos_dummy, pos_src, pos_dst, 0);
+    ProjectionPath grid_g(floor, range, pos_src, pos_dst);
     if (grid_g.path_num() == 0) {
         return true;
     }

--- a/src/target/projection-path-calculator.h
+++ b/src/target/projection-path-calculator.h
@@ -9,6 +9,7 @@ class ProjectionPath {
 public:
     using pp_const_iterator = std::vector<Pos2D>::const_iterator;
 
+    ProjectionPath(const FloorType &floor, int range, const Pos2D &pos_src, const Pos2D &pos_dst);
     ProjectionPath(const FloorType &floor, int range, const Pos2D &p_pos, const Pos2D &pos_src, const Pos2D &pos_dst, uint32_t flag);
     pp_const_iterator begin() const;
     pp_const_iterator end() const;

--- a/src/target/projection-path-calculator.h
+++ b/src/target/projection-path-calculator.h
@@ -21,4 +21,4 @@ private:
     std::vector<Pos2D> positions;
 };
 
-bool projectable(const FloorType &floor, const Pos2D &p_pos, const Pos2D &pos1, const Pos2D &pos2);
+bool projectable(const FloorType &floor, const Pos2D &pos_src, const Pos2D &pos_dst);

--- a/src/target/target-preparation.cpp
+++ b/src/target/target-preparation.cpp
@@ -52,7 +52,7 @@ bool target_able(PlayerType *player_ptr, MONSTER_IDX m_idx)
     }
 
     const auto p_pos = player_ptr->get_position();
-    if (!projectable(floor, p_pos, p_pos, monster.get_position())) {
+    if (!projectable(floor, p_pos, monster.get_position())) {
         return false;
     }
 

--- a/src/target/target-setter.cpp
+++ b/src/target/target-setter.cpp
@@ -210,7 +210,7 @@ std::string TargetSetter::describe_projectablity() const
     const auto cheatinfo = format(" X:%d Y:%d LOS:%d LOP:%d",
         this->pos_target.x, this->pos_target.y,
         los(*this->player_ptr->current_floor_ptr, p_pos, this->pos_target),
-        projectable(floor, p_pos, p_pos, this->pos_target));
+        projectable(floor, p_pos, this->pos_target));
     return info.append(cheatinfo);
 }
 
@@ -419,7 +419,7 @@ std::string TargetSetter::describe_grid_wizard() const
     constexpr auto fmt = " X:%d Y:%d LOS:%d LOP:%d SPECIAL:%d";
     const auto p_pos = this->player_ptr->get_position();
     const auto is_los = los(floor, p_pos, this->pos_target);
-    const auto is_projectable = projectable(floor, p_pos, p_pos, this->pos_target);
+    const auto is_projectable = projectable(floor, p_pos, this->pos_target);
     const auto cheatinfo = format(fmt, this->pos_target.x, this->pos_target.y, is_los, is_projectable, grid.special);
     return cheatinfo;
 }


### PR DESCRIPTION
p_pos はProjectionPathクラスの flag に PROJECT_STOP を設定する時以外は不要であり、 projectable関数の処理においてはダミーを渡せばよいので引数で p_pos を受け取る必要はない。したがって引数から p_pos を削除する。

Resolaves #5166 

## gemini code assist
Please write all comments in Japanese.