### PR TITLE
[Fix] 善良でも邪悪でもないモンスターに変身したカメレオンがその後二度と変身しない

### DIFF
--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -601,7 +601,7 @@ static bool monster_hook_chameleon(PlayerType *player_ptr, const ChameleonTransf
             return false;
         }
 
-        if (old_monrace.kind_flags.has_none_of(alignment_mask)) {
+        if (old_monrace.kind_flags.has_none_of(alignment_mask) && monrace.kind_flags.has_any_of(alignment_mask)) {
             return false;
         }
     } else if (ct.summoner_m_idx && monster_has_hostile_to_other_monster(floor.m_list[*ct.summoner_m_idx], monrace)) {


### PR DESCRIPTION
カメレオンは変身する時、変身元が善良なら変身先も善良、変身元が邪悪なら変身先も邪悪、変身元が善良でも邪悪でもないなら変身先も善良でも邪悪でもないモンスターのみ選択できる。
しかし、この制限を加えるロジックが 69feb9b で意図せず書き換わってしまったことにより、変身元が善良でも邪悪でもない場合にどのモンスターも選択できなくなってしまっており、結果として元のモンスターのまま、二度と変身しないという不具合が発生している。
元のロジックを復活させ、変身先に善良でも邪悪でもないモンスターを選択できるようにする。

Fixes #5181 

## gemini code assist
Write all summary and review comments in Japanese.