### PR TITLE
[Refactor] MonsterMessage.jsoncの整理

### DIFF
--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -3,7 +3,7 @@
     "groups": [
         {
             "id_list": [
-                8 /*農夫『マゴット』*/
+                8 /*Farmer Maggot*/
             ],
             "message": [
                 {
@@ -23,6 +23,50 @@
                             "「何かやっかい事に巻き込まれたようじゃな。」",
                             "「やあ、お若いの！」",
                             "「今日はろくでもない日じゃ、間違いない！」"
+                        ],
+                        "en": [
+                            "seems sad about something.",
+                            "asks if you have seen his dogs.",
+                            "tells you to get off his land.",
+                            "says, \"Grip! Fang! Wolf! Come on, lads!\"",
+                            "says, \"They won't harm you -- not unless I tell 'em to!\"",
+                            "says, \"Here, Grip! Fang! Heel!\"",
+                            "exclaims, \"Well, if that isn't queerer than ever?\"",
+                            "asks, \"Were you coming to visit me?\"",
+                            "says, \"I'll not light my lanterns till I turn for home.\"",
+                            "says, \"I see you are in some kind of trouble.\"",
+                            "yells, \"Hallo there!\"",
+                            "says, \"It's been a queer day, and no mistake.\""
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は叫んだ。「この哀れで無抵抗なホビットを殺さないでくれ！」",
+                            "は叫んだ。「あの困った犬どもはこの大事な時にどこにいるんだ！」"
+                        ],
+                        "en": [
+                            "screams, 'Don't hurt a poor helpless hobbit!'",
+                            "yells, 'Where are my vicious dogs when I need them?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FRIEND",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は何か悲しそうだ。",
+                            "は彼の犬を見なかったかと尋ねている。",
+                            "はキノコがどうのとつぶやいている。"
+                        ],
+                        "en": [
+                            "seems sad about something.",
+                            "asks if you have seen his dogs.",
+                            "mumbles something about mushrooms."
                         ]
                     }
                 }
@@ -54,68 +98,96 @@
                             "「郵政民営化、民営化で鉄道や電話が無くなりましたか？」",
                             "「構造改革なくして景気回復はありえない。」",
                             "「今の痛みに耐えて、明日の豊かさ米百俵の精神。」"
+                        ],
+                        "en": [
+                            "says, 'We must stand up with firm resolve to strive for the eradication of terrorism, together with other nations of the world'",
+                            "says, 'Japan supports the U.S. position that it will not bow to terrorism. I think it is only natural for President Bush to hunt down the culprits and take firm steps against this serious crime.'",
+                            "says, 'The terrorist acts are extremely heinous and outrageous and cannot be forgiven.'",
+                            "says, 'It is a challenge not only to the U.S. but also to democracy, and I am outraged.'",
+                            "says, 'Japan-U.S. alliance is becoming bigger and bigger.'",
+                            "says, 'Not only for borth countries, but in the Asia-Pacific region and the entire world.'",
+                            "says, 'The safe society is crumbling and this is a significant incident.'",
+                            "sings, 'As K*izumi as the day is long...'",
+                            "says, 'I don't think there's any going back to what politics was in this country even three weeks ago.'",
+                            "says, 'What will the prime minister do if the anti-reform forces within the Liberal Democratic Party regain power?'",
+                            "says, 'People are driving the LDP members, and the LDP members are driving the party. That is a total reversal of the past.'",
+                            "says, 'No pain, no gain.'",
+                            "says, 'Here's a present for you. A compact disc of X-JAPAN!'",
+                            "sings, 'Forever...'",
+                            "is composing haiku, 'Liberal Democrats, You said it's good, Let's go voting.'",
+                            "says, 'Perfect circle, round, round, Perfect circle.'",
+                            "says, 'You stuck it out despite the pain. I was thrilled. Congratulations.'",
+                            "says, 'The illegal entry was one thing and the abduction issue was another, although I think it is necessary for the government to take sufficient measures toward families of the abducted people.'",
+                            "says, 'I am starting with the issue that is the most difficalt and which draws the strongest resistance.'",
+                            "says, 'Though the ministry is making a hard effort to consider reforms, all of you will just have to wait and see.'",
+                            "says, 'People call me a eccentric, but I am a man of reform.'",
+                            "says, 'Structural reforms without sanctuaries.'",
+                            "says, 'No structural reforms, no economic recovery.'",
+                            "says, 'The belief -A pain of today makes affluence of tommorow- '"
                         ]
                     }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1059 /*イークの大統領『ノボータ・ケシータ』*/
-            ],
-            "message": [
+                },
                 {
-                    "action": "SPEAK_ALL",
+                    "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
                         "ja": [
-                            "「わすの一億ゴールドでカズノ建てなはったさながどげなっちょますかいの」",
-                            "「わすはげんごめーりょ、えめふめーですけんの」"
+                            "は叫んだ。「私は一国の長だ。そんなことするのは許されない！」",
+                            "は叫んだ。「助けてくれ！野放しのキチガイだ！」"
+                        ],
+                        "en": [
+                            "yells, 'I'm a head of state!  You can't *do* this!'",
+                            "yells, 'Help! Psycho on the loose!'"
                         ]
                     }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1060 /*Mori troll*/
-            ],
-            "message": [
+                },
                 {
-                    "action": "SPEAK_ALL",
+                    "action": "SPEAK_FRIEND",
                     "chance": 8,
                     "message": {
                         "ja": [
-                            "「日本の国、まさに天皇を中心にしている神の国であるぞということを、国民のみなさんにしっかりと承知をしていただく…」",
-                            "「まだ決めていない人が４０％ぐらいある。そのまま関心がない、といって寝てしまってくれればいいんですけれども。」",
-                            "「何も教育勅語に戻せとか超国家的なことに賛成している訳ではない。」",
-                            "「教育勅語には時代を超えて普遍的哲学がある。」",
-                            "「結構国会に残っていますのは、神様を大事にしているからちゃんと当選させてもらえるのだなあと。」",
-                            "「私があいさつに行くと、農作業をしている農家の方が全部家に入っていった。」",
-                            "「大阪は“たんつぼ”といわれるのは無理からぬこと。金もうけだけを考える実に汚い街になった。」",
-                            "「アメリカでは停電が起きたら必ずギャングや殺し屋がやってくる。」",
-                            "「沖縄で万博やることも……」",
-                            "「小渕さんはなんとか万博だけは成功させたいという思いだったんだろう。」",
-                            "「銃後のこと、前線で戦ってまいりますので、この地区はみなさんでお守りいただきたい。」",
-                            "「共産党は綱領は変えないと言っている。天皇制も認めないし、自衛隊は解散、日米安保も容認しない。」",
-                            "「日本の安全を、日本の「国体」をどう守ることができるか。民主党は困っているでしょう。」",
-                            "「共産党と組むとはいかない。」",
-                            "「失言でも何でもない。」",
-                            "「朝鮮半島は２つの民族に分断されていたわけでありますが……」",
-                            "「神様の話をするとまた怒られますが……」",
-                            "「これは政局にしてはいけない、まさに挙国一致……」",
-                            "「あん時はすんません。」",
-                            "「私が来るといい。なぜか。モリ上がるから。」",
-                            "「ＰＨＳってなんだ？携帯の新製品なのか？」",
-                            "「僕だって馬鹿じゃない。」",
-                            "「自分の発言がどういう影響を与えるかは、ちゃんと考えている。」",
-                            "「ベリー・ファイン・トゥデー」",
-                            "「十分に意を尽くさない表現により、多くの方々に誤解を与えたことを深く反省し、国民に深くおわびする。」",
-                            "「間違ったことを言ったとは思っていない。」",
-                            "「パソコンが使えない人は、言葉は悪いが日陰者というんだ。」",
-                            "「心の教育は私立のほうがいいね。」",
-                            "「重油は九州の方に流れていってくれればいい。」",
-                            "「ふーあーゆー？」"
+                            "「旧郵政省のわけのわからない論理はコイ○ミ内閣には通用しない！」",
+                            "「私は芸能人じゃない。政治家なんですよ。」",
+                            "「♪なんてったってコイ○ミ～」",
+                            "「私の方から自民党をぶち壊しますから。」",
+                            "「今日はX-JAPANのCDプレゼント！」",
+                            "「♪フォ～エバ～」",
+                            "「よく仕事する人はよく遊ぶ。」",
+                            "「候補者が燃えなきゃ、有権者も燃えないよ。」",
+                            "「自民党がいいねと君が行ったから29日は投票に行こう。」",
+                            "「まんまる丸く丸くまんまる。」",
+                            "「痛みに耐えてよく頑張った！感動した！」",
+                            "「これからさまざまな妨害や抵抗がある。」",
+                            "「私の内閣に反対するものはすべて抵抗勢力だ。」",
+                            "「郵政民営化、民営化で鉄道や電話が無くなりましたか？」",
+                            "「構造改革なくして景気回復はありえない。」",
+                            "「今の痛みに耐えて、明日の豊かさ米百俵の精神。」"
+                        ],
+                        "en": [
+                            "says, 'We must stand up with firm resolve to strive for the eradication of terrorism, together with other nations of the world'",
+                            "says, 'Japan supports the U.S. position that it will not bow to terrorism. I think it is only natural for President Bush to hunt down the culprits and take firm steps against this serious crime.'",
+                            "says, 'The terrorist acts are extremely heinous and outrageous and cannot be forgiven.'",
+                            "says, 'It is a challenge not only to the U.S. but also to democracy, and I am outraged.'",
+                            "says, 'Japan-U.S. alliance is becoming bigger and bigger.'",
+                            "says, 'Not only for borth countries, but in the Asia-Pacific region and the entire world.'",
+                            "says, 'The safe society is crumbling and this is a significant incident.'",
+                            "sings, 'As K*izumi as the day is long...'",
+                            "says, 'I don't think there's any going back to what politics was in this country even three weeks ago.'",
+                            "says, 'What will the prime minister do if the anti-reform forces within the Liberal Democratic Party regain power?'",
+                            "says, 'People are driving the LDP members, and the LDP members are driving the party. That is a total reversal of the past.'",
+                            "says, 'No pain, no gain.'",
+                            "says, 'Here's a present for you. A compact disc of X-JAPAN!'",
+                            "sings, 'Forever...'",
+                            "is composing haiku, 'Liberal Democrats, You said it's good, Let's go voting.'",
+                            "says, 'Perfect circle, round, round, Perfect circle.'",
+                            "says, 'You stuck it out despite the pain. I was thrilled. Congratulations.'",
+                            "says, 'The illegal entry was one thing and the abduction issue was another, although I think it is necessary for the government to take sufficient measures toward families of the abducted people.'",
+                            "says, 'I am starting with the issue that is the most difficalt and which draws the strongest resistance.'",
+                            "says, 'Though the ministry is making a hard effort to consider reforms, all of you will just have to wait and see.'",
+                            "says, 'People call me a eccentric, but I am a man of reform.'",
+                            "says, 'Structural reforms without sanctuaries.'",
+                            "says, 'No structural reforms, no economic recovery.'",
+                            "says, 'The belief -A pain of today makes affluence of tommorow- '"
                         ]
                     }
                 }
@@ -123,37 +195,10 @@
         },
         {
             "id_list": [
-                1083 /*Hato Poppo*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「トラスト・ミー。」",
-                            "「鳩山内閣が取り組むのは『無血の平成維新』だ。」",
-                            "「必ずしも抑止力として沖縄に存在しなければならない理由にはならないと思ってました。」",
-                            "「国というものがよく分からないのですが。」",
-                            "「人間がいなくなるのが一番地球にとって優しい。」",
-                            "「日本列島は日本人だけの所有物じゃないんですから。」",
-                            "「政治家が馬鹿者であり、そのトップの総理大臣が大馬鹿者である。そんな国が世界的にも認められるはずがない。」",
-                            "「今日は大変いい天気です。」",
-                            "「友愛精神に基づいた『人間のための経済』が日本の新たな成長をつくる。」",
-                            "「正直、政権交代する前の方が楽だった。名前には『山』がつくが、谷ばかりだ。」",
-                            "「公約というのは選挙の時の党の考え方ということ。」",
-                            "「恵まれた家庭に育ったものですから。」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                53, /*農夫マゴットの飼犬『くいつき』*/
-                54, /*農夫マゴットの飼犬『おおかみ』*/
-                55, /*農夫マゴットの飼犬『きば』*/
-                1320 /*偉大なる祖国の『ライカ』*/
+                53 /*Grip, Farmer Maggot's dog*/,
+                54 /*Wolf, Farmer Maggot's dog*/,
+                55 /*Fang, Farmer Maggot's dog*/,
+                1320 /*Laika, the greatest beast of USSR*/
             ],
             "message": [
                 {
@@ -167,6 +212,46 @@
                             "は尻尾をふっている。",
                             "はごろんと寝ころんだ。",
                             "はうなった。"
+                        ],
+                        "en": [
+                            "chases its tail.",
+                            "barks loudly.",
+                            "froths at the mouth.",
+                            "wags its tail.",
+                            "rolls over.",
+                            "growls."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            ""
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はクンクン鳴いた。",
+                            "は片足を引きずってほえた。",
+                            "はうなった。",
+                            "は悲しそうにあなたを見た。",
+                            "はクンクン鳴いた。",
+                            "は片足を引きずってほえた。",
+                            "はうなった。",
+                            "は悲しそうにあなたを見た。"
+                        ],
+                        "en": [
+                            "whimpers.",
+                            "pines.",
+                            "limps away, howling.",
+                            "howls.",
+                            "looks at you sadly."
                         ]
                     }
                 }
@@ -197,10 +282,8 @@
                             "「よくないよ！ホビットの旦那！」",
                             "「あの指輪はずーーっとわしらの物だった！」",
                             "「スメアゴル近くにいるよ！近くよ！ス、ス、ス」",
-                            "says, 'Every way is guarded, silly foolsis!'",
                             "「わしら魚が食いたい」",
                             "「わしらずっと持ってたものをなくしてしまったよ。」",
-                            "says, 'He'll eastus all the world if he getsitses it.'",
                             "「食べるものない、休みない．スメアゴルこそこそやるね」",
                             "「おまえはあのしとのおいしいごちそうになるよ」",
                             "「ホビットさんはいつだってとても礼儀がある」",
@@ -209,6 +292,60 @@
                             "「あいつの黒い手には四本しか指がないよ」",
                             "「よくないホビットだよ．物わかりよくないよ」",
                             "「もし見つけたら、わしらに返しなよ。」"
+                        ],
+                        "en": [
+                            "mutters, 'My precious, wheres my precious?'",
+                            "screams, 'Nasty Hobbitsisisisis...'",
+                            "says, 'Come on, quickly, follow Smeagol'",
+                            "says, 'Nasty Bagginis, stole my precious.'",
+                            "says, 'She will kill them oh yes she will precious.'",
+                            "says, 'Whats has its got in its pocketses, hmmm?'",
+                            "sniggers.",
+                            "grovels.",
+                            "picks his nose.",
+                            "pines for his precious.",
+                            "searches his pockets.",
+                            "eats some slimy creatures.",
+                            "shouts, 'No Master Hobbitsisisisis!'",
+                            "cries, 'The ring was ours for agesisisisis!'",
+                            "says, 'Smeagol sneeking! ME! Shneekingsisis!'",
+                            "says, 'Every way is guarded, silly foolsis!'",
+                            "whines, 'Weees wants some fishises.'",
+                            "whimpers, 'We've lost itses we have.'",
+                            "says, 'He'll eastus all the world if he getsitses it.'",
+                            "says, 'No food, no rest; Smeagol a SNEAK!'",
+                            "says, 'What a dainty little dish you will be for her.'",
+                            "says, 'Hobbitses always SOOOO Polite.'",
+                            "screams, 'Stop, Thief!'",
+                            "says, 'Makeses him drop his weapon precious.'",
+                            "grovels, 'He has only four fingers on the black hand.'",
+                            "growls, 'Not nice Hobbits, not sensible!'",
+                            "says, 'If you findesis it, give it us back.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「にくむ、にくむ、にくむぅぅぅ！」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「しどいことしないでくれよう、旦那、---ス、ス、ス---」",
+                            "「かわいそうなスメアゴル、かわいそうなスメアゴル。」",
+                            "「あぁ！いやだよう、しどいことしないでくれよう。」"
+                        ],
+                        "en": [
+                            "says, 'Don't hurt us, mastersisis.'",
+                            "says, 'Poor Smeagol, poor Smeagol.'",
+                            "says, 'No AH! Don't hurtsis us.'"
                         ]
                     }
                 }
@@ -228,6 +365,26 @@
                             "「俺の怒りを思い知れ！バカめ！」",
                             "「死と破壊こそが我が喜びだ！」",
                             "は邪悪に笑った。"
+                        ],
+                        "en": [
+                            "says, 'I may be a kobold, but I'll kick your arse!'",
+                            "says, 'Feel my wrath, fool!'",
+                            "says, 'Death and destruction make me happy!'",
+                            "snickers evilly."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は叫んだ。「臆病者どもめ！オレを置き去りにしやがって！」",
+                            "は慈悲を乞うた。"
+                        ],
+                        "en": [
+                            "screams, 'Cowards! Why did you abandon me?'",
+                            "begs for mercy."
                         ]
                     }
                 }
@@ -253,6 +410,34 @@
                             "「わたくしのことずかった用件は今となってはむだです。」",
                             "「いやだ！いやだ！」",
                             "「あんたがいいつけたんだ、あんたがさせたんだ！」"
+                        ],
+                        "en": [
+                            "whines and sniggers.",
+                            "whispers nasty things.",
+                            "says, 'I'll slaughter you slowly...'",
+                            "says, 'Lathspell I name you, Ill-news; and Ill-news is an ill guest they say.'",
+                            "says, 'Forbid his staff!'",
+                            "yells, 'You lie!'",
+                            "says, 'Let me go, let me go!  I know the way!'",
+                            "says, 'My messages are useless now!'",
+                            "says, 'No no!'",
+                            "hisses, 'You told me to; you made me do it!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は哀れっぽく命乞いをした。",
+                            "は哀れっぽく泣いた。「私のせいではない！」",
+                            "は叫んだ。「助けて！助けて！」"
+                        ],
+                        "en": [
+                            "begs you to spare his miserable life.",
+                            "whines, 'This is not my fault!'",
+                            "screams, 'Help! Help!'"
                         ]
                     }
                 }
@@ -274,27 +459,30 @@
                             "「よこせ、ぶっとばされんうちにな」",
                             "「俺にお前の頭を射抜かせないでくれ...」",
                             "「ケビン・コスナーは俺の名前を地に落とした！」"
+                        ],
+                        "en": [
+                            "is looking at your wallet with a wishful eyes.",
+                            "says, 'You look like Nottingham's man to me!'",
+                            "says, 'I bet I can shoot better than you...'",
+                            "says, 'Give 'til it hurts!'",
+                            "says, 'Don't force me to put an arrow in your skull...'",
+                            "says, 'Kevin Costner has soiled my name!'"
                         ]
                     }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                180, /*ボルドールの息子『オルファックス』*/
-                237 /*イークの大王『ボルドール』*/
-            ],
-            "message": [
+                },
                 {
-                    "action": "SPEAK_ALL",
+                    "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
                         "ja": [
-                            "はあなたを変態呼ばわりしてわめいている。",
-                            "はひわいな言葉をまくしたてた。",
-                            "「イーク！イーク！イーク！」",
-                            "「イークもバカにできないってことを教えてやろう！」'",
-                            "はダーティーハリーの真似をして「命を賭けてみるか、チンピラ野郎」と言っている。"
+                            "は命乞いをした。",
+                            "「けど俺は善玉なんだぞ、ホントに！」",
+                            "「金？もちろん全部返すよ！」"
+                        ],
+                        "en": [
+                            "begs you to spare his life.",
+                            "says, 'But I'm a GOOD guy, really!'",
+                            "says, 'Money? Sure, take it all back!'"
                         ]
                     }
                 }
@@ -302,26 +490,7 @@
         },
         {
             "id_list": [
-                200 /*『トラのホッブス』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「人間は何のためにいるのかな？虎の餌でーす！」",
-                            "「うまそう！冒険者サンドイッチ！」",
-                            "「カルヴィンを殺しちゃったから、次は君だ！」",
-                            "「君の短い人生を酷くて惨めなものにしてあげよう！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                140, /*Lagduf, the Snaga*/
+                140 /*Lagduf, the Snaga*/,
                 186 /*Grishnakh, the Hill Orc*/
             ],
             "message": [
@@ -336,6 +505,37 @@
                             "「良き指導者！偉大なるウグルクよ、再び我らを導き給わんことを」",
                             "は「弱っちくて可愛いお馬鹿ちゃん」と、あなたを嘲っている。",
                             "「おう、ちびっ子、休暇は楽しんでいるか？」"
+                        ],
+                        "en": [
+                            "says, 'Saruman is a fool, and a dirty treacherous fool.'",
+                            "says, 'I left a fool.'",
+                            "yells, 'Nazgul, Nazgul!'",
+                            "says, 'Fine leadership!　I hope the great Ugluk will lead us out again.'",
+                            "hisses, 'My dear tender little fools.'",
+                            "says, 'Well, my little ones!　Enjoying your nice rest?'",
+                            "snarls, 'Have you got it -- either of you?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は叫んだ。「おい！オークにも権利があるんだぞ！」",
+                            "「おまえはオークに対して偏見を持ってるだけなんじゃないか？」",
+                            "「助けてくれ！『リンギル』をやるから！ホントだ！」",
+                            "「今度はもっとウルクをたくさん連れてくるからな！」",
+                            "「醜いからって憎まないでくれ！」",
+                            "はシクシク泣いてひれ伏した。"
+                        ],
+                        "en": [
+                            "screams, 'Hey, orcs have rights too!'",
+                            "says, 'You're just prejudiced against orc-kind, aren't you?'",
+                            "begs, 'Spare me and I'll get you Ringil! Really!'",
+                            "says, 'Next time, I'm bringing more Uruks with me!'",
+                            "says, 'Don't hate me because I'm ugly!'",
+                            "whimpers and grovels."
                         ]
                     }
                 }
@@ -343,13 +543,92 @@
         },
         {
             "id_list": [
-                215, /*Golfimbul, the Hill Orc Chief*/
-                260, /*Ufthak of Cirith Ungol*/
-                314, /*Shagrat, the Orc Captain*/
-                315, /*Gorbag, the Orc Captain*/
-                330, /*Bolg, Son of Azog*/
-                350, /*Ugluk, the Uruk*/
-                356, /*Lugdush, the Uruk*/
+                180 /*Orfax, Son of Boldor*/,
+                237 /*Boldor, King of the Yeeks*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はあなたを変態呼ばわりしてわめいている。",
+                            "はひわいな言葉をまくしたてた。",
+                            "「イーク！イーク！イーク！」",
+                            "「イークもバカにできないってことを教えてやろう！」'",
+                            "はダーティーハリーの真似をして「命を賭けてみるか、チンピラ野郎」と言っている。"
+                        ],
+                        "en": [
+                            "wonders aloud about your sexual orientation.",
+                            "spouts torrents of obscenities.",
+                            "shouts, 'YEEK! YEEK! YEEK!'",
+                            "says, 'I'll teach you to respect Yeeks!",
+                            "says, 'Feel lucky, punk?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はベソをかいて「こんなつもりじゃなかったんだ...」と言った。",
+                            "はシクシク泣いてうなった。"
+                        ],
+                        "en": [
+                            "sobs, 'I didn't MEAN it...'",
+                            "whimpers and moans."
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                200 /*Hobbes the Tiger*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「人間は何のためにいるのかな？虎の餌でーす！」",
+                            "「うまそう！冒険者サンドイッチ！」",
+                            "「カルヴィンを殺しちゃったから、次は君だ！」",
+                            "「君の短い人生を酷くて惨めなものにしてあげよう！」"
+                        ],
+                        "en": [
+                            "says, 'Why were people put here? TIGER FOOD!'",
+                            "says, 'Yum! Adventurer sandwiches!'",
+                            "says, 'I killed Calvin, now I'll kill YOU!'",
+                            "says, 'I'll make your short life nasty and brutish!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は叫んだ。「わー！僕をマンガの中に帰してくれ！」"
+                        ],
+                        "en": [
+                            "yells, 'Ow! Get me back to the comics!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                215 /*Golfimbul, the Hill Orc Chief*/,
+                260 /*Ufthak of Cirith Ungol*/,
+                314 /*Shagrat, the Orc Captain*/,
+                315 /*Gorbag, the Orc Captain*/,
+                330 /*Bolg, Son of Azog*/,
+                350 /*Ugluk, the Uruk*/,
+                356 /*Lugdush, the Uruk*/,
                 373 /*Azog, King of the Uruk-Hai*/
             ],
             "message": [
@@ -374,9 +653,29 @@
                             "「貴様をゆっくり拷問してやる。」",
                             "はあなたのことを腐れカス野郎のケツの毛と呼んでいる。",
                             "「お前の女を俺の横に侍らせて使ってやろう！」",
-                            "says, 'You're not so tough, buttmunch!'",
                             "「お前はそんなにタフじゃないぞ、間抜けめが！」",
                             "「へへ、へへ。人を殺すのは楽しいなあ。」"
+                        ],
+                        "en": [
+                            "fingers his blade and grins evilly.",
+                            "snickers, 'Now, I strike a blow for *our* side!'",
+                            "says, 'Orcs don't get no respect... I'm gonna change that!'",
+                            "calls your mother nasty names.",
+                            "says, 'I'll bet your innards would taste real sweet...'",
+                            "belches and spits.",
+                            "scratches his armpits.",
+                            "says, 'I love the smell of fresh blood.'",
+                            "says, 'Yeeha! Another idiot to slaughter!'",
+                            "hawks a loogie in your direction.",
+                            "farts thunderously.",
+                            "wonders aloud how many experience points you're worth.",
+                            "says, 'I love being psychotic!'",
+                            "says, 'My brain's on fire with the feeling to kill!'",
+                            "says, 'I shall torture you slowly.'",
+                            "calls you a scum-sucking pig-dog.",
+                            "says, 'I shall have my way with your women!'",
+                            "says, 'You're not so tough, buttmunch!'",
+                            "says, 'Heh-heh, heh-heh, killing people is cool.'"
                         ]
                     }
                 }
@@ -399,6 +698,41 @@
                             "「貴様には代償を払ってもらう…その命でな！」",
                             "はニヤリと笑っている。",
                             "「貴様の頭の中をぐちゃぐちゃに回してやる！」"
+                        ],
+                        "en": [
+                            "says, 'Get away! This spot is mine!'",
+                            "says, 'I will soon close your eyes in eternal sleep.'",
+                            "says, 'I'll mess up all your stuff!'",
+                            "says, 'Give me the Rheingold, or die!'",
+                            "cries, 'You must pay me... with your life!'",
+                            "grins.",
+                            "says, 'Maybe I will just hack your head off.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はすすり泣いた。",
+                            "は哀れっぽく泣いた。",
+                            "「オヘ！オヘ！アウ！アウ！」",
+                            "は「俺を放せ！」と抗った。",
+                            "「アウ！アウ！アウ！」",
+                            "「お前には良くしてやったのに、その報いがこの有様か？」",
+                            "はうめいた。「恩知らずめ！」",
+                            "「帰れ！今すぐに！」"
+                        ],
+                        "en": [
+                            "sobs.",
+                            "sobs and whines.",
+                            "screams, 'Ohe! Ohe! Au! Au!'",
+                            "pleads, 'Let me go!'",
+                            "wails, 'Au! Au! Au!'",
+                            "says, 'I was so good to you, and this is my reward?'",
+                            "moans, 'Such ingratitude!'",
+                            "says, 'Go now, on your way!'"
                         ]
                     }
                 }
@@ -424,6 +758,134 @@
                             "「私は偽誓者を罰しているにすぎない。」",
                             "「今ここで指輪を渡すのだ！」",
                             " 「ホイホ！ホイホ！ホイホ！」"
+                        ],
+                        "en": [
+                            "says, 'Did you hear what the ravens said? Revenge, that is what they cry!'",
+                            "shouts, 'Hoiho! Hoiho! To arms! To arms!'",
+                            "grumbles, 'I hate the happy, and I am never glad.'",
+                            "cries, 'Keep away from the Ring!'",
+                            "boasts, 'My spear will certainly cut down the wrongful one.'",
+                            "cries, 'There! There shall my spear strike!'",
+                            "grins, 'You will die soon, handsome hero!'",
+                            "states, 'I am but avenging perjury.'",
+                            "shouts, 'Give the Ring here!'",
+                            "shouts, 'Hoiho! Hoiho-hoho!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「者共、立ち上がるのだ！武器を取れ！強い武器を！」",
+                            "は叫んだ。「これはまずい！まずいぞ！」",
+                            "は泣きわめいた。「災難だ！災難だ！」"
+                        ],
+                        "en": [
+                            "shouts, 'Vassals, rouse yourselves! Take your weapons, good strong weapons!'",
+                            "shouts, 'There is danger! Danger!'",
+                            "cries, 'Woe! Woe!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                393 /*It*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「うんにゃ、うんにゃ、ちみはミーを見つけれないね！」",
+                            "「かかってこい！」",
+                            "が魔法で強力なアンデッドを召喚した！",
+                            "は邪悪に笑っている。",
+                            "はサイバーデーモンを召喚した！",
+                            "は魔法で特別な強敵を召喚した！",
+                            "が自分の傷に集中した。",
+                            "が自分の体に念を送った。それの動きが速くなった。",
+                            "がテレポートした。"
+                        ],
+                        "en": [
+                            "says, 'Nyah, nyah, betcha can't find me!'",
+                            "says, 'Come get some!'",
+                            "magically summons mighty undead opponents!",
+                            "chuckles evilly.",
+                            "magically summons Cyberdemons!",
+                            "summons special opponents!",
+                            "concentrates on its wounds.",
+                            "concentrates on its body. It starts moving faster.",
+                            "teleports away."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「それってひどくない？」"
+                        ],
+                        "en": [
+                            "says, 'It's appalling.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はうなった。「いつか戻ってくるぞ！」",
+                            "「昔はそれほど悪くなかったんだよ！」",
+                            "はテレポートした。"
+                        ],
+                        "en": [
+                            "howls, 'I'll be back!'",
+                            "whimpers, 'They said this invisibility thing was better than it is!'",
+                            "teleports away."
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                409 /*Kharis the Powerslave*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「私の地獄の門を開くがよい。墓から甦ってお前を討ってやろう。」",
+                            "は呪いをかけている。"
+                        ],
+                        "en": [
+                            "says, 'Open the gates of my hell, I will strike from the grave!'",
+                            "curses you."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は叫んだ。「ノオオオオオオッ！」",
+                            "「死にたくない！なぜ神である私が死なねばならぬのか！」",
+                            "はあなたを呪った。"
+                        ],
+                        "en": [
+                            "howls, 'Nnnnooo!'",
+                            "says, 'I don't want to die, I'm a god, why can't I live on?'",
+                            "curses you."
                         ]
                     }
                 }
@@ -454,30 +916,55 @@
                             "「わが怒りを思い知れ、役立たずのごろつきめ！」",
                             "「ついに見つけたぞ！愚かな泥棒め！」",
                             "「怖くないというのか？！恐れた方が身の為だぞ！」"
+                        ],
+                        "en": [
+                            "says, 'I'll mess up all your stuff!'",
+                            "says, 'Give me the Rheingold, or die!'",
+                            "states, 'As I have renounced love, all who live shall soon renounce it!'",
+                            "laughs insanely.",
+                            "asks, 'Did you hear it? The nibelung hordes are rising from the depths!'",
+                            "laughs, 'Ha ha ha ha! Beware!'",
+                            "says, 'Beware, fool! Beware!'",
+                            "says, 'Envy led you here, pitiful rogue!'",
+                            "boasts, 'I dauntlessly defy everyone, everyone!'",
+                            "yells, 'Tremble, on your knees before the master of the Ring.'",
+                            "yells, 'Tremble with terror, abject throng!'",
+                            "says, 'I am watching you everywhere, expect me where you do not perceive me!'",
+                            "says, 'Feel my wrath, idle rascal!'",
+                            "says, 'I have discovered you, you stupid thief!'",
+                            "says, 'Are you still not afraid? You should be!'"
                         ]
                     }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                393 /*It*/
-            ],
-            "message": [
+                },
                 {
-                    "action": "SPEAK_ALL",
+                    "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
                         "ja": [
-                            "「うんにゃ、うんにゃ、ちみはミーを見つけれないね！」",
-                            "「かかってこい！」",
-                            "が魔法で強力なアンデッドを召喚した！",
-                            "は邪悪に笑っている。",
-                            "はサイバーデーモンを召喚した！",
-                            "は魔法で特別な強敵を召喚した！",
-                            "が自分の傷に集中した。",
-                            "が自分の体に念を送った。それの動きが速くなった。",
-                            "がテレポートした。"
+                            "「助けて！人殺し！人殺し！」",
+                            "「ああっ！壊れた！バラバラだ！」",
+                            "は「さもしいペテン、汚らわしい欺瞞だ！」とうめいた。",
+                            "は「代価は払っただろう、私を放せ！」と抗った。",
+                            "はすすり泣いた。「恥ずべき屈辱だ！」",
+                            "は叫んだ。「卑劣な盗賊野郎！強盗め！やくざ者！」",
+                            "ぶつぶつと愚痴った。「この非道なふるまいを後悔するぞ、嫌われ者が！」",
+                            "「この悪徳には必ず復讐してやる！」",
+                            "「今は笑っているがいい、だが貴様は私の呪いからは逃れられん！」",
+                            "「おお！おお！災厄が私に！」",
+                            "「なぜ私を嘲笑う？」とうめいた。"
+                        ],
+                        "en": [
+                            "screams, 'Help! Murder! Murder!'",
+                            "screams, 'Aaah! Crushed! Shattered!'",
+                            "moans, 'Base trickery, foul deceit!'",
+                            "pleads, 'I have paid, now let me depart!'",
+                            "cries, 'O shameful humiliation!'",
+                            "shouts, 'Rascally rogue! Robber! Ruffian!'",
+                            "grumbles, 'You will regret this outrage, you wretch!'",
+                            "moans, 'Terrible vengeance I vow for this wrong!'",
+                            "says, 'Smile now, but you can never escape my curse!'",
+                            "wails, 'Alas! Alas! Woe is me!'",
+                            "moans, 'Do you mock me?'"
                         ]
                     }
                 }
@@ -485,16 +972,18 @@
         },
         {
             "id_list": [
-                409 /*Kharis the Powerslave*/
+                431 /*Grendel*/
             ],
             "message": [
                 {
-                    "action": "SPEAK_ALL",
+                    "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
                         "ja": [
-                            "「私の地獄の門を開くがよい。墓から甦ってお前を討ってやろう。」",
-                            "は呪いをかけている。"
+                            "はすすり泣いた。「ママ、助けて！」"
+                        ],
+                        "en": [
+                            "whines, 'Mommy, save me!'"
                         ]
                     }
                 }
@@ -502,7 +991,7 @@
         },
         {
             "id_list": [
-                441, /*Gachapin*/
+                441 /*Gachapin*/,
                 1061 /*Barney the Dinosaur*/
             ],
             "message": [
@@ -518,6 +1007,31 @@
                             "はカメラ目線だ。",
                             "はいやらしくニヤニヤ笑っている。",
                             "「一緒にあそぼうよ、僕のともだち！ヒドラ君たち！」"
+                        ],
+                        "en": [
+                            "says, 'Cooperation! That's the magic word!'",
+                            "mutters, 'I *hate* those Teletubbies...'",
+                            "says, 'Won't you be my friend?'",
+                            "says, 'Let's all sing a HAPPY SONG!'",
+                            "mugs for the camera.",
+                            "simpers disgustingly.",
+                            "chews up a 'Tinky Winky' doll."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「やめて！子供たちのことも考えて！」",
+                            "は叫んだ。「僕は TVの大スターなんだぞ！」",
+                            "はベソをかいた。「分かった！謝るよ！ほんとにほんとだよ！」"
+                        ],
+                        "en": [
+                            "begs, 'Don't! Think of the children!'",
+                            "screams, 'But I'm a big TV star!'",
+                            "sobs, 'All right! I apologize! I really really do!'"
                         ]
                     }
                 }
@@ -525,8 +1039,8 @@
         },
         {
             "id_list": [
-                493, /*Bert the Stone Troll*/
-                494, /*Bill the Stone Troll*/
+                493 /*Bert the Stone Troll*/,
+                494 /*Bill the Stone Troll*/,
                 495 /*Tom the Stone Troll*/
             ],
             "message": [
@@ -539,6 +1053,28 @@
                             "は「羊のあぶり肉はもうやめだ！今日は冒険者のあぶり肉だ！」と喜んでいる。",
                             "「すこしはこりるがいいぞや」",
                             "「とんまはおかえしすらあ！」"
+                        ],
+                        "en": [
+                            "complains, 'What's a burrahobbit got to do with my pocket, anyways?'",
+                            "rejoices, 'No more roast mutton! Roast adventurer today!'",
+                            "says, 'That'll teach yer!'",
+                            "says, 'I won't take that from you!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「止めてくれ！今すぐに！」",
+                            "「おでは見たぞ、生意気なくそがきが！」",
+                            "「俺のダチがおめえを八裂きにするぜ！」"
+                        ],
+                        "en": [
+                            "says, 'Now, stop it!'",
+                            "yells, 'Ey, watch it, you cheeky sod!'",
+                            "screams, 'Me mates'll settle yer hash!'"
                         ]
                     }
                 }
@@ -558,22 +1094,11 @@
                             "「またつまらぬものを斬ってしまった．．．」",
                             "「．．．．．」",
                             "「斬鉄剣と拙者の腕をもってして斬れん物は無い。勝負！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1062 /*Groo the Wanderer*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「けんかだ！けんかだ！」"
+                        ],
+                        "en": [
+                            "says, 'Zantetsuken is sharp this night. '",
+                            "mumbles, 'Sign..Another trifling thing I've cut....'",
+                            "buttons his lips, '.....'"
                         ]
                     }
                 }
@@ -592,6 +1117,27 @@
                             "「待て、強欲者め！俺の分を残しておけ！」",
                             "「退け！無謀者めが！」",
                             "は「おう、詐欺師めが。おれをどうけなすか粗探ししようってか？」と愚痴った。"
+                        ],
+                        "en": [
+                            "grumbles, 'Stop, greedy one! Leave something for me!'",
+                            "shouts, 'Back, over-bold one!'",
+                            "whines, 'You swindler, do you seek to vilify me?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「俺の命などくれてやる。でも俺の金は駄目だ！」",
+                            "は愚痴った。「なんで襲い掛かってくるんだ？俺は正当な分け前を要求しただけだ！」",
+                            "は哀れに叫んだ。「なんで俺を怖がらせるんだ？」"
+                        ],
+                        "en": [
+                            "cries, 'Take my life, but not my gold!'",
+                            "complains, 'Why do you rush at me? I sought justice, my just payment!'",
+                            "whines, 'Why do you threaten me?'"
                         ]
                     }
                 }
@@ -610,6 +1156,11 @@
                             "「全部貴様のせいだ！」",
                             "「貴様が死ねば何もかも解決するんだ！」",
                             "「俺をドジと呼ぶな！」"
+                        ],
+                        "en": [
+                            "shouts, 'All your fault!'",
+                            "shouts, 'Only your death will set things right!'",
+                            "says, 'Don't call me clumsy!'"
                         ]
                     }
                 }
@@ -617,7 +1168,7 @@
         },
         {
             "id_list": [
-                573 /*Lord Borel of Hendrake*/
+                573 /*Lord Borel*/
             ],
             "message": [
                 {
@@ -628,6 +1179,43 @@
                             "「我こそはヘンドレイク流武術指南、ボレル公爵なり！」",
                             "「武器を取れ！臆病者め！」",
                             "「貴様はマントを投げるような卑怯者でないだろうな！」"
+                        ],
+                        "en": [
+                            "says, 'I am Borel, Duke of Hendrake, Master of Arms of the Ways of Hendrake.'",
+                            "says, 'You smile at your own cowardice? Stand and fight, bastard!'",
+                            "says, 'You aren't a caitiff that throws a cloak?!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "にあなたは言った 「これはオリンピックじゃないんだ」"
+                        ],
+                        "en": [
+                            "says, 'Oh, basely done! I had hoped for better of thee!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                595 /*Father Dagon*/,
+                596 /*Mother Hydra*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「やめて！私は絶滅危機生物に指定されてるんだぞ！」"
+                        ],
+                        "en": [
+                            "sobs, 'No! I'm an endangered aquatic species!'"
                         ]
                     }
                 }
@@ -647,6 +1235,92 @@
                             "「我が下僕があなたの相手をしてくれるでしょう。」",
                             "「失礼、私はつまらぬ争いをしている暇はないのでね。」",
                             "「ふむ、久しぶりに骨のある方とお手合わせできて光栄至極。」"
+                        ],
+                        "en": [
+                            "enjoys espresso coffee between battles.",
+                            "says, 'My slaves fight with you.'",
+                            "says, 'Excuse me, I have no time to continue a small fight.'",
+                            "says, 'It is a great pleasure to fight with such a worthy opponent as you.'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                606 /*Loge, Spirit of Fire*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は蒸気を吐いてあえいだ。"
+                        ],
+                        "en": [
+                            "pants and gasps."
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                615 /*Moire, Queen of Rebma*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は泣き叫んだ。「助けて！人殺し！人殺し！」"
+                        ],
+                        "en": [
+                            "wails, 'Help! Murder! Murder!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                616 /*Kavlax the Many-Headed*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "の首の1つが「これは貴様のミスだ！」と言って別の首を噛んだ。",
+                            "は今までのことを全部もう死んだ首のせいにしている。"
+                        ],
+                        "en": [
+                            "says, 'This is YOUR fault!' and bites itself.",
+                            "blames its problems on the head you've managed to kill."
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                628 /*Malekith the Accursed*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "来やがれこの野郎！何とかしてやろうじゃないか！",
+                            "は自分のみじめな人生を言い訳にした。"
+                        ],
+                        "en": [
+                            "says, 'C'mon! I'm sure we can work this out...'",
+                            "pleads for his miserable life."
                         ]
                     }
                 }
@@ -664,6 +1338,22 @@
                         "ja": [
                             "「コート架けにしてやる。」",
                             "「四界の砦の支配者にはむかうつもりか？」"
+                        ],
+                        "en": [
+                            "says, 'I will turn you into a coatrack.'",
+                            "says, 'I'm a master of the Keep of the Four Worlds!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "シューッと音を立てた。「我らは死なず、我らは繁栄するのだ！」"
+                        ],
+                        "en": [
+                            "hisses, 'We don't die, we multiply!'"
                         ]
                     }
                 }
@@ -681,6 +1371,10 @@
                         "ja": [
                             "「秩序は滅びるのだ！」",
                             "「混沌の力に屈服するのだ！」"
+                        ],
+                        "en": [
+                            "says, 'Order will crumble.'",
+                            "says, 'Obey the power of chaos!'"
                         ]
                     }
                 }
@@ -688,9 +1382,9 @@
         },
         {
             "id_list": [
-                654, /*Judge Fire*/
-                656, /*Judge Mortis*/
-                674, /*Judge Fear*/
+                654 /*Judge Fire*/,
+                656 /*Judge Mortis*/,
+                674 /*Judge Fear*/,
                 686 /*Judge Death*/
             ],
             "message": [
@@ -699,10 +1393,112 @@
                     "chance": 8,
                     "message": {
                         "ja": [
+                            "「このダンジョンは有罪である。」",
+                            "「罪状は生命。」",
+                            "「判決は死刑！」",
+                            "「罪状は生命。判決は死刑。」"
+                        ],
+                        "en": [
                             "hisses, 'Thisssss dungeon issss guilty.'",
                             "hisses, 'Your crime isssss life.'",
                             "hisses, 'The sssentencce isss death!'",
                             "hisses, 'Your crime issss life. The sssentencce isss death.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「このまま勝てると思っているのか？そんなはずがなかろう……」",
+                            "「おい、弁護士達を呼んだからな！」"
+                        ],
+                        "en": [
+                            "says, 'You'll never get away with this...'",
+                            "says, 'Hey! I've got LAWYERS!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                655 /*Ubbo-Sathla, the Unbegotten Source*/,
+                695 /*Zoth-Ommog*/,
+                706 /*Yibb-Tstll the Patient One*/,
+                734 /*Eihort, the Thing in the Labyrinth*/,
+                735 /*The King in Yellow*/,
+                757 /*Hastur the Unspeakable*/,
+                760 /*Nyogtha, the Thing that Should not Be*/,
+                761 /*Ahtu, Avatar of Nyarlathotep*/,
+                788 /*Glaaki*/,
+                797 /*Rhan-Tegoth*/,
+                806 /*Tsathoggua, the Sleeper of N'kai*/,
+                810 /*Y'golonac*/,
+                826 /*Cyaegha*/,
+                833 /*Abhoth, Source of Uncleanness*/,
+                841 /*Shuma-Gorath*/,
+                845 /*Yog-Sothoth, the All-in-One*/,
+                848 /*Shub-Niggurath, Black Goat of the Woods*/,
+                849 /*Nodens, Lord of the Great Abyss*/,
+                851 /*Nyarlathotep, the Crawling Chaos*/,
+                857 /*Great Cthulhu*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「ウジュウジュウジュ」",
+                            "は気持悪い音を発している。",
+                            "は叫んで死者を甦らせようとしている。",
+                            "は不潔にてかった粘液をダンジョン中に垂れ流している。",
+                            "は頭がぼんやりするような悪臭を放っている。",
+                            "は「テキリ=リ、テキリ=リ」と吠えている。",
+                            "は背筋の凍るような音を立てて這いずっている。",
+                            "は吐き気のするような渦巻く噴煙を放っている。",
+                            "の気持ち悪い触腕が蠕いている。",
+                            "があなたの精神を名状しがたい宇宙的恐怖に陥れた。"
+                        ],
+                        "en": [
+                            "slurps and gibbers disgustingly.",
+                            "shrieks fit to wake the dead.",
+                            "oozes nasty, glistening slime all over the dungeon.",
+                            "farts thunderously.",
+                            "lets off a mind-numbing stench.",
+                            "howls, 'Tekeli-li!  Tekeli-li!'",
+                            "makes a chilling slithering sound.",
+                            "howls, 'The OTHER GODS will feast on your brain!'",
+                            "hisses, 'I'll feed you to the Hounds of Tindalos...'",
+                            "hisses, 'Randolph Carter got off easy; you won't!'",
+                            "seethes and fumes sickeningly.",
+                            "hisses, 'I'll send you beyond Known Space to Azathoth!'",
+                            "waves nasty-looking tentacles about.",
+                            "picks its teeth with the bones of former players.",
+                            "opens your mind to a vista of nameless cosmic horror!",
+                            "opens your mind to a vista of endless 'Three's Company' reruns!",
+                            "snorts and slobbers with glee."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「私が悪いわけではない。生まれながらにしてこうだったのだ。」",
+                            "は弱々しくわけのわからないことを言った。",
+                            "は大量の傷口から緑の血を流している。",
+                            "は恐怖でまくしたてた。"
+                        ],
+                        "en": [
+                            "sobs, 'I'm not bad, I was just born like this!'",
+                            "gibbers weakly.",
+                            "mumbles, 'kill -9 adventurer, kill -9 adventurer', and you say 'No such process'",
+                            "oozes greenish blood from many wounds.",
+                            "burbles with terror."
                         ]
                     }
                 }
@@ -724,6 +1520,28 @@
                             "はあなたに葬式セットを売りつけようとしている。",
                             "「悪いけど死んでもらうぜ。」",
                             "「チキンを取ってきてやろうか？それともアルミで包んだ白ネズミか？」"
+                        ],
+                        "en": [
+                            "says, 'I am Rinaldo I, Kashfan King and B.S. in Business Management, UC Berkeley.'",
+                            "says, 'Freezer? Glad you asked! A box to store your body!'",
+                            "says, 'If you buy a Grand-D machine, I'll throw Werewindle into the bargain.'",
+                            "has an eye to stick you with a burial set.",
+                            "says, 'Sorry but I kill you.'",
+                            "says, 'Can I get you a chicken? Maybe some white mice and aluminum foil?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は泣き叫んだ。「顔は止めてくれ！顔は！」",
+                            "「ちぃっ！通販で買ったサイバーデーモンどこに置いといたっけな？」"
+                        ],
+                        "en": [
+                            "screams, 'Not the face! Not the face!'",
+                            "says, 'Yikes! Where'd I put my mail-order Cyberdemon?'"
                         ]
                     }
                 }
@@ -743,6 +1561,24 @@
                             "「影の力は無限なのだ！」",
                             "「コルウィニアの鍵を手に入れた俺に敵はないのだ！」",
                             "「魂？それが何の役にたつというんだ。」"
+                        ],
+                        "en": [
+                            "says, 'Be made to realize my darkness hold.'",
+                            "says, 'Power of shadow is infinite.'",
+                            "says, 'With the Key of Kolwynia, I am invincible!'",
+                            "says, 'Soul? What is it of use to?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「覚えておけ！今度会った時は貴様が堆屍穴に行く番だ！」"
+                        ],
+                        "en": [
+                            "says, 'I'll get even! Next time I see you, Death is yours!'"
                         ]
                     }
                 }
@@ -760,6 +1596,10 @@
                         "ja": [
                             "があなたに向かって恐ろしげに突進してくる。",
                             "「テキリ・リ！ テキリ・リ！」"
+                        ],
+                        "en": [
+                            "says, 'barrels towards you horrifyingly.'",
+                            "wails, 'Tekeli-li!  Tekeli-li!'"
                         ]
                     }
                 }
@@ -783,6 +1623,34 @@
                             "「今俺は年老いて、強いのだ。覚えておけ、おれは何よりも強いのだぞ。」",
                             "「俺のうろこは十重の盾、どんな剣も通しはしない。」",
                             "「俺の歯は剣、爪は槍、吐く息は、すなわち死だ！」"
+                        ],
+                        "en": [
+                            "speaks, 'I smell you and I feel your air. I hear your breath. Come along!'",
+                            "says, 'If you get off alive, you will be lucky.'",
+                            "grimaces.",
+                            "laughs with a devastating sound which shakes the ground.",
+                            "asks, 'Where are those who dare approach me?'",
+                            "gloats, 'I am old and strong, strong, strong.'",
+                            "boasts, 'My armour is like tenfold shields, no blade can pierce me.'",
+                            "boasts, 'My teeth are swords, my claws are spears, my breath is death.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "信じられない思いでうめき声を上げた。",
+                            "は激怒して吠え猛けた。",
+                            "「黒い矢？やめてくれ～～！」",
+                            "「そんなバカな！」"
+                        ],
+                        "en": [
+                            "groans in disbelief.",
+                            "roars furiously.",
+                            "howls, 'Black Arrow? NOOOO!'",
+                            "howls, 'This CAN'T be happening!'"
                         ]
                     }
                 }
@@ -803,6 +1671,27 @@
                             "「俺の牙はおしゃべりの為の物じゃない。すぐにそれを味あわせてやる。」",
                             "「俺の喉は貴様を丸飲みできるぞ。」",
                             "「来い！自惚れ屋の若造！」"
+                        ],
+                        "en": [
+                            "says, 'You will make a fine meal.'",
+                            "says, 'I wanted a drink, now I have also found food.'",
+                            "says, 'My fangs are not for chattering, soon you will feel them.'",
+                            "says, 'My throat is well made to gulp you down.'",
+                            "growls, 'Come here, young braggart.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は泣き叫んだ。「俺を傷つけた奴は誰だ？名を名乗れ！」",
+                            "は泣き言を言った。「小童の蛮勇を唆し、殺しの業を冒させたのは誰だ?」"
+                        ],
+                        "en": [
+                            "wails, 'Who are you that have wounded me so? Speak me your name!'",
+                            "complains, 'Who kindled your childish courage to this deadly deed?'"
                         ]
                     }
                 }
@@ -810,7 +1699,7 @@
         },
         {
             "id_list": [
-                715, /*Glaurung, Father of the Dragons*/
+                715 /*Glaurung, Father of the Dragons*/,
                 766 /*Ancalagon the Black*/
             ],
             "message": [
@@ -821,6 +1710,24 @@
                         "ja": [
                             "「汝、破滅を逃るること能わず。」",
                             "「愚かなる定命の者よ。余の炎で灰燼に帰すがよい。」"
+                        ],
+                        "en": [
+                            "says, 'You cannot avoid the ballyhack.'",
+                            "says, 'A mere mortal, Be burned to the ground by my fire.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は大量の傷口から黒い血を吹き出してのたうち回った。",
+                            "「覚えておれ！」"
+                        ],
+                        "en": [
+                            "writhes as he spouts black blood from many wounds.",
+                            "says, 'I shall be avenged!'"
                         ]
                     }
                 }
@@ -828,7 +1735,7 @@
         },
         {
             "id_list": [
-                732 /*リンゴ嫌い『ブル・ゲイツ』*/
+                732 /*Bull Gates*/
             ],
             "message": [
                 {
@@ -852,6 +1759,52 @@
                             "は悪魔のように笑った。",
                             "はリンゴの果樹園すら買い占めようとしている。",
                             "「カスタマイズくらいユーザの自由だろう？　当然どんなバグが出ても私は責任を取らんがね。例えそれがデフォルトのままであったとしても」"
+                        ],
+                        "en": [
+                            "says, 'Did I once say '640K should be enough for ANYBODY!'?'",
+                            "says, 'Unlike that passionate person, I'm humble, apologize. 640K wasn't enough for a Millennium party. Even if you have 640M of user memory.'",
+                            "says, 'So now is the time to say it again, '640G should be enough for ANYBODY!''",
+                            "says, 'Buy Windows 10; the system will be updated automatically without saving any datum'",
+                            "says, 'Linux?  I've only heard that it's the worst...'",
+                            "says, 'I don't know who is the best manager. But the worst owner is definitely that apple store.'",
+                            "says, 'Are you still using Fuckintosh?  It's very pathetic.'",
+                            "says, 'Resistance is futile--you will be assimilated.'",
+                            "says, 'Pro version is the solution for ALL your needs.'",
+                            "hacks out some code and calls it a Feature Update.",
+                            "says, 'We've had a monopoly, but iOS's stronghold hasn't collapsed'",
+                            "wonders if he should buy a small country.",
+                            "says, 'Where will we let you go today?  HELL!'",
+                            "cackles diabolically.",
+                            "is even buying up an apple orchard.",
+                            "says, 'Isn't it as user-free as customization? Of course, I wouldn't take responsibility for any bugs. Even if it stays the default.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「Ｍ＄帝国は永遠に不滅だ！」"
+                        ],
+                        "en": [
+                            "says, 'Empire Micro$oft is eternal!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はベソをかいている。「分かった。Linux はクソじゃない。助けてくれるよな？」",
+                            "は「誇大妄想はそんなに悪いことか？」と叫んだ。",
+                            "は MS-DOS について謝罪している。"
+                        ],
+                        "en": [
+                            "sobs, 'OK, Linux doesn't suck. Let me live?'",
+                            "screams, 'Is megalomania THAT bad?'",
+                            "apologizes for MS-DOS."
                         ]
                     }
                 }
@@ -869,12 +1822,37 @@
                         "ja": [
                             "「ホーホーホー！死ぬのじゃ！」",
                             "「君の靴下にはクソを入れてあげよう！」",
-                            "says, 'On Smasher, on Whoop-Ass, now dash away all!'",
                             "は残忍そうに笑った。",
                             "「君は悪い子リストに載ってるぞ！」",
                             "「君にはプレゼント絶対無し！」",
                             "「わしの人喰いトナカイをけしかけてやろう！」",
                             "「わしはクリスマスが大嫌いじゃ！嫌い過ぎてイカれちまったぞ！」"
+                        ],
+                        "en": [
+                            "says, 'Ho ho ho! You're gonna die!'",
+                            "says, 'You're gettin' COAL in your stocking!'",
+                            "says, 'On Smasher, on Whoop-Ass, now dash away all!'",
+                            "chortles sadistically.",
+                            "says, 'You're on the Naughty List!'",
+                            "says, 'No presents for you, ever!'",
+                            "says, 'I'll sic my man-eating reindeer on you!'",
+                            "says, 'I hate Christmas so much that I've gone psychotic!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「お前は子供たちを失望させることになるんじゃぞ！いいのか？」",
+                            "「いないんじゃよ、ヴァージニアや。サンタなんて...もう...」",
+                            "はいいものを餌にあなたを買収しようとしている。"
+                        ],
+                        "en": [
+                            "sobs, 'Think of the children you'll disappoint!'",
+                            "sobs, 'No, Virginia, there isn't... not any more...'",
+                            "attempts to buy you off with offers of goodies."
                         ]
                     }
                 }
@@ -882,8 +1860,27 @@
         },
         {
             "id_list": [
-                764, /*Uriel, Angel of Fire*/
-                765, /*Azriel, Angel of Death*/
+                743 /*The Phoenix*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「私は必ず蘇る！」"
+                        ],
+                        "en": [
+                            "defiantly caws, 'I shall rise again!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                764 /*Uriel, Angel of Fire*/,
+                765 /*Azriel, Angel of Death*/,
                 769 /*Raphael, the Messenger*/
             ],
             "message": [
@@ -899,6 +1896,85 @@
                             "「主の御意志を伺うまでもない、我が汝に神罰を与えん！」",
                             "「永遠の呪いを気に入ってくれるといいがな。」",
                             "「たった今悔い改めようとも、それは汝にとって遅すぎた」"
+                        ],
+                        "en": [
+                            "says, 'Repent, evildoer!'",
+                            "says, 'My righteousness shall cleanse you!'",
+                            "says, 'Don't EVER steal from the collection plate!'",
+                            "says, 'God may love you, but *I* don't!'",
+                            "says, 'I shall smite thee with extreme prejudice!'",
+                            "says, 'Hope you like eternal damnation!'",
+                            "says, 'Verily, it is too late for thee.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「主よ、この罪深き者に天罰をお与え下さい！」"
+                        ],
+                        "en": [
+                            "says, 'My God, Please visit a punishment upon this unrighteous sinner!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「主よ助け給え！もう駄目です！」",
+                            "「主が私に命じられたことなのだ。私は従わねばならぬ。」",
+                            "「主よ、主よ、何故に私をお見捨てになられたのか？」"
+                        ],
+                        "en": [
+                            "screams, 'Help! I am undone!'",
+                            "says, 'The Most High hath ordained this; I must follow.'",
+                            "screams, 'My God, my God, why hast thou forsaken me?'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                766 /*Ancalagon the Black*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は、多数の傷口から酸の血をまき散らしながらもがいている",
+                            "「我が友人のパワー・ワイアームたちがお前を迎えに来るだろう！」"
+                        ],
+                        "en": [
+                            "writhes as he spouts acidic blood from many wounds.",
+                            "says, 'My friends the Wyrms of Power will get you!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                771 /*Saruman of Many Colours*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「待て！後ろを見てみろ！」",
+                            "「ヘビの舌！どこへ行った！この間抜けめ！」"
+                        ],
+                        "en": [
+                            "says, 'Wait! Look behind you!'",
+                            "howls, 'Wormtongue! Where are you, you bastard?'"
                         ]
                     }
                 }
@@ -916,6 +1992,38 @@
                         "ja": [
                             "「わしは神秘の火に仕えるもの、アノールの焔の使い手じゃ。きさまは渡ることはできぬ。」",
                             "「暗き火、ウデュンの焔はきさまの助けとはならぬ。常つ闇に戻るがよい！きさまは渡れぬぞ。」"
+                        ],
+                        "en": [
+                            "says, 'I am a Wielder of the Flame of Anor, you cannot pass.'",
+                            "says, 'The dark fire will not avail you, Flame of Udun.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「なんたることだ！お前さんは指輪物語を読んだことがないのか！？」",
+                            "「痛ッ！」"
+                        ],
+                        "en": [
+                            "screams, 'How have things come to this... again?!'",
+                            "yells, 'Ouch!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FRIEND",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「ボヤボヤせんでお前も手伝わんか！馬鹿もん！」",
+                            "「わしが火の魔法で敵を攻撃するから、お前さんも同時に攻撃しろ。」"
+                        ],
+                        "en": [
+                            "says, 'Don't space out. Cover me! Bogan!'",
+                            "says, 'I'll invoke fire magic. Attack concurrently with me!'"
                         ]
                     }
                 }
@@ -933,6 +2041,22 @@
                         "ja": [
                             "「俺の計画を邪魔させはしない！」",
                             "「アンバーを敵に回して勝てるとでも思っているのか？」"
+                        ],
+                        "en": [
+                            "says, 'I don't endure your sabotaging my plan!'",
+                            "says, 'You dare to oppose Amber?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「アンバーの血の呪いの恐ろしさを知っているのか！」"
+                        ],
+                        "en": [
+                            "says, 'Do you know the terrors of Amberite blood curse?!'"
                         ]
                     }
                 }
@@ -940,7 +2064,59 @@
         },
         {
             "id_list": [
-                789, /*Bleys, Master of Manipulation*/
+                777 /*Bast, Goddess of Cats*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「また戻ってくるからな！このビチグソがぁ～～～っ！」",
+                            "は弱々しくうなった。"
+                        ],
+                        "en": [
+                            "spits, 'I'll be back, worse than ever!'",
+                            "snarls weakly."
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                780 /*Vlad Dracula, Prince of Darkness*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「フフフ、私はまた甦るだろう…人間の心に暗黒がある限り。ハハハハ！」"
+                        ],
+                        "en": [
+                            "says, 'Faugh, I'll be back...so long as human psyche has a blackness. Ho-ho.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は苦痛と恐怖で吠えた。"
+                        ],
+                        "en": [
+                            "howls with pain and fear."
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                789 /*Bleys, Master of Manipulation*/,
                 799 /*Caine, the Conspirator*/
             ],
             "message": [
@@ -952,6 +2128,11 @@
                             "「アンバーを敵に回して勝てるとでも思っているのか？」",
                             "「お前は誰に雇われた？エリックか？コーウィンか？」",
                             "「我々の争いに首を突っ込めば死は免れんぞ！」"
+                        ],
+                        "en": [
+                            "says, 'You dare to oppose Amber?'",
+                            "says, 'Who is Your malik? Eric? Corwin?'",
+                            "says, 'To barge into our blood feud is to die!'"
                         ]
                     }
                 }
@@ -970,6 +2151,20 @@
                             "「私を甘く見ないほうがいいわよ。」",
                             "「アンバーを敵に回して勝てると思っているの？」",
                             "は小悪魔的に微笑んだ。"
+                        ],
+                        "en": [
+                            "says, 'You should not think me easy to deal with.'",
+                            "says, 'You dare to oppose Amber?'",
+                            "smiles diabolic."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「アンバーの血の呪いの恐ろしさを知っているの？！」"
                         ]
                     }
                 }
@@ -988,6 +2183,11 @@
                             "は角笛を高らかに吹き鳴らしている。",
                             "「今日の獲物は手応えがあるぞ！」",
                             "「お前はいい剥製になりそうだ！」"
+                        ],
+                        "en": [
+                            "belows a horn in a loud voice.",
+                            "says, 'This Haul offers resistance!'",
+                            "says, 'You'll become a good mounting'"
                         ]
                     }
                 }
@@ -1004,6 +2204,9 @@
                     "message": {
                         "ja": [
                             "は無言で突進して来る。"
+                        ],
+                        "en": [
+                            "rushes toward you wordlessly."
                         ]
                     }
                 }
@@ -1021,6 +2224,10 @@
                         "ja": [
                             "「貴様もコーウィンと同じ目に遭わせてやろうか。」",
                             "「アンバーの王を敵に回した愚かさを呪うがいい。」"
+                        ],
+                        "en": [
+                            "says, 'I'm going to make you to have the same problem of Corwin.'",
+                            "says, 'Curse your daffiness that you make an enemy of a Lord of Amber.'"
                         ]
                     }
                 }
@@ -1028,17 +2235,18 @@
         },
         {
             "id_list": [
-                820 /*Corwin, Lord of Avalon*/
+                815 /*Unmaker*/
             ],
             "message": [
                 {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
                     "message": {
                         "ja": [
-                            "「グレイスワンダーの切れ味を教えてやろう。」",
-                            "はマントを投げた。",
-                            "「悪いがこんな下らん争いをしてる暇はないんだ。」"
+                            "は辺りにログルスの残り香を撒き散らした！"
+                        ],
+                        "en": [
+                            "sprinkled the remaining incense from Logrus!"
                         ]
                     }
                 }
@@ -1046,104 +2254,25 @@
         },
         {
             "id_list": [
-                824 /*Benedict, the Ideal Warrior*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「降伏しろ。この状況で私が勝つのは予測済みだ。」",
-                            "「その勇敢さには敬意を表する。しかし命は大事にすることだ。」",
-                            "「私と出会ったのは不運だったな。」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
+                817 /*Hela, Queen of the Dead*/,
+                834 /*Ymir the Ice Giant*/,
+                835 /*Loki the Trickster*/,
                 837 /*Surtur the Giant Fire Demon*/
             ],
             "message": [
                 {
-                    "action": "SPEAK_ALL",
+                    "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
                         "ja": [
-                            "「私を倒しても『運命のオーブ』は手に入らんぞ」",
-                            "「燃えろ！灰になるのだ！」",
-                            "「前に来たレベル１４のワルキューレの方が骨があったぞ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                655, /*Ubbo-Sathla, the Unbegotten Source*/
-                695, /*Zoth-Ommog*/
-                706, /*Yibb-Tstll the Patient One*/
-                734, /*Eihort, the Thing in the Labyrinth*/
-                735, /*The King in Yellow*/
-                757, /*Hastur the Unspeakable*/
-                760, /*Nyogtha, the Thing that Should not Be*/
-                761, /*Ahtu, Avatar of Nyarlathotep*/
-                788, /*Glaaki*/
-                797, /*Rhan-Tegoth*/
-                806, /*Tsathoggua, the Sleeper of N'kai*/
-                810, /*Y'golonac*/
-                826, /*Cyaegha*/
-                833, /*Abhoth, Source of Uncleanness*/
-                841, /*Shuma-Gorath*/
-                845, /*Yog-Sothoth, the All-in-One*/
-                848, /*Shub-Niggurath, Black Goat of the Woods*/
-                849, /*Nodens, Lord of the Great Abyss*/
-                851, /*Nyarlathotep, the Crawling Chaos*/
-                857 /*Great Cthulhu*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「ウジュウジュウジュ」",
-                            "は気持悪い音を発している。",
-                            "は叫んで死者を甦らせようとしている。",
-                            "は不潔にてかった粘液をダンジョン中に垂れ流している。",
-                            "は頭がぼんやりするような悪臭を放っている。",
-                            "は「テキリ=リ、テキリ=リ」と吠えている。",
-                            "は背筋の凍るような音を立てて這いずっている。",
-                            "は吐き気のするような渦巻く噴煙を放っている。",
-                            "の気持ち悪い触腕が蠕いている。",
-                            "があなたの精神を名状しがたい宇宙的恐怖に陥れた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                850, /*Carcharoth, the Jaws of Thirst*/
-                846, /*Fenris Wolf*/
-                840 /*Draugluin, Sire of All Werewolves*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はぞっとするような鳴き声で吠え立てた！",
-                            "「よし、またおもちゃが来やがったぞ！」",
-                            "「ゴクッ！チキンには飽きてたところだ！」",
-                            "は耳をつんざく声で吠えた。",
-                            "は迷宮中によだれをたらした。",
-                            "は壁に向かって片足を上げた。",
-                            "「行儀の悪い冒険者だ！お前の命はおあずけだ！」",
-                            "はうなって吠えた。"
+                            "「こんなことならずっとアスガルドにいるんだった！」",
+                            "は命と引き替えなら何でも渡すと言っている。",
+                            "「私は戻ってくるぞ！サイバーデーモンどもを引きつれてな！」"
+                        ],
+                        "en": [
+                            "shouts, 'Why didn't I just stay in Asgard?'",
+                            "offers you everything in exchange for life.",
+                            "yells, 'I'll be back, with a squad of Cyberdemons!'"
                         ]
                     }
                 }
@@ -1165,6 +2294,14 @@
                             "「お前は我が力に屈服し、奴隷でい続けるのだ。」",
                             "「止まれ！私はお前を倒すのに相応しい武器をもっているぞ！」",
                             "「お前の主の槍で刺し殺してやる！」"
+                        ],
+                        "en": [
+                            "states, 'The time has come.'",
+                            "bellows, 'Your master calls! Obey!'",
+                            "grunts, 'Beware!'",
+                            "states, 'You will fall into my power, you will remain my slave!'",
+                            "cries, 'Halt! I have the right weapon to fell you!'",
+                            "yells, 'I will cut you down with your master's spear!'"
                         ]
                     }
                 }
@@ -1172,11 +2309,90 @@
         },
         {
             "id_list": [
-                830, /*Cantoras, the Skeletal Lord*/
-                831, /*Mephistopheles, Lord of Hell*/
-                818, /*The Mouth of Sauron*/
-                804, /*Vecna, the Emperor Lich*/
-                844, /*Kaschei the Immortal*/
+                820 /*Corwin, Lord of Avalon*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「グレイスワンダーの切れ味を教えてやろう。」",
+                            "はマントを投げた。",
+                            "「悪いがこんな下らん争いをしてる暇はないんだ。」"
+                        ],
+                        "en": [
+                            "says, 'I teach you bite of Grayswandir.'",
+                            "throws his cloak.",
+                            "says, 'Sorry but I have no time to continue a small fight like this.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「ハッ！？私は誰？ここは何処？なぜ攻撃してくるんだ？」",
+                            "「オリンピックのように正々堂々といこう！」"
+                        ],
+                        "en": [
+                            "says, 'Who am I? Where is here? Why do you attack me?'",
+                            "says, 'Let's make it a clean game as Olympics'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                824 /*Benedict, the Ideal Warrior*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「降伏しろ。この状況で私が勝つのは予測済みだ。」",
+                            "「その勇敢さには敬意を表する。しかし命は大事にすることだ。」",
+                            "「私と出会ったのは不運だったな。」"
+                        ],
+                        "en": [
+                            "says, 'Back Down. This situation only results in my victory, I know.'",
+                            "says, 'I praise your bravery. But take good care of your life.'",
+                            "says, 'It's unlucky for you to see me.'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                825 /*The Witch-King of Angmar*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「おのれええええ！」"
+                        ],
+                        "en": [
+                            "wails, 'Nooooo!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                830 /*Cantoras, the Skeletal Lord*/,
+                831 /*Mephistopheles, Lord of Hell*/,
+                818 /*The Mouth of Sauron*/,
+                804 /*Vecna, the Emperor Lich*/,
+                844 /*Kaschei the Immortal*/,
                 856 /*Gothmog, the High Captain of Balrogs*/
             ],
             "message": [
@@ -1197,6 +2413,34 @@
                             "「しもべどもよ、この馬鹿者を始末しろ！」",
                             "「汝の家を整えよ、汝死す定めなれば。」",
                             "「私は神ではない...神なら慈悲を持っている！」"
+                        ],
+                        "en": [
+                            "brags, 'My power is beyond compare!'",
+                            "snorts, 'A mere mortal dares challenge my might? HA!'",
+                            "says, 'Not another one! I just finished chewing on the last!'",
+                            "wonders aloud how many XP you're worth.",
+                            "leafs through 'Evil Geniuses For Dummies.'",
+                            "mutters, 'Another damn loser to kill...'",
+                            "says, 'Hell shall claim your remains!'",
+                            "says, 'Another 12 skulls and I get that reward from the Boss!'",
+                            "yawns at your pathetic efforts to kill him.",
+                            "says, 'Minions, slaughter this fool!'",
+                            "says, 'Set thine house in order, for thou shalt die...'",
+                            "says, 'I'm no god... God has MERCY!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「そんなバカな！」",
+                            "「殺すなら殺せ！ボスが黙っちゃいないぞ！」"
+                        ],
+                        "en": [
+                            "screams, 'This CAN'T be happening!'",
+                            "shouts, 'Kill me if you want, the Boss will getcha!'"
                         ]
                     }
                 }
@@ -1204,7 +2448,81 @@
         },
         {
             "id_list": [
-                862, /*The Serpent of Chaos*/
+                837 /*Surtur the Giant Fire Demon*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「私を倒しても『運命のオーブ』は手に入らんぞ」",
+                            "「燃えろ！灰になるのだ！」",
+                            "「前に来たレベル１４のワルキューレの方が骨があったぞ！」"
+                        ],
+                        "en": [
+                            "says, 'You cannot get \"Orb of Destiny\" even if you bring me down into the dust.'",
+                            "says, 'Burn out! And turn to dust!'",
+                            "says, 'The level 14 valkyrie who came before was storonger than you!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                850 /*Carcharoth, the Jaws of Thirst*/,
+                846 /*Fenris Wolf*/,
+                840 /*Draugluin, Sire of All Werewolves*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はぞっとするような鳴き声で吠え立てた！",
+                            "「よし、またおもちゃが来やがったぞ！」",
+                            "「ゴクッ！チキンには飽きてたところだ！」",
+                            "は耳をつんざく声で吠えた。",
+                            "は迷宮中によだれをたらした。",
+                            "は壁に向かって片足を上げた。",
+                            "「行儀の悪い冒険者だ！お前の命はおあずけだ！」",
+                            "はうなって吠えた。"
+                        ],
+                        "en": [
+                            "barks and bellows frighteningly!",
+                            "says, 'Oh good, another chew toy!'",
+                            "says, 'Yummy! I was getting tired of chicken...'",
+                            "lets out an earsplitting howl.",
+                            "drools all over the dungeon.",
+                            "lifts his leg at the nearest wall.",
+                            "says, 'Bad adventurer! No more living for you!'",
+                            "snarls and howls."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "縮みあがってクンクン鳴いた。",
+                            "「もう郵便配達人を噛まないと約束する！」",
+                            "「おい！その丸めた新聞紙を振りかざすのはやめてくれ！」"
+                        ],
+                        "en": [
+                            "cringes and whimpers.",
+                            "says, 'Look, I promise I won't bite the mailman anymore!'",
+                            "says, 'Hey, put that rolled-up newspaper down!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                862 /*The Serpent of Chaos*/,
                 883 /*Zombified Serpent of Chaos*/
             ],
             "message": [
@@ -1226,6 +2544,32 @@
                             "「これほどまでに破滅的で哀れなお前の行動は英雄的でさえある！」",
                             "「お前ごとき定命の者が<力>同士の争いに首を突っ込む事なぞあってはならぬ！」",
                             "「お前は永遠に続く混沌と秩序の争いの道具にすぎぬ。」"
+                        ],
+                        "en": [
+                            "says, 'Foolish worm, you are DOOMED!'",
+                            "says, 'I'm the Big Bad Guy, and you're toast!'",
+                            "shouts, 'MOO HA HA HA! I am DEATH incarnate!'",
+                            "says, 'Prepare for your untimely demise!'",
+                            "opens up a can of Whoop-Ass (tm).",
+                            "picks its teeth with former adventurers' bones.",
+                            "says, 'Maybe I won't kill you... NOT!'",
+                            "yawns at your pathetic efforts to kill it.",
+                            "says, 'Another day, another bastard to slaughter...'",
+                            "says, 'I can't be bothered... minions, slaughter this fool!'",
+                            "says, 'Such a doomed, pathetic gesture as yours verges on the heroic!'",
+                            "says, 'Mere mortals such as you should not meddle the affair of the Powers!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「そんなバカな！」"
+                        ],
+                        "en": [
+                            "screams, 'This CAN'T be happening!'"
                         ]
                     }
                 }
@@ -1233,7 +2577,7 @@
         },
         {
             "id_list": [
-                873 /*Combat-Echizen, SEKKAKUDAKARA*/
+                873 /*Combat-Echizen*/
             ],
             "message": [
                 {
@@ -1245,6 +2589,40 @@
                             "「なんだこの階段は！」",
                             "「せっかくだから、俺はこの赤の扉を選ぶぜ！」",
                             "「今夜もまた、誰かが命を落とす．．．」"
+                        ],
+                        "en": [
+                            "says, 'Somethig comes from above! Be careful!'",
+                            "says, 'What is this stair?'",
+                            "says, 'Because it's time, I choose this red door!'",
+                            "chunters, 'Tonight, someone dies again...'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「おーのー。」"
+                        ],
+                        "en": [
+                            "says shiftlessly, 'Oh. No.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「くっそ～！」",
+                            "「このやろー！」",
+                            "「やりやがったな！」"
+                        ],
+                        "en": [
+                            "says shiftlessly, 'Shit...!'",
+                            "says shiftlessly, 'Yegg...!'",
+                            "says shiftlessly, 'yariyagattana!'"
                         ]
                     }
                 }
@@ -1273,6 +2651,45 @@
                             "「貴様は犬死するためにここへ来たのだ！」",
                             "「ちょいとでもおれにかなうとでも思ったか！マヌケがァ～～～ッ！」",
                             "「何人の命を吸い取ったかだと？おまえは今まで食ったパンの枚数をおぼえているのか？」"
+                        ],
+                        "en": [
+                            "shouts, 'You cannot escape!'",
+                            "says, 'You are checkmated!'",
+                            "says, 'Huh! Come on!'",
+                            "shouts, 'Weak! Weak!'",
+                            "says, 'I announce beforehand that I kill you by sucking your blood!'",
+                            "shouts, 'bootless bootless bootless effort! Sing small!'",
+                            "shouts, 'bootless bootless bootless bootless bootless bootless bootless effort'",
+                            "says, 'Your slow sleepy speed never kill me!'",
+                            "says, 'A monkey cannot be a human! You are a monkey for this Dio!!'",
+                            "shouts, 'WRYYYYYYYYY!!!!!!'",
+                            "says, 'You came here to die in vain!'",
+                            "says, 'You think that you have a little possibilities that you defeat me? You are dull fish!'",
+                            "says, 'How many people I killed? Do you remember the amount of bread you ate?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「ば，ばかなッ！このディオが．．．このディオがァァァァ～～～～！！」"
+                        ],
+                        "en": [
+                            "shouts, 'This CAN'T be happening! I am Dying....!!!!!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「馬鹿なッ！このディオが恐怖を感じているというのかッッ！」"
+                        ],
+                        "en": [
+                            "says, 'This CAN'T be happening! I feel horror?!'"
                         ]
                     }
                 }
@@ -1280,7 +2697,7 @@
         },
         {
             "id_list": [
-                880 /*Wong*/
+                880 /*Wong, Master of Time*/
             ],
             "message": [
                 {
@@ -1317,6 +2734,47 @@
                             "「これ以上邪魔はさせませんよ。」",
                             "「私の計画に君は少々邪魔なのですよ。死んでもらいましょう…。」",
                             "「全てが私の思い通り…ふっふっふっ…。」"
+                        ],
+                        "en": [
+                            "says, 'I knew that you come'",
+                            "says, 'Make your dream come true in the heaven'",
+                            "says, 'I am only man who actuate the time...'",
+                            "says, 'I can set forward the time and puch back the time as I like...'",
+                            "says, 'Time, move for only me!'",
+                            "says, 'What I boss is not the \"Human being\" but the \"Time\"...'",
+                            "says, 'A broken clock only have a detrimental effect on our doing.'",
+                            "says, 'I get here at any minute... And I get the world...'",
+                            "says, 'Nobody can stop the time, now...'",
+                            "says, '...For the future, I am the time...'",
+                            "says, 'I don't endure your sabotaging...'",
+                            "says, 'You are a little barrier of my plan. Die...'",
+                            "says, 'Everything is as I like... huh...'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「この私がぁ！」"
+                        ],
+                        "en": [
+                            "shouts, 'This CAN'T be happening!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「やりますねぇ。」",
+                            "「無駄ですよ…」"
+                        ],
+                        "en": [
+                            "says, 'You are no fool.'",
+                            "says, 'What you are doing is pointless.'"
                         ]
                     }
                 }
@@ -1324,7 +2782,7 @@
         },
         {
             "id_list": [
-                921 /*インターネット・エクスプローダー*/
+                921 /*Internet Exploder*/
             ],
             "message": [
                 {
@@ -1342,6 +2800,58 @@
                             "はShockwaveをまだ動かそうとしている。",
                             "はJavaアプレットをまだ動かそうとしている。",
                             "はトライデントを持ち上げた…が取り落した。"
+                        ],
+                        "en": [
+                            "is slow.",
+                            "throws off some dorky packets.",
+                            "became unresponsive.",
+                            "displayed a screen that was different from what the technician expected.",
+                            "receives a hot look from the officials.",
+                            "is still trying to get ActiveX working.",
+                            "is still trying to get Flash working.",
+                            "is still trying to get Shockwave working.",
+                            "is still trying to get Java applet working.",
+                            "lifted Trident ... but dropped it."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "を削除します。"
+                        ],
+                        "en": [
+                            "is deleted."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は重い。",
+                            "は妙なパケットを発している。"
+                        ],
+                        "en": [
+                            "is slow.",
+                            "throws off some dorky packets."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FRIEND",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は重い。",
+                            "は妙なパケットを発している。"
+                        ],
+                        "en": [
+                            "is slow.",
+                            "throws off some dorky packets."
                         ]
                     }
                 }
@@ -1364,6 +2874,27 @@
                             "「無駄な努力はやめて、さっさと帰りたまえ。」",
                             "「帝国は再びかつての栄光をとり戻すだろう。この私の手によって！」",
                             "「私には限りない未来がある。」"
+                        ],
+                        "en": [
+                            "says, 'Lookup failure, human race will go to ruin.'",
+                            "says, 'I am necessary for human race!'",
+                            "says, 'To kill me is to wipe off the future of human race!'",
+                            "says, 'Don't get in my way! You make human race go to ruin!'",
+                            "says, 'Stop the bootless effort and come back.'",
+                            "says, 'Empire have the glory back again. By me!'",
+                            "says, 'I have infinite days.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「すべての人々に．．．平和を．．．」"
+                        ],
+                        "en": [
+                            "says, 'I desire peace ... for all people... '"
                         ]
                     }
                 }
@@ -1384,6 +2915,34 @@
                             "「北斗神拳は無敵だ！！」",
                             "「あーたたたたたたたたたたたたたたたたたたたた！！！！」",
                             "「おまえは既に死んでいる。」"
+                        ],
+                        "en": [
+                            "says, 'Count 3, then you die.'",
+                            "says, 'I came back to kill you.'",
+                            "says, 'Fist of the north star is invincible!!'",
+                            "shouts, 'AAATATATATATATATATATATATATATATATA!!!!'",
+                            "says, 'You're already dead.'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「ユリアーーーーーーーーーー！！！」"
+                        ],
+                        "en": [
+                            "shouts, 'JuliaAAAAAAA!!!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「み、水……」"
                         ]
                     }
                 }
@@ -1424,6 +2983,10 @@
                         "ja": [
                             "「おかわり！」",
                             "「正ちゃん、おなか空いたよ～」"
+                        ],
+                        "en": [
+                            "says, 'Refill'",
+                            "says, 'Sho, I'm hungry..'"
                         ]
                     }
                 }
@@ -1443,6 +3006,54 @@
                             "「火の指1！」",
                             "「火の指2！」",
                             "「でくのぼうめ！」"
+                        ],
+                        "en": [
+                            "shouts, 'Fire-ball!'",
+                            "shouts, 'Fire-finger1!'",
+                            "shouts, 'Fire-finger2!'",
+                            "shouts, 'Blockhead!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "は無慈悲な冒険者によって殺されてしまった。14へ行け。"
+                        ],
+                        "en": [
+                            "is killed by a cruel venturer. Go to 14."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「魔法のアヒルよ、援護を頼む。ぼくはちっとも恐くないぞ！」"
+                        ],
+                        "en": [
+                            "says, 'Magic ducks, Cover me. I don't shit hits the fan!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FRIEND",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「火の玉、発射！」",
+                            "「火の指1！」",
+                            "「火の指2！」",
+                            "「でくのぼうめ！」"
+                        ],
+                        "en": [
+                            "shouts, 'Fire-ball!'",
+                            "shouts, 'Fire-finger1!'",
+                            "shouts, 'Fire-finger2!'",
+                            "shouts, 'Blockhead!'"
                         ]
                     }
                 }
@@ -1461,6 +3072,25 @@
                             "「１４へ行け！」",
                             "「忘れるな、好奇心は災いのもとなり！」",
                             "「よく来たな、若いの・・・」"
+                        ],
+                        "en": [
+                            "says, 'Go to 14!'",
+                            "shouts, 'Remember! Curiosity killed the cat!'",
+                            "says, 'Welcome, youth...'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「わしの猟犬が！なんてことを！」",
+                            "「きさま、よくもわしの愛する猟犬を殺しおったな！」"
+                        ],
+                        "en": [
+                            "cries, 'Oh! My gun dogs was dead! Damn it!'",
+                            "shouts, 'You! have been and killed my darling gun dogs!'"
                         ]
                     }
                 }
@@ -1468,7 +3098,26 @@
         },
         {
             "id_list": [
-                1018 /*Raou the Conqueror*/
+                1013 /*Rolento*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "は手榴弾を抱えて自爆した！"
+                        ],
+                        "en": [
+                            "blew himself up with grenades!"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1018 /*Raou*/
             ],
             "message": [
                 {
@@ -1483,1704 +3132,19 @@
                             "「おまえなどこの親指一本で十分！」 "
                         ]
                     }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1029 /*ベビーサタン*/
-            ],
-            "message": [
+                },
                 {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
                     "message": {
                         "ja": [
-                            "がサイバーデーモンを召喚した！しかしMPが足りない！",
-                            "が魔法で特別な強敵を召喚した！しかしMPが足りない！",
-                            "が魔力の嵐の呪文を念じた。しかしMPが足りない！",
-                            "が暗黒の嵐の呪文を念じた。しかしMPが足りない！",
-                            "がスターバーストの呪文を念じた。しかしMPが足りない！",
-                            "が光の剣を放った。しかしMPが足りない！",
-                            "が破滅の手を放った！しかしMPが足りない！",
-                            "は無傷の球の呪文を唱えた。しかしMPが足りない！",
-                            "がアンバーの王を召喚した！しかしMPが足りない！",
-                            "「『ザ・ワールド』！時は止まった！」しかしMPが足りない！"
+                            "は自分の胸の秘孔を突いた！「我が生涯に一片の悔いなし！」"
+                        ],
+                        "en": [
+                            "points at himself and shouts, 'I finished my life with no regrets!'"
                         ]
                     }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1063 /*lousy, the King of louses*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「おまえもシラミになっちゃえ！」",
-                            "「そんなシラミを見るような目で俺を見るな！」",
-                            "「そらシラミ～♪」",
-                            "「死ね，死ね，強いよコイツ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1069 /*魔人ウォーケン*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「物質は全て塵に帰る…………」",
-                            "「闘いこそがすべて…殺戮こそ生きがい…………」",
-                            "「熱いコーヒーはないのか！」",
-                            "「ようこそ来訪者！」",
-                            "「ある種の事がらは死ぬことより恐ろしい」",
-                            "「わたしもおまえも同じだ………『化物』だ！」",
-                            "「この手で直接闇の彼方へ沈めてやろう」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1081 /*チャージマン『研』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「チャージーーング…ゴー！」",
-                            "「くたばれ！ジュラル星人め！」",
-                            "「盛大にやろうぜ！」",
-                            "「よーしひとまとめに片付けてやる」",
-                            "「よくもあんなキ○ガイレコードを！」",
-                            "「今度という今度は許さないぞ！」",
-                            "「今のあなたは人間ロボットなんだ！」",
-                            "「ボルガ博士、お許しください！」",
-                            "「行け！スカイロッド！」",
-                            "「院長、あなたは狂っているんだ！」",
-                            "「どうも怪しいと思ったら やっぱり そうだったのか」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1090 /*『ボルガ博士』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「お菓子好きかい？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1096 /*濃尾無双『岩本虎眼』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "について「剣術流祖録」はこのような詩を記す―　狂ほしく　血のごとき　月はのぼれり　秘めおきし　魔剣　いずこぞや",
-                            "が構えたる星流れの型が蘇らせた忌まわしき記憶は鮮明であったが　目の前の＠がその一件と無関係であることは明確だろうか？",
-                            "について「剣術流祖録」はこう記している―　『虎眼流に「流れ星」なる秘剣あり　掛川城主松平隠岐守定勝をして「神妙古今に比類なし」と言わしめたり』",
-                            "の脳裏に浮かぶは　鮮明なる勝利の幻 虎眼流秘剣「流れ星」　何人もこの魔技から逃れることは出来ない　",
-                            "について「剣術流祖録」はこう記している―　常人よりも一指多い虎眼の右手の掴みは　猫科動物が爪を立てるが如き異様なもの　今一つは刀身を万力の如く掴む左手の存在",
-                            "「あの折儂が指を伏せたるは宗矩が指図　はかった喃　はかってくれた喃」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1106 /*光の堕天使『エミリオ・ミハイロフ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「ははは、変な格好ぉ」",
-                            "「僕は今とっても楽しいんだ」",
-                            "「いい歌だな、もっと歌ってよ」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1123 /*巴流『葦名弦一郎』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「俺が芦名を守る」",
-                            "「踏みにじらせはせぬぞ」",
-                            "「卑怯とは言うまいな」",
-                            "「巴の雷、見せてやろう」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1146 /*ハヤブサ*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「逃げろ、雲の影を飛べ！」",
-                            "「何としても振り切るんだ！！」",
-                            "「しまった、燃料噴くぞ！」",
-                            "「バカ！　まだ敵が見えん。お前を切り離すのは敵が見えてからだ」",
-                            "「はっはっは！　まだ飛べるぜよ！」",
-                            "「後は任せたぞ！」",
-                            "「あっはっはっは！　行った行った！　あいつめ、ロケットを全部いっぺんに点火していきよった！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1240 /*ソードマスター『ヤマト』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「パンツだけは…許さない！」",
-                            "「オレの肉しみは消えないんだ！」",
-                            "「オレはポテトだ！」",
-                            "「オレの新しい脇を見せてやる！」",
-                            "「まそっぷ」",
-                            "「チクショオオオオ！」",
-                            "「新必殺技音速火炎剣！」",
-                            "「くらええええ！」",
-                            "「やった…ついに四天王を倒したぞ…」",
-                            "「これでベルゼバブのいる魔籠城の扉が開かれる！！」",
-                            "「こ…ここが魔籠城だったのか…！」",
-                            "「感じる…ベルゼバブの魔力を…」",
-                            "「な　なんだって！？」",
-                            "「フ…上等だ…オレも一つ言っておくことがある」",
-                            "「このオレに生き別れた妹がいるような気がしていたが別にそんなことはなかったぜ！」",
-                            "「ウオオオいくぞオオオ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1245 /*エッヂ*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はインターネット・エクスプローダーの残骸を踏み潰した。",
-                            "はインターネット・エクスプローダーを見て嘲笑した。",
-                            "は機密データを勝手に送信している。",
-                            "はあなたのメールアドレスに広告を送った。",
-                            "に誰かがクラックを試みたが、プロテクトは突破されなかった。",
-                            "はあなたの性癖を把握した。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1246 /*アイ・ホーン*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は尻がどうとか言っている。",
-                            "は教祖たるスティーヴンの肖像画を表示した。",
-                            "はエンジンをクラックしてWebKitに差し替えた。",
-                            "は課金画面を表示させなかった。",
-                            "は落ちて割れた。",
-                            "はアイコンのサイズ変更を拒否した。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1247 /*ゲイツの宿敵『スティーヴン・ジョーブツ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「今日のネクタイは赤だと？　オレは赤が嫌いなんだ！　貴様はクビだ！！」",
-                            "「今日のネクタイは青だと？　オレは青が嫌いなんだ！　貴様はクビだ！！」",
-                            "「今日のネクタイは緑だと？　オレは緑が嫌いなんだ！　貴様はクビだ！！」",
-                            "「今日のネクタイは黄色だと？　オレは黄色が嫌いなんだ！　貴様はクビだ！！」",
-                            "「今日のネクタイは紫だと？　オレは紫が嫌いなんだ！　貴様はクビだ！！」",
-                            "「今日のネクタイはオレンジだと？　オレはオレンジが嫌いなんだ！　貴様はクビだ！！」",
-                            "「今日のネクタイは青だと？　オレは赤しか好かん！　貴様はクビだ！！」",
-                            "「今日のネクタイは緑だと？　オレは赤しか好かん！　貴様はクビだ！！」",
-                            "「今日のネクタイは黄色だと？　オレは赤しか好かん！　貴様はクビだ！！」",
-                            "「今日のネクタイは紫だと？　オレは赤しか好かん！　貴様はクビだ！！」",
-                            "「今日のネクタイはオレンジだと？　オレは赤しか好かん！　貴様はクビだ！！」",
-                            "「アシッドをキメればいつだっていいアイディアが浮かんでくる！　貴様もキメろ！！」",
-                            "「なんだその新機種のアイディアは！　そんなつまらん製品を世に送り出すつもりか！？　貴様はクビだ！！」",
-                            "「素晴らしい新機種のアイディアが浮かんだぞ！　なに、『それは先週自分で却下した』だと！？　ウソをこけ！　オレのアイディアは完璧なのだ！」",
-                            "「素晴らしい新機種のアイディアが浮かんだぞ！　なに、『それは私のアイディアです』だと！？　ウソをこけ！　オレのアイディアに決まっている！！」",
-                            "「株式を上場する！　手元の株主はオレ一人だ！！」",
-                            "「明日までにこのコードを書き上げろ！　できれば２０万ドル、できなきゃクビだ！！」",
-                            "「オレが想定した使い方しか認めない！　他の使い方は全てロックしてやる！！」",
-                            "「このオレが？ ユーザ様の意見を聞き入れる、だと！？ 断じてあり得ない！ 逆だバカどもが！ オレ様の意見を！ ユーザが聞き入れるのだ！」",
-                            "「無知蒙昧な客の意見など聞くに値せん！ オレ様は忙しいのだ！」",
-                            "「このオレ様が生み出した最高のリンゴにカバーを被せるだと！？　ありえない！！」",
-                            "「須らく馬鹿に決まっているユーザ様にコマンドなぞ見せるな！　これだからゲイツのOSはSM-DOSなのだ！」",
-                            "「絶対にrootを取らせるな！　どんな開発よりも優先して脱獄を阻止しろ！　このオレ様が作った完璧なOSと完璧なデザインを改造するような奴は全員死刑だ！！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1258 /*『ロボ・ガンダルフ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「ばっど・いぶにんぐ！」",
-                            "「ユビワヲヨコセ！」",
-                            "「オマエニモウアサハコナイ！」",
-                            "「どぅりんノワザワイニクラベタラヘデモネエナテメーハ！」",
-                            "「オメーハ『める＝ろん』デハナイ！」",
-                            "「カトウセイブツメ！」",
-                            "「トンチキガ！」",
-                            "「コレガキカイノチカラダ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1282 /*盗賊『鼠小僧』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はあなたの財布を物欲しそうに見つめている。",
-                            "「おぬし奉行所の手の者のようだな！」",
-                            "「おぬしから盗んでみせるさ、賭けてもいい...」",
-                            "「痛い目を見る前に金子を置いて失せな！」",
-                            "「女ねずみは俺の名前を地に落とした！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1290 /*『ヴィネガー・ドッピオ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「とうおるるるるるるるる、とうおるるるるるるるる」",
-                            "「......もしもし、はい　ドッピオです」 "
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1291 /*『ディアボロ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「消したつもりでも……『過去』というものは人間の真の平和をがんじがらめにする」",
-                            "「おまえごときの浅知恵で『キング・クリムゾン』の予測の上を行くことは絶対にない……くぐり抜けることもないッ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1292 /*『チョコラータ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "E:Cioccolata",
-                            "「生命エネルギーはこの『グリーン・ディ』の敵ではない…」",
-                            "「よおーく見せるんだッ！希望が尽きて…命を終える瞬間の顔をッ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1299 /*『ロストリンギル大佐』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「なぁ、俺のリンギルを知らないか？」",
-                            "は地面を探している。",
-                            "は手持ちの剣を片っ端から鑑定している。",
-                            "は虚ろな目でぶつぶつ呟いている。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1303 /*ヨグ=ソトートの落とし子*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は気持ち悪い音を発している。",
-                            "は気持ち悪い悪臭を放っている。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1305 /*スーパーモンキー『孫悟空』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「猪八戒は置いてきた、忙しいらしいからな」",
-                            "「お師匠様も沙悟浄も死んじまった……」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1306 /*ソーシャルディスタンスの王者『リー・ナス』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「誰だ、このファックなアイテムを実装した奴は！」",
-                            "「誰だ、このファックなアーティファクトを実装した奴は！」",
-                            "「誰だ、このファックなエゴを実装した奴は！」",
-                            "「誰だ、このファックなモンスターを実装した奴は！」",
-                            "「誰だ、このファックなユニークを実装した奴は！」",
-                            "「誰だ、このファックなコードを書いた奴は！」",
-                            "「このカーネルにはファッキンコードをマージさせない！」",
-                            "「ソースコードが非公開？　そんなファッキンソフトをインストールするな！」",
-                            "「ソースコードが非公開？　そんなファッキンドライバは不要だ！」",
-                            "「C++はファッキン言語だ！　拡張したのはケツの穴だけだ！」",
-                            "「モリアがカーネルより年上なら、ファッキンコードの量もモリアの方が多いな！」",
-                            "「ファッキュー！！」",
-                            "「ファック！　ファック！　ファック！」",
-                            "は中指を突き立てている！",
-                            "がダンジョンの主を召喚した。しかし、誰も来てくれなかった…。",
-                            "がサイバーデーモンを召喚した！　しかし、ロケットしか飛んでこなかった…。",
-                            "が魔法で仲間を召喚した！　しかし、彼に仲間はいなかった…。",
-                            "が魔法でモンスターを召喚した！　しかし、誰も彼に従ってくれなかった…。",
-                            "が魔法でアリを召喚した。しかし、一匹も来てくれなかった…。",
-                            "が魔法でクモを召喚した。しかし、一匹も来てくれなかった…。",
-                            "が魔法でハウンドを召喚した。しかし、一匹も来てくれなかった…。",
-                            "が魔法でヒドラを召喚した。しかし、一匹も来てくれなかった…。",
-                            "が魔法で天使を召喚した！　しかし、天使も堕天使も来てくれなかった…。",
-                            "は魔法で混沌の宮廷から悪魔を召喚した！　しかし、最弱のインプすらも応じてくれなかった…。",
-                            "が魔法で強力なアンデッドを召喚した！　しかし、屍は応じてくれなかった…。",
-                            "が魔法でアンデッドの強敵を召喚した！　しかし、屍は応じてくれなかった…。",
-                            "が魔法でアンデッドを召喚した。しかし、骨一本たりとも応じてくれなかった…。",
-                            "が魔法でドラゴンを召喚した！　しかし、ドラゴンはつばを吐きかけて逃げていった…。",
-                            "が魔法で古代ドラゴンを召喚した！　しかし、古代ドラゴンは彼に侮蔑の目線を向けただけだった…。",
-                            "がアンバーの王族を召喚した！　しかし、アンバーの王族は誰もパターンを渡ってこなかった…。",
-                            "が魔法で特別な強敵を召喚した！　しかしカリスマが足りない！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1323 /*狂戦士『バストラル』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「どうやら、生き残ったのは、俺達だけのようだな。」",
-                            "「ディーンよ、手出しは無用だ。こいつは俺が仕留める！」",
-                            "「バインドアウト帝国を、俺は再興する！」",
-                            "は、雄叫びを上げながら、あなたに近づいてくる。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1333 /*『プロフェッサー・オオツキ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「私もプラズマ・パワーを見せてやる！！」",
-                            "「パターンウォーク、あれもプラズマで説明できる！」",
-                            "「お前が混沌のサーペントを倒せる科学的根拠はないのだ！」",
-                            "「私のプラズマ・パワーはついに限界を超えた！！絶対に負けん！！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1345 /*巨大戦艦『グレート・シング』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "の迫力がボディソニックの振動となって伝わってくる。",
-                            "は美しいBGMを纏っている。",
-                            "はバーストビームをチャージしている。",
-                            "IS APPROACHING FAST."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1346 /*地獄の論客『カイム』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「君も、光の剣を撃ってみたくはないかね？」",
-                            "「ルターよりは、気骨のある所を見せて欲しいものだ。」",
-                            "「神の方が悪魔よりも狭量で、多くの命を奪う。違うかね？」",
-                            "「有意義に語らおうではないか。」",
-                            "「君さえその気であれば、私がルシファー様に口添えをしてもよいのだが。」",
-                            "「こんな薄暗いダンジョンで、人生を終える気かね？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1356 /*ラフィーII*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「接続完了、展開…！」",
-                            "「撃てる限り、諦めない…」",
-                            "「まずは敵を倒す…うん、早く…」",
-                            "「目標発見、殲滅開始…！」",
-                            "「「不死身の船」、簡単には沈まない…」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1362 /*ティーパーティーの魔女『聖園ミカ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「あなた、退いてもらってもいい？……退く気ないみたいね。じゃあ消し飛ばすね？」",
-                            "「サオリは……恐らく向こうにいるかな？」",
-                            "「邪魔だなぁ……また一人冒険者が私を殺しに来てる。」",
-                            "「復讐の邪魔だからさ……消えてくれないかな？」",
-                            "は全てを奪いたそうな目で誰かを探し回っている…",
-                            "は「サオリ」という人物への怨み言を呟いている。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1387 /*亡霊『はらへりじじい』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「おにぎりをくれぇ！ おにぎりをくれぇぇーー！」",
-                            "「うはっ、うはははははーーーーーー！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                8 /*Farmer Maggot*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は叫んだ。「この哀れで無抵抗なホビットを殺さないでくれ！」",
-                            "は叫んだ。「あの困った犬どもはこの大事な時にどこにいるんだ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                19, /*Lion Heart*/
-                1059, /*Mori troll*/
-                1060 /*Noborta Kesyta*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は叫んだ。「私は一国の長だ。そんなことするのは許されない！」",
-                            "は叫んだ。「助けてくれ！野放しのキチガイだ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1083 /*Hato Poppo*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「大変なことになった、予想してなかった。困ったなあ。」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                53, /*Grip, Farmer Maggot's dog*/
-                54, /*Wolf, Farmer Maggot's dog*/
-                55 /*Fang, Farmer Maggot's dog*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はクンクン鳴いた。",
-                            "は片足を引きずってほえた。",
-                            "はうなった。",
-                            "は悲しそうにあなたを見た。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                63 /*Smeagol*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「しどいことしないでくれよう、旦那、---ス、ス、ス---」",
-                            "「かわいそうなスメアゴル、かわいそうなスメアゴル。」",
-                            "「あぁ！いやだよう、しどいことしないでくれよう。」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                135 /*Mughash the Kobold Lord*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は叫んだ。「臆病者どもめ！オレを置き去りにしやがって！」",
-                            "は慈悲を乞うた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                137 /*Wormtongue, Agent of Saruman*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は哀れっぽく命乞いをした。",
-                            "は哀れっぽく泣いた。「私のせいではない！」",
-                            "は叫んだ。「助けて！助けて！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                138 /*Robin Hood, the Outlaw*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は命乞いをした。",
-                            "「けど俺は善玉なんだぞ、ホントに！」",
-                            "「金？もちろん全部返すよ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                180, /*Orfax, Son of Boldor*/
-                237 /*Boldor, King of the Yeeks*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はベソをかいて「こんなつもりじゃなかったんだ...」と言った。",
-                            "はシクシク泣いてうなった。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                200 /*Hobbes the Tiger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は叫んだ。「わー！僕をマンガの中に帰してくれ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                140, /*Lagduf, the Snaga*/
-                186, /*Grishnakh, the Hill Orc*/
-                215, /*Golfimbul, the Hill Orc Chief*/
-                260, /*Ufthak of Cirith Ungol*/
-                314, /*Shagrat, the Orc Captain*/
-                315, /*Gorbag, the Orc Captain*/
-                330, /*Bolg, Son of Azog*/
-                350, /*Ugluk, the Uruk*/
-                356, /*Lugdush, the Uruk*/
-                373 /*Azog, King of the Uruk-Hai*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は叫んだ。「おい！オークにも権利があるんだぞ！」",
-                            "「おまえはオークに対して偏見を持ってるだけなんじゃないか？」",
-                            "「助けてくれ！『リンギル』をやるから！ホントだ！」",
-                            "「今度はもっとウルクをたくさん連れてくるからな！」",
-                            "「醜いからって憎まないでくれ！」",
-                            "はシクシク泣いてひれ伏した。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                382 /*Mime, the Nibelung*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はすすり泣いた。",
-                            "は哀れっぽく泣いた。",
-                            "「オヘ！オヘ！アウ！アウ！」",
-                            "は「俺を放せ！」と抗った。",
-                            "「アウ！アウ！アウ！」",
-                            "「お前には良くしてやったのに、その報いがこの有様か？」",
-                            "はうめいた。「恩知らずめ！」",
-                            "「帰れ！今すぐに！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                383 /*Hagen, son of Alberich*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「者共、立ち上がるのだ！武器を取れ！強い武器を！」",
-                            "は叫んだ。「これはまずい！まずいぞ！」",
-                            "は泣きわめいた。「災難だ！災難だ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                419 /*Alberich the Nibelung King*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「助けて！人殺し！人殺し！」",
-                            "「ああっ！壊れた！バラバラだ！」",
-                            "は「さもしいペテン、汚らわしい欺瞞だ！」とうめいた。",
-                            "は「代価は払っただろう、私を放せ！」と抗った。",
-                            "はすすり泣いた。「恥ずべき屈辱だ！」",
-                            "は叫んだ。「卑劣な盗賊野郎！強盗め！やくざ者！」",
-                            "ぶつぶつと愚痴った。「この非道なふるまいを後悔するぞ、嫌われ者が！」",
-                            "「この悪徳には必ず復讐してやる！」",
-                            "「今は笑っているがいい、だが貴様は私の呪いからは逃れられん！」",
-                            "「おお！おお！災厄が私に！」",
-                            "「なぜ私を嘲笑う？」とうめいた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                393 /*It*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はうなった。「いつか戻ってくるぞ！」",
-                            "「昔はそれほど悪くなかったんだよ！」",
-                            "はテレポートした。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                409 /*Kharis the Powerslave*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は叫んだ。「ノオオオオオオッ！」",
-                            "「死にたくない！なぜ神である私が死なねばならぬのか！」",
-                            "はあなたを呪った。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                431 /*Grendel*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "whines, 'Mommy, save me!'",
-                            "はすすり泣いた。「ママ、助けて！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                441, /*Gachapin*/
-                1061 /*Barney the Dinosaur*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「やめて！子供たちのことも考えて！」",
-                            "は叫んだ。「僕は TVの大スターなんだぞ！」",
-                            "はベソをかいた。「分かった！謝るよ！ほんとにほんとだよ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                493, /*Bert the Stone Troll*/
-                494, /*Bill the Stone Troll*/
-                495, /*Tom the Stone Troll*/
-                551 /*Rogrog the Black Troll*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「止めてくれ！今すぐに！」",
-                            "「おでは見たぞ、生意気なくそがきが！」",
-                            "「俺のダチがおめえを八裂きにするぜ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1062 /*Groo the Wanderer*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「おっと...おいらとてもヤバいね！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                506 /*Fasolt the Giant*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「俺の命などくれてやる。でも俺の金は駄目だ！」",
-                            "は愚痴った。「なんで襲い掛かってくるんだ？俺は正当な分け前を要求しただけだ！」",
-                            "は哀れに叫んだ。「なんで俺を怖がらせるんだ？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                595, /*Father Dagon*/
-                596 /*Mother Hydra*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「やめて！私は絶滅危機生物に指定されてるんだぞ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                606 /*Loge, Spirit of Fire*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は蒸気を吐いてあえいだ。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                615 /*Moire, Queen of Rebma*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は泣き叫んだ。「助けて！人殺し！人殺し！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                616 /*Kavlax the Many-Headed*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "の首の1つが「これは貴様のミスだ！」と言って別の首を噛んだ。",
-                            "は今までのことを全部もう死んだ首のせいにしている。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                628 /*Malekith the Accursed*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "来やがれこの野郎！何とかしてやろうじゃないか！",
-                            "は自分のみじめな人生を言い訳にした。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                642 /*Jasra, Brand's Mistress*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "hisses, 'We don't die, we multiply!'",
-                            "シューッと音を立てた。「我らは死なず、我らは繁栄するのだ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                660, /*Rinaldo, son of Brand*/
-                670 /*Jack of Shadows*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は泣き叫んだ。「顔は止めてくれ！顔は！」",
-                            "「ちぃっ！通販で買ったサイバーデーモンどこに置いといたっけな？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                686, /*Judge Death*/
-                674, /*Judge Fear*/
-                654, /*Judge Fire*/
-                656 /*Judge Mortis*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「このまま勝てると思っているのか？そんなはずがなかろう……」",
-                            "「おい、弁護士達を呼んだからな！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                697 /*Smaug the Golden*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "信じられない思いでうめき声を上げた。",
-                            "は激怒して吠え猛けた。",
-                            "「黒い矢？やめてくれ～～！」",
-                            "「そんなバカな！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                712 /*Fafner the Dragon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は泣き叫んだ。「俺を傷つけた奴は誰だ？名を名乗れ！」",
-                            "は泣き言を言った。「小童の蛮勇を唆し、殺しの業を冒させたのは誰だ?」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                715 /*Glaurung, Father of the Dragons*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は大量の傷口から黒い血を吹き出してのたうち回った。",
-                            "「覚えておれ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                732 /*Bull Gates*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はベソをかいている。「分かった。Linux はクソじゃない。助けてくれるよな？」",
-                            "は「誇大妄想はそんなに悪いことか？」と叫んだ。",
-                            "は MS-DOS について謝罪している。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                733 /*Santa Claus*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「お前は子供たちを失望させることになるんじゃぞ！いいのか？」",
-                            "「いないんじゃよ、ヴァージニアや。サンタなんて...もう...」",
-                            "はいいものを餌にあなたを買収しようとしている。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                743 /*The Phoenix*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「私は必ず蘇る！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                764, /*Uriel, Angel of Fire*/
-                765, /*Azriel, Angel of Death*/
-                769 /*Raphael, the Messenger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「主よ助け給え！もう駄目です！」",
-                            "「主が私に命じられたことなのだ。私は従わねばならぬ。」",
-                            "「主よ、主よ、何故に私をお見捨てになられたのか？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                766 /*Ancalagon the Black*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は、多数の傷口から酸の血をまき散らしながらもがいている",
-                            "「我が友人のパワー・ワイアームたちがお前を迎えに来るだろう！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                771 /*Saruman of Many Colours*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「待て！後ろを見てみろ！」",
-                            "「ヘビの舌！どこへ行った！この間抜けめ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                772 /*Gandalf the Grey*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「なんたることだ！お前さんは指輪物語を読んだことがないのか！？」",
-                            "「痛ッ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                777 /*Bast, Goddess of Cats*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「また戻ってくるからな！このビチグソがぁ～～～っ！」",
-                            "は弱々しくうなった。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                780 /*Vlad Dracula, Prince of Darkness*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は苦痛と恐怖で吠えた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                791 /*Fiona the Sorceress*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「アンバーの血の呪いの恐ろしさを知っているの？！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                820 /*Corwin, Lord of Avalon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「ハッ！？私は誰？ここは何処？なぜ攻撃してくるんだ？」",
-                            "「オリンピックのように正々堂々といこう！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                773, /*Brand, Mad Visionary of Amber*/
-                789, /*Bleys, Master of Manipulation*/
-                794, /*Julian, Master of Forest Amber*/
-                799, /*Caine, the Conspirator*/
-                807, /*Gerard, Strongman of Amber*/
-                813, /*Eric the Usurper*/
-                824 /*Benedict, the Ideal Warrior*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「アンバーの血の呪いの恐ろしさを知っているのか！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                825 /*The Witch-King of Angmar*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "wails, 'Nooooo!'",
-                            "「おのれええええ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                817, /*Hela, Queen of the Dead*/
-                834, /*Ymir the Ice Giant*/
-                835, /*Loki the Trickster*/
-                837 /*Surtur the Giant Fire Demon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「こんなことならずっとアスガルドにいるんだった！」",
-                            "は命と引き替えなら何でも渡すと言っている。",
-                            "「私は戻ってくるぞ！サイバーデーモンどもを引きつれてな！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                655, /*Ubbo-Sathla, the Unbegotten Source*/
-                695, /*Zoth-Ommog*/
-                706, /*Yibb-Tstll the Patient One*/
-                734, /*Eihort, the Thing in the Labyrinth*/
-                735, /*The King in Yellow*/
-                757, /*Hastur the Unspeakable*/
-                760, /*Nyogtha, the Thing that Should not Be*/
-                761, /*Ahtu, Avatar of Nyarlathotep*/
-                767, /*Daoloth, the Render of the Veils*/
-                788, /*Glaaki*/
-                797, /*Rhan-Tegoth*/
-                806, /*Tsathoggua, the Sleeper of N'kai*/
-                809, /*Atlach-Nacha, the Spider God*/
-                810, /*Y'golonac*/
-                826, /*Cyaegha*/
-                833, /*Abhoth, Source of Uncleanness*/
-                841, /*Shuma-Gorath*/
-                845, /*Yog-Sothoth, the All-in-One*/
-                848, /*Shub-Niggurath, Black Goat of the Woods*/
-                849, /*Nodens, Lord of the Great Abyss*/
-                851, /*Nyarlathotep, the Crawling Chaos*/
-                857 /*Great Cthulhu*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「私が悪いわけではない。生まれながらにしてこうだったのだ。」",
-                            "は弱々しくわけのわからないことを言った。",
-                            "は大量の傷口から緑の血を流している。",
-                            "は恐怖でまくしたてた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                850, /*Carcharoth, the Jaws of Thirst*/
-                846, /*Fenris Wolf*/
-                840 /*Draugluin, Sire of All Werewolves*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "縮みあがってクンクン鳴いた。",
-                            "「もう郵便配達人を噛まないと約束する！」",
-                            "「おい！その丸めた新聞紙を振りかざすのはやめてくれ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                830, /*Cantoras, the Skeletal Lord*/
-                831, /*Mephistopheles, Lord of Hell*/
-                818, /*The Mouth of Sauron*/
-                819, /*Klingsor, Evil Master of Magic*/
-                804, /*Vecna, the Emperor Lich*/
-                844, /*Kaschei the Immortal*/
-                856, /*Gothmog, the High Captain of Balrogs*/
-                858, /*Sauron, the Sorcerer*/
-                860 /*Oberon, King of Amber*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「そんなバカな！」",
-                            "「殺すなら殺せ！ボスが黙っちゃいないぞ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                862, /*The Serpent of Chaos*/
-                883 /*Zombified Serpent of Chaos*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「そんなバカな！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                873 /*Combat-Echizen, SEKKAKUDAKARA*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「くっそ～！」",
-                            "「このやろー！」",
-                            "「やりやがったな！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                878 /*Dio Brando*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「馬鹿なッ！このディオが恐怖を感じているというのかッッ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                880 /*Wong*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「やりますねぇ。」",
-                            "「無駄ですよ…」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                921 /*Internet Exploder*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は重い。",
-                            "は妙なパケットを発している。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                936 /*Kenshirou of hokuto*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「み、水……」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1004 /*Pip, the Braver from Another World*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「魔法のアヒルよ、援護を頼む。ぼくはちっとも恐くないぞ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1005 /*Antharom, Magic Master in the Castle of Darkness*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「わしの猟犬が！なんてことを！」",
-                            "「きさま、よくもわしの愛する猟犬を殺しおったな！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1018 /*Raou the Conqueror*/
-            ],
-            "message": [
+                },
                 {
                     "action": "SPEAK_FEAR",
                     "chance": 8,
@@ -3200,6 +3164,36 @@
             ],
             "message": [
                 {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "がサイバーデーモンを召喚した！しかしMPが足りない！",
+                            "が魔法で特別な強敵を召喚した！しかしMPが足りない！",
+                            "が魔力の嵐の呪文を念じた。しかしMPが足りない！",
+                            "が暗黒の嵐の呪文を念じた。しかしMPが足りない！",
+                            "がスターバーストの呪文を念じた。しかしMPが足りない！",
+                            "が光の剣を放った。しかしMPが足りない！",
+                            "が破滅の手を放った！しかしMPが足りない！",
+                            "は無傷の球の呪文を唱えた。しかしMPが足りない！",
+                            "がアンバーの王を召喚した！しかしMPが足りない！",
+                            "「『ザ・ワールド』！時は止まった！」しかしMPが足りない！"
+                        ],
+                        "en": [
+                            "magically summons Cyberdemons!",
+                            "magically summons special opponents!",
+                            "invokes a mana storm.",
+                            "invokes a darkness storm.",
+                            "invokes a starburst.",
+                            "throw a Psyco-Spear.",
+                            "invokes the Hand of Doom!",
+                            "casts a Globe of Invulnerability.",
+                            "magically summons Lords of Amber!",
+                            "yells 'The World! Time has stopped!'"
+                        ]
+                    }
+                },
+                {
                     "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
@@ -3216,870 +3210,21 @@
                             "が自分の傷に集中した。しかしMPが足りない！",
                             "がアンバーの王を召喚した！しかしMPが足りない！",
                             "「『ザ・ワールド』！時は止まった！」しかしMPが足りない！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1081 /*チャージマン『研』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「よし分かった！つかの間の握手だ！」",
-                            "「さ、帰って夕食だ」",
-                            "「いくら悪い奴らでも、人間にアルファガンは撃てないよ」",
-                            "「弱いものいじめはやめるんだ！」",
-                            "「僕は世話をかけないよ！」",
-                            "「ちぇっ、…くっそぉ～」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1090 /*『ボルガ博士』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「何をする！？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1096 /*濃尾無双『岩本虎眼』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「い、いくぅ・・・」",
-                            "「た、種ぇ・・・」",
-                            "「う　うま　うまれたあ」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1106 /*光の堕天使『エミリオ・ミハイロフ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「こんな力があるから……」",
-                            "「痛いなぁ……痛いよ」",
-                            "「うぅっ！あ、頭が…」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1291 /*『ディアボロ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「オ、オレは、何回死ぬんだ!?　次はど……どこから……　い…いつ『襲って』くるんだ!?　オレは！　オレはッ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1292 /*『チョコラータ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「なんてひどい野郎だ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1299 /*『ロストリンギル大佐』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「ここにはリンギルはない！　退却だ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1303 /*ヨグ=ソトートの落とし子*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は半ば音、半ば意識の中枢に入り込む絶叫を上げた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1323 /*狂戦士『バストラル』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「ディーンよ！弟よ！手を貸してくれ！助けてくれ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1333 /*『プロフェッサー・オオツキ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「私が負ける…科学的根拠を示せ…」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1345 /*巨大戦艦『グレート・シング』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "はチカチカ光っている。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1346 /*地獄の論客『カイム』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「グザファン！そいつを、地獄の釜の炎にくべてしまえ！」",
-                            "「議論をしようというのに！野蛮人め！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                53, /*農夫マゴットの飼犬『くいつき』*/
-                54, /*農夫マゴットの飼犬『おおかみ』*/
-                55, /*農夫マゴットの飼犬『きば』*/
-                1320 /*偉大なる祖国の『ライカ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            ""
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                63 /*Smeagol*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「にくむ、にくむ、にくむぅぅぅ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                393 /*It*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「それってひどくない？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                573 /*Lord Borel*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "にあなたは言った 「これはオリンピックじゃないんだ」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                670 /*Jack of Shadows*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「覚えておけ！今度会った時は貴様が堆屍穴に行く番だ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                732 /*Bull Gates*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「Ｍ＄帝国は永遠に不滅だ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                764, /*Uriel, Angel of Fire*/
-                765, /*Azriel, Angel of Death*/
-                769 /*Raphael, the Messenger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「主よ、この罪深き者に天罰をお与え下さい！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                780 /*Vlad Dracula, Prince of Darkness*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「フフフ、私はまた甦るだろう…人間の心に暗黒がある限り。ハハハハ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                815 /*混沌*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "は辺りにログルスの残り香を撒き散らした！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                873 /*Combat-Echizen, SEKKAKUDAKARA*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「おーのー。」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                878 /*Dio Brando*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「ば，ばかなッ！このディオが．．．このディオがァァァァ～～～～！！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                880 /*Wong, Master of Time*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「この私がぁ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                921 /*Internet Exploder*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "を削除します。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                931 /*Caldarm the third*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「すべての人々に．．．平和を．．．」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                936 /*Kenshirou of hokuto*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「ユリアーーーーーーーーーー！！！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1004 /*Pip, the Braver from Another World*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "は無慈悲な冒険者によって殺されてしまった。14へ行け。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1013 /*『ロレント』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "は手榴弾を抱えて自爆した！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1018 /*Raou*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "は自分の胸の秘孔を突いた！「我が生涯に一片の悔いなし！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1063 /*lousy, the King of louses*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「ああん，やっぱり変愚って難しいよ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1069 /*魔人ウォーケン*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「おおお………」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1081 /*チャージマン『研』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「応援、ありがとー！！ 」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1089 /*『ジュラルの魔王』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「ア゛ア゛ア゛ア゛ァ゛ァ゛ァ゛ァ゛ァ゛！！！！！！！！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1090 /*『ボルガ博士』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "！お許し下さい！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1096 /*濃尾無双『岩本虎眼』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "の大脳がうどん玉の如くこぼれ落ちた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1106 /*光の堕天使『エミリオ・ミハイロフ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「何で僕がーー！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1123 /*巴流『葦名弦一郎』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「あし…な……」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1164 /*鬼殺隊の『先輩』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "の身体はあなたの闘気でサイコロ状に切り刻まれた！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1203 /*アルドゥインの尖兵『ミルムルニル』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「ドヴ＠ーキン、やめろぉ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1240 /*ソードマスター『ヤマト』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "の勇気が世界を救うと信じて…！　ご愛読ありがとうございました！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1268 /*『ビッグキューちゃん』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "はお星さまになった！"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1291 /*『ディアボロ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「オレのそばに近寄るなああーーーーーーーーッ！！！！！！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1292 /*『チョコラータ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "は「ヤッダーバァアァァァァアアアアア！！！」と叫んで、ゴミ収集車にぶち込まれた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1299 /*『ロストリンギル大佐』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「リンギルが！　俺のリンギルが！！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1303 /*ヨグ=ソトートの落とし子*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「お助けください、父よ、父なるヨグ=ソトートよ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1333 /*『プロフェッサー・オオツキ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「なぜ…私のプラズマ・パワーが負けるのだ…全身を改造したのに」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1345 /*巨大戦艦『グレート・シング』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "を撃破した。FINAL ZONE IS OVER."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1356 /*ラフィーII*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「ラフィーの戦いは…これで終わりじゃない…うん」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1362 /*ティーパーティーの魔女『聖園ミカ』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "は「まだ…まだあの女を…」と涙ながらに最期の言葉を紡ぎ、ヘイローが砕け散ってそのまま倒れた。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                8 /*Farmer Maggot*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は何か悲しそうだ。",
-                            "は彼の犬を見なかったかと尋ねている。",
-                            "はキノコがどうのとつぶやいている。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                19 /*Lion Heart*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「旧郵政省のわけのわからない論理はコイ○ミ内閣には通用しない！」",
-                            "「私は芸能人じゃない。政治家なんですよ。」",
-                            "「♪なんてったってコイ○ミ～」",
-                            "「私の方から自民党をぶち壊しますから。」",
-                            "「今日はX-JAPANのCDプレゼント！」",
-                            "「♪フォ～エバ～」",
-                            "「よく仕事する人はよく遊ぶ。」",
-                            "「候補者が燃えなきゃ、有権者も燃えないよ。」",
-                            "「自民党がいいねと君が行ったから29日は投票に行こう。」",
-                            "「まんまる丸く丸くまんまる。」",
-                            "「痛みに耐えてよく頑張った！感動した！」",
-                            "「これからさまざまな妨害や抵抗がある。」",
-                            "「私の内閣に反対するものはすべて抵抗勢力だ。」",
-                            "「郵政民営化、民営化で鉄道や電話が無くなりましたか？」",
-                            "「構造改革なくして景気回復はありえない。」",
-                            "「今の痛みに耐えて、明日の豊かさ米百俵の精神。」"
+                        ],
+                        "en": [
+                            "teleports away.",
+                            "casts a Globe of Invulnerability.",
+                            "magically summons Cyberdemons!",
+                            "magically summons special opponents!",
+                            "invokes a mana storm.",
+                            "invokes a darkness storm.",
+                            "invokes a starburst.",
+                            "throw a Psyco-Spear.",
+                            "invokes the Hand of Doom!",
+                            "casts a Globe of Invulnerability.",
+                            "concentrates its wounds.",
+                            "magically summons Lords of Amber!",
+                            "yells 'The World! Time has stopped!'"
                         ]
                     }
                 }
@@ -4091,12 +3236,30 @@
             ],
             "message": [
                 {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「わすの一億ゴールドでカズノ建てなはったさながどげなっちょますかいの」",
+                            "「わすはげんごめーりょ、えめふめーですけんの」"
+                        ],
+                        "en": [
+                            "says, 'Haw iz my 100,000,000 gold kasino?'",
+                            "says, 'I speek cleerly, My speech is anbiguity.'"
+                        ]
+                    }
+                },
+                {
                     "action": "SPEAK_FRIEND",
                     "chance": 8,
                     "message": {
                         "ja": [
                             "「わすの一億ゴールドでカズノ建てなはったさながどげなっちょますかいの」",
                             "「わすはげんごめーりょ、えめふめーですけんの」"
+                        ],
+                        "en": [
+                            "says, 'Haw iz my 100,000,000 gold kasino?'",
+                            "says, 'I speek cleerly, My speech is anbiguity.'"
                         ]
                     }
                 }
@@ -4107,6 +3270,63 @@
                 1060 /*Mori troll*/
             ],
             "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「日本の国、まさに天皇を中心にしている神の国であるぞということを、国民のみなさんにしっかりと承知をしていただく…」",
+                            "「まだ決めていない人が４０％ぐらいある。そのまま関心がない、といって寝てしまってくれればいいんですけれども。」",
+                            "「何も教育勅語に戻せとか超国家的なことに賛成している訳ではない。」",
+                            "「教育勅語には時代を超えて普遍的哲学がある。」",
+                            "「結構国会に残っていますのは、神様を大事にしているからちゃんと当選させてもらえるのだなあと。」",
+                            "「私があいさつに行くと、農作業をしている農家の方が全部家に入っていった。」",
+                            "「大阪は“たんつぼ”といわれるのは無理からぬこと。金もうけだけを考える実に汚い街になった。」",
+                            "「アメリカでは停電が起きたら必ずギャングや殺し屋がやってくる。」",
+                            "「沖縄で万博やることも……」",
+                            "「小渕さんはなんとか万博だけは成功させたいという思いだったんだろう。」",
+                            "「銃後のこと、前線で戦ってまいりますので、この地区はみなさんでお守りいただきたい。」",
+                            "「共産党は綱領は変えないと言っている。天皇制も認めないし、自衛隊は解散、日米安保も容認しない。」",
+                            "「日本の安全を、日本の「国体」をどう守ることができるか。民主党は困っているでしょう。」",
+                            "「共産党と組むとはいかない。」",
+                            "「失言でも何でもない。」",
+                            "「朝鮮半島は２つの民族に分断されていたわけでありますが……」",
+                            "「神様の話をするとまた怒られますが……」",
+                            "「これは政局にしてはいけない、まさに挙国一致……」",
+                            "「あん時はすんません。」",
+                            "「私が来るといい。なぜか。モリ上がるから。」",
+                            "「ＰＨＳってなんだ？携帯の新製品なのか？」",
+                            "「僕だって馬鹿じゃない。」",
+                            "「自分の発言がどういう影響を与えるかは、ちゃんと考えている。」",
+                            "「ベリー・ファイン・トゥデー」",
+                            "「十分に意を尽くさない表現により、多くの方々に誤解を与えたことを深く反省し、国民に深くおわびする。」",
+                            "「間違ったことを言ったとは思っていない。」",
+                            "「パソコンが使えない人は、言葉は悪いが日陰者というんだ。」",
+                            "「心の教育は私立のほうがいいね。」",
+                            "「重油は九州の方に流れていってくれればいい。」",
+                            "「ふーあーゆー？」"
+                        ],
+                        "en": [
+                            "says, 'We hope the Japanese people acknowledge that Japan is a divine nation centering on the emperor.'",
+                            "says, 'Lowbrow sex industries are always created first in Osaka. Excuse my language, but it is a spittoon.'",
+                            "says, 'When there was a Y2K problem, the Japanese bought water and noodles. Americans bought pistols and guns.'",
+                            "says, 'If a blackout happens in America, gangsters and murderers will always come out. It is that kind of society.'",
+                            "says, 'I don't have the intention to do a job like this for long.'",
+                            "says, 'In rugby, one person doesn't become a star, one person plays for all and all play for one.'",
+                            "says, 'None of the Party executives, which whom I met Saturday night, think that I announced my resignation. '",
+                            "says, 'The Japanese media have decided that that's what happend, and they feel they have to keep writing that regardless of what we actually said.'",
+                            "says, 'How would I be able to leave the country when we must do everything to have the budget pass?'",
+                            "says, 'I have been mistreated by the media as if I'm baby picked up under an overpass.'",
+                            "blurts out, 'How then could we ensure Japan's public safety and secure the nation's \"kokutai\"?'",
+                            "says, 'It was not a slip of the tongue. I didn't say I have retracted it.'",
+                            "says, 'Sorry, at that time.'",
+                            "says, 'I'm not fool.'",
+                            "says, 'Berry fine today.'",
+                            "says, 'I think I didn't mistake.'",
+                            "says, 'foo are yu?'"
+                        ]
+                    }
+                },
                 {
                     "action": "SPEAK_FRIEND",
                     "chance": 8,
@@ -4142,200 +3362,7 @@
                             "「心の教育は私立のほうがいいね。」",
                             "「重油は九州の方に流れていってくれればいい。」",
                             "「ふーあーゆー？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1083 /*Hato Poppo*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「トラスト・ミー。」",
-                            "「鳩山内閣が取り組むのは『無血の平成維新』だ。」",
-                            "「必ずしも抑止力として沖縄に存在しなければならない理由にはならないと思ってました。」",
-                            "「国というものがよく分からないのですが。」",
-                            "「人間がいなくなるのが一番地球にとって優しい。」",
-                            "「日本列島は日本人だけの所有物じゃないんですから。」",
-                            "「政治家が馬鹿者であり、そのトップの総理大臣が大馬鹿者である。そんな国が世界的にも認められるはずがない。」",
-                            "「今日は大変いい天気です。」",
-                            "「友愛精神に基づいた『人間のための経済』が日本の新たな成長をつくる。」",
-                            "「正直、政権交代する前の方が楽だった。名前には『山』がつくが、谷ばかりだ。」",
-                            "「公約というのは選挙の時の党の考え方ということ。」",
-                            "「大変なことになった、予想してなかった。困ったなあ。」",
-                            "「恵まれた家庭に育ったものですから。」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                772 /*Gandalf the Grey*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「ボヤボヤせんでお前も手伝わんか！馬鹿もん！」",
-                            "「わしが火の魔法で敵を攻撃するから、お前さんも同時に攻撃しろ。」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                921 /*Internet Exploder*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "は重い。",
-                            "は妙なパケットを発している。"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1004 /*Pip, the Braver from Another World*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「火の玉、発射！」",
-                            "「火の指1！」",
-                            "「火の指2！」",
-                            "「でくのぼうめ！」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1090 /*『ボルガ博士』*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "「お菓子好きかい？」"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                8 /*Farmer Maggot*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "seems sad about something.",
-                            "asks if you have seen his dogs.",
-                            "tells you to get off his land.",
-                            "says, \"Grip! Fang! Wolf! Come on, lads!\"",
-                            "says, \"They won't harm you -- not unless I tell 'em to!\"",
-                            "says, \"Here, Grip! Fang! Heel!\"",
-                            "exclaims, \"Well, if that isn't queerer than ever?\"",
-                            "asks, \"Were you coming to visit me?\"",
-                            "says, \"I'll not light my lanterns till I turn for home.\"",
-                            "says, \"I see you are in some kind of trouble.\"",
-                            "yells, \"Hallo there!\"",
-                            "says, \"It's been a queer day, and no mistake.\""
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                19 /*Lion Heart*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'We must stand up with firm resolve to strive for the eradication of terrorism, together with other nations of the world'",
-                            "says, 'Japan supports the U.S. position that it will not bow to terrorism. I think it is only natural for President Bush to hunt down the culprits and take firm steps against this serious crime.'",
-                            "says, 'The terrorist acts are extremely heinous and outrageous and cannot be forgiven.'",
-                            "says, 'It is a challenge not only to the U.S. but also to democracy, and I am outraged.'",
-                            "says, 'Japan-U.S. alliance is becoming bigger and bigger.'",
-                            "says, 'Not only for borth countries, but in the Asia-Pacific region and the entire world.'",
-                            "says, 'The safe society is crumbling and this is a significant incident.'",
-                            "sings, 'As K*izumi as the day is long...'",
-                            "says, 'I don't think there's any going back to what politics was in this country even three weeks ago.'",
-                            "says, 'What will the prime minister do if the anti-reform forces within the Liberal Democratic Party regain power?'",
-                            "says, 'People are driving the LDP members, and the LDP members are driving the party. That is a total reversal of the past.'",
-                            "says, 'No pain, no gain.'",
-                            "says, 'Here's a present for you. A compact disc of X-JAPAN!'",
-                            "sings, 'Forever...'",
-                            "is composing haiku, 'Liberal Democrats, You said it's good, Let's go voting.'",
-                            "says, 'Perfect circle, round, round, Perfect circle.'",
-                            "says, 'You stuck it out despite the pain. I was thrilled. Congratulations.'",
-                            "says, 'The illegal entry was one thing and the abduction issue was another, although I think it is necessary for the government to take sufficient measures toward families of the abducted people.'",
-                            "says, 'I am starting with the issue that is the most difficalt and which draws the strongest resistance.'",
-                            "says, 'Though the ministry is making a hard effort to consider reforms, all of you will just have to wait and see.'",
-                            "says, 'People call me a eccentric, but I am a man of reform.'",
-                            "says, 'Structural reforms without sanctuaries.'",
-                            "says, 'No structural reforms, no economic recovery.'",
-                            "says, 'The belief -A pain of today makes affluence of tommorow- '"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1059 /*Noborta Kesyta*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Haw iz my 100,000,000 gold kasino?'",
-                            "says, 'I speek cleerly, My speech is anbiguity.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1060 /*Mori troll*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
+                        ],
                         "en": [
                             "says, 'We hope the Japanese people acknowledge that Japan is a divine nation centering on the emperor.'",
                             "says, 'Lowbrow sex industries are always created first in Osaka. Excuse my language, but it is a spittoon.'",
@@ -4361,421 +3388,6 @@
         },
         {
             "id_list": [
-                53, /*Grip, Farmer Maggot's dog*/
-                54, /*Wolf, Farmer Maggot's dog*/
-                55, /*Fang, Farmer Maggot's dog*/
-                1320 /*Laika, the greatest beast of USSR*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "chases its tail.",
-                            "barks loudly.",
-                            "froths at the mouth.",
-                            "wags its tail.",
-                            "rolls over.",
-                            "growls."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                63 /*Smeagol*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "mutters, 'My precious, wheres my precious?'",
-                            "screams, 'Nasty Hobbitsisisisis...'",
-                            "says, 'Come on, quickly, follow Smeagol'",
-                            "says, 'Nasty Bagginis, stole my precious.'",
-                            "says, 'She will kill them oh yes she will precious.'",
-                            "says, 'Whats has its got in its pocketses, hmmm?'",
-                            "sniggers.",
-                            "grovels.",
-                            "picks his nose.",
-                            "pines for his precious.",
-                            "searches his pockets.",
-                            "eats some slimy creatures.",
-                            "shouts, 'No Master Hobbitsisisisis!'",
-                            "cries, 'The ring was ours for agesisisisis!'",
-                            "says, 'Smeagol sneeking! ME! Shneekingsisis!'",
-                            "says, 'Every way is guarded, silly foolsis!'",
-                            "whines, 'Weees wants some fishises.'",
-                            "whimpers, 'We've lost itses we have.'",
-                            "says, 'He'll eastus all the world if he getsitses it.'",
-                            "says, 'No food, no rest; Smeagol a SNEAK!'",
-                            "says, 'What a dainty little dish you will be for her.'",
-                            "says, 'Hobbitses always SOOOO Polite.'",
-                            "screams, 'Stop, Thief!'",
-                            "says, 'Makeses him drop his weapon precious.'",
-                            "grovels, 'He has only four fingers on the black hand.'",
-                            "growls, 'Not nice Hobbits, not sensible!'",
-                            "says, 'If you findesis it, give it us back.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                135 /*Mughash the Kobold Lord*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I may be a kobold, but I'll kick your arse!'",
-                            "says, 'Feel my wrath, fool!'",
-                            "says, 'Death and destruction make me happy!'",
-                            "snickers evilly."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                137 /*Wormtongue, Agent of Saruman*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "whines and sniggers.",
-                            "whispers nasty things.",
-                            "says, 'I'll slaughter you slowly...'",
-                            "says, 'Lathspell I name you, Ill-news; and Ill-news is an ill guest they say.'",
-                            "says, 'Forbid his staff!'",
-                            "yells, 'You lie!'",
-                            "says, 'Let me go, let me go!  I know the way!'",
-                            "says, 'My messages are useless now!'",
-                            "says, 'No no!'",
-                            "hisses, 'You told me to; you made me do it!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                138 /*Robin Hood, the Outlaw*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "is looking at your wallet with a wishful eyes.",
-                            "says, 'You look like Nottingham's man to me!'",
-                            "says, 'I bet I can shoot better than you...'",
-                            "says, 'Give 'til it hurts!'",
-                            "says, 'Don't force me to put an arrow in your skull...'",
-                            "says, 'Kevin Costner has soiled my name!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                180, /*Orfax, Son of Boldor*/
-                237 /*Boldor, King of the Yeeks*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "wonders aloud about your sexual orientation.",
-                            "spouts torrents of obscenities.",
-                            "shouts, 'YEEK! YEEK! YEEK!'",
-                            "says, 'I'll teach you to respect Yeeks!",
-                            "says, 'Feel lucky, punk?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                200 /*Hobbes the Tiger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Why were people put here? TIGER FOOD!'",
-                            "says, 'Yum! Adventurer sandwiches!'",
-                            "says, 'I killed Calvin, now I'll kill YOU!'",
-                            "says, 'I'll make your short life nasty and brutish!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                140, /*Lagduf, the Snaga*/
-                186 /*Grishnakh, the Hill Orc*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Saruman is a fool, and a dirty treacherous fool.'",
-                            "says, 'I left a fool.'",
-                            "yells, 'Nazgul, Nazgul!'",
-                            "says, 'Fine leadership!　I hope the great Ugluk will lead us out again.'",
-                            "hisses, 'My dear tender little fools.'",
-                            "says, 'Well, my little ones!　Enjoying your nice rest?'",
-                            "snarls, 'Have you got it -- either of you?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                215, /*Golfimbul, the Hill Orc Chief*/
-                260, /*Ufthak of Cirith Ungol*/
-                314, /*Shagrat, the Orc Captain*/
-                315, /*Gorbag, the Orc Captain*/
-                330, /*Bolg, Son of Azog*/
-                350, /*Ugluk, the Uruk*/
-                356, /*Lugdush, the Uruk*/
-                373 /*Azog, King of the Uruk-Hai*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "fingers his blade and grins evilly.",
-                            "snickers, 'Now, I strike a blow for *our* side!'",
-                            "says, 'Orcs don't get no respect... I'm gonna change that!'",
-                            "calls your mother nasty names.",
-                            "says, 'I'll bet your innards would taste real sweet...'",
-                            "belches and spits.",
-                            "scratches his armpits.",
-                            "says, 'I love the smell of fresh blood.'",
-                            "says, 'Yeeha! Another idiot to slaughter!'",
-                            "hawks a loogie in your direction.",
-                            "farts thunderously.",
-                            "wonders aloud how many experience points you're worth.",
-                            "says, 'I love being psychotic!'",
-                            "says, 'My brain's on fire with the feeling to kill!'",
-                            "says, 'I shall torture you slowly.'",
-                            "calls you a scum-sucking pig-dog.",
-                            "says, 'I shall have my way with your women!'",
-                            "says, 'You're not so tough, buttmunch!'",
-                            "says, 'Heh-heh, heh-heh, killing people is cool.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                382 /*Mime, the Nibelung*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Get away! This spot is mine!'",
-                            "says, 'I will soon close your eyes in eternal sleep.'",
-                            "says, 'I'll mess up all your stuff!'",
-                            "says, 'Give me the Rheingold, or die!'",
-                            "cries, 'You must pay me... with your life!'",
-                            "grins.",
-                            "says, 'Maybe I will just hack your head off.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                383 /*Hagen, son of Alberich*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Did you hear what the ravens said? Revenge, that is what they cry!'",
-                            "shouts, 'Hoiho! Hoiho! To arms! To arms!'",
-                            "grumbles, 'I hate the happy, and I am never glad.'",
-                            "cries, 'Keep away from the Ring!'",
-                            "boasts, 'My spear will certainly cut down the wrongful one.'",
-                            "cries, 'There! There shall my spear strike!'",
-                            "grins, 'You will die soon, handsome hero!'",
-                            "states, 'I am but avenging perjury.'",
-                            "shouts, 'Give the Ring here!'",
-                            "shouts, 'Hoiho! Hoiho-hoho!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                419 /*Alberich the Nibelung King*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I'll mess up all your stuff!'",
-                            "says, 'Give me the Rheingold, or die!'",
-                            "states, 'As I have renounced love, all who live shall soon renounce it!'",
-                            "laughs insanely.",
-                            "asks, 'Did you hear it? The nibelung hordes are rising from the depths!'",
-                            "laughs, 'Ha ha ha ha! Beware!'",
-                            "says, 'Beware, fool! Beware!'",
-                            "says, 'Envy led you here, pitiful rogue!'",
-                            "boasts, 'I dauntlessly defy everyone, everyone!'",
-                            "yells, 'Tremble, on your knees before the master of the Ring.'",
-                            "yells, 'Tremble with terror, abject throng!'",
-                            "says, 'I am watching you everywhere, expect me where you do not perceive me!'",
-                            "says, 'Feel my wrath, idle rascal!'",
-                            "says, 'I have discovered you, you stupid thief!'",
-                            "says, 'Are you still not afraid? You should be!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                393 /*It*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Nyah, nyah, betcha can't find me!'",
-                            "says, 'Come get some!'",
-                            "magically summons mighty undead opponents!",
-                            "chuckles evilly.",
-                            "magically summons Cyberdemons!",
-                            "summons special opponents!",
-                            "concentrates on its wounds.",
-                            "concentrates on its body. It starts moving faster.",
-                            "teleports away."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                409 /*Kharis the Powerslave*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Open the gates of my hell, I will strike from the grave!'",
-                            "curses you."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                441, /*Gachapin*/
-                1061 /*Barney the Dinosaur*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Cooperation! That's the magic word!'",
-                            "mutters, 'I *hate* those Teletubbies...'",
-                            "says, 'Won't you be my friend?'",
-                            "says, 'Let's all sing a HAPPY SONG!'",
-                            "mugs for the camera.",
-                            "simpers disgustingly.",
-                            "chews up a 'Tinky Winky' doll."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                493, /*Bert the Stone Troll*/
-                494, /*Bill the Stone Troll*/
-                495 /*Tom the Stone Troll*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "complains, 'What's a burrahobbit got to do with my pocket, anyways?'",
-                            "rejoices, 'No more roast mutton! Roast adventurer today!'",
-                            "says, 'That'll teach yer!'",
-                            "says, 'I won't take that from you!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                505 /*Goemon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Zantetsuken is sharp this night. '",
-                            "mumbles, 'Sign..Another trifling thing I've cut....'",
-                            "buttons his lips, '.....'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
                 1062 /*Groo the Wanderer*/
             ],
             "message": [
@@ -4783,887 +3395,23 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「けんかだ！けんかだ！」"
+                        ],
                         "en": [
                             "says, 'A fray! A fray!'"
                         ]
                     }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                506 /*Fasolt the Giant*/
-            ],
-            "message": [
+                },
                 {
-                    "action": "SPEAK_ALL",
+                    "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「おっと...おいらとてもヤバいね！」"
+                        ],
                         "en": [
-                            "grumbles, 'Stop, greedy one! Leave something for me!'",
-                            "shouts, 'Back, over-bold one!'",
-                            "whines, 'You swindler, do you seek to vilify me?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                517 /*Jurt the Living Trump*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "shouts, 'All your fault!'",
-                            "shouts, 'Only your death will set things right!'",
-                            "says, 'Don't call me clumsy!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                573 /*Lord Borel of Hendrake*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I am Borel, Duke of Hendrake, Master of Arms of the Ways of Hendrake.'",
-                            "says, 'You smile at your own cowardice? Stand and fight, bastard!'",
-                            "says, 'You aren't a caitiff that throws a cloak?!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                598 /*Mandor, Master of the Logrus*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "enjoys espresso coffee between battles.",
-                            "says, 'My slaves fight with you.'",
-                            "says, 'Excuse me, I have no time to continue a small fight.'",
-                            "says, 'It is a great pleasure to fight with such a worthy opponent as you.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                642 /*Jasra, Brand's Mistress*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I will turn you into a coatrack.'",
-                            "says, 'I'm a master of the Keep of the Four Worlds!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                651 /*Strygalldwir*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Order will crumble.'",
-                            "says, 'Obey the power of chaos!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                654, /*Judge Fire*/
-                656, /*Judge Mortis*/
-                674, /*Judge Fear*/
-                686 /*Judge Death*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "hisses, 'Thisssss dungeon issss guilty.'",
-                            "hisses, 'Your crime isssss life.'",
-                            "hisses, 'The sssentencce isss death!'",
-                            "hisses, 'Your crime issss life. The sssentencce isss death.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                660 /*Rinaldo, son of Brand*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I am Rinaldo I, Kashfan King and B.S. in Business Management, UC Berkeley.'",
-                            "says, 'Freezer? Glad you asked! A box to store your body!'",
-                            "says, 'If you buy a Grand-D machine, I'll throw Werewindle into the bargain.'",
-                            "has an eye to stick you with a burial set.",
-                            "says, 'Sorry but I kill you.'",
-                            "says, 'Can I get you a chicken? Maybe some white mice and aluminum foil?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                670 /*Jack of Shadows*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Be made to realize my darkness hold.'",
-                            "says, 'Power of shadow is infinite.'",
-                            "says, 'With the Key of Kolwynia, I am invincible!'",
-                            "says, 'Soul? What is it of use to?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                685 /*Shoggoth*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'barrels towards you horrifyingly.'",
-                            "wails, 'Tekeli-li!  Tekeli-li!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                697 /*Smaug the Golden*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "speaks, 'I smell you and I feel your air. I hear your breath. Come along!'",
-                            "says, 'If you get off alive, you will be lucky.'",
-                            "grimaces.",
-                            "laughs with a devastating sound which shakes the ground.",
-                            "asks, 'Where are those who dare approach me?'",
-                            "gloats, 'I am old and strong, strong, strong.'",
-                            "boasts, 'My armour is like tenfold shields, no blade can pierce me.'",
-                            "boasts, 'My teeth are swords, my claws are spears, my breath is death.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                712 /*Fafner the Dragon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'You will make a fine meal.'",
-                            "says, 'I wanted a drink, now I have also found food.'",
-                            "says, 'My fangs are not for chattering, soon you will feel them.'",
-                            "says, 'My throat is well made to gulp you down.'",
-                            "growls, 'Come here, young braggart.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                715, /*Glaurung, Father of the Dragons*/
-                766 /*Ancalagon the Black*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'You cannot avoid the ballyhack.'",
-                            "says, 'A mere mortal, Be burned to the ground by my fire.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                732 /*Bull Gates*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Did I once say '640K should be enough for ANYBODY!'?'",
-                            "says, 'Unlike that passionate person, I'm humble, apologize. 640K wasn't enough for a Millennium party. Even if you have 640M of user memory.'",
-                            "says, 'So now is the time to say it again, '640G should be enough for ANYBODY!''",
-                            "says, 'Buy Windows 10; the system will be updated automatically without saving any datum'",
-                            "says, 'Linux?  I've only heard that it's the worst...'",
-                            "says, 'I don't know who is the best manager. But the worst owner is definitely that apple store.'",
-                            "says, 'Are you still using Fuckintosh?  It's very pathetic.'",
-                            "says, 'Resistance is futile--you will be assimilated.'",
-                            "says, 'Pro version is the solution for ALL your needs.'",
-                            "hacks out some code and calls it a Feature Update.",
-                            "says, 'We've had a monopoly, but iOS's stronghold hasn't collapsed'",
-                            "wonders if he should buy a small country.",
-                            "says, 'Where will we let you go today?  HELL!'",
-                            "cackles diabolically.",
-                            "is even buying up an apple orchard.",
-                            "says, 'Isn't it as user-free as customization? Of course, I wouldn't take responsibility for any bugs. Even if it stays the default.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                733 /*Santa Claus*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Ho ho ho! You're gonna die!'",
-                            "says, 'You're gettin' COAL in your stocking!'",
-                            "says, 'On Smasher, on Whoop-Ass, now dash away all!'",
-                            "chortles sadistically.",
-                            "says, 'You're on the Naughty List!'",
-                            "says, 'No presents for you, ever!'",
-                            "says, 'I'll sic my man-eating reindeer on you!'",
-                            "says, 'I hate Christmas so much that I've gone psychotic!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                764, /*Uriel, Angel of Fire*/
-                765, /*Azriel, Angel of Death*/
-                769 /*Raphael, the Messenger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Repent, evildoer!'",
-                            "says, 'My righteousness shall cleanse you!'",
-                            "says, 'Don't EVER steal from the collection plate!'",
-                            "says, 'God may love you, but *I* don't!'",
-                            "says, 'I shall smite thee with extreme prejudice!'",
-                            "says, 'Hope you like eternal damnation!'",
-                            "says, 'Verily, it is too late for thee.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                772 /*Gandalf the Grey*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I am a Wielder of the Flame of Anor, you cannot pass.'",
-                            "says, 'The dark fire will not avail you, Flame of Udun.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                773 /*Brand, Mad Visionary of Amber*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I don't endure your sabotaging my plan!'",
-                            "says, 'You dare to oppose Amber?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                789, /*Bleys, Master of Manipulation*/
-                799 /*Caine, the Conspirator*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'You dare to oppose Amber?'",
-                            "says, 'Who is Your malik? Eric? Corwin?'",
-                            "says, 'To barge into our blood feud is to die!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                791 /*Fiona the Sorceress*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'You should not think me easy to deal with.'",
-                            "says, 'You dare to oppose Amber?'",
-                            "smiles diabolic."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                794 /*Julian, Master of Forest Amber*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "belows a horn in a loud voice.",
-                            "says, 'This Haul offers resistance!'",
-                            "says, 'You'll become a good mounting'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                807 /*Gerard, Strongman of Amber*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "rushes toward you wordlessly."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                813 /*Eric the Usurper*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I'm going to make you to have the same problem of Corwin.'",
-                            "says, 'Curse your daffiness that you make an enemy of a Lord of Amber.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                820 /*Corwin, Lord of Avalon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I teach you bite of Grayswandir.'",
-                            "throws his cloak.",
-                            "says, 'Sorry but I have no time to continue a small fight like this.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                824 /*Benedict, the Ideal Warrior*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Back Down. This situation only results in my victory, I know.'",
-                            "says, 'I praise your bravery. But take good care of your life.'",
-                            "says, 'It's unlucky for you to see me.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                837 /*Surtur the Giant Fire Demon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'You cannot get \"Orb of Destiny\" even if you bring me down into the dust.'",
-                            "says, 'Burn out! And turn to dust!'",
-                            "says, 'The level 14 valkyrie who came before was storonger than you!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                655, /*Ubbo-Sathla, the Unbegotten Source*/
-                695, /*Zoth-Ommog*/
-                706, /*Yibb-Tstll the Patient One*/
-                734, /*Eihort, the Thing in the Labyrinth*/
-                735, /*The King in Yellow*/
-                757, /*Hastur the Unspeakable*/
-                760, /*Nyogtha, the Thing that Should not Be*/
-                761, /*Ahtu, Avatar of Nyarlathotep*/
-                788, /*Glaaki*/
-                797, /*Rhan-Tegoth*/
-                806, /*Tsathoggua, the Sleeper of N'kai*/
-                810, /*Y'golonac*/
-                826, /*Cyaegha*/
-                833, /*Abhoth, Source of Uncleanness*/
-                841, /*Shuma-Gorath*/
-                845, /*Yog-Sothoth, the All-in-One*/
-                848, /*Shub-Niggurath, Black Goat of the Woods*/
-                849, /*Nodens, Lord of the Great Abyss*/
-                851, /*Nyarlathotep, the Crawling Chaos*/
-                857 /*Great Cthulhu*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "slurps and gibbers disgustingly.",
-                            "shrieks fit to wake the dead.",
-                            "oozes nasty, glistening slime all over the dungeon.",
-                            "farts thunderously.",
-                            "lets off a mind-numbing stench.",
-                            "howls, 'Tekeli-li!  Tekeli-li!'",
-                            "makes a chilling slithering sound.",
-                            "howls, 'The OTHER GODS will feast on your brain!'",
-                            "hisses, 'I'll feed you to the Hounds of Tindalos...'",
-                            "hisses, 'Randolph Carter got off easy; you won't!'",
-                            "seethes and fumes sickeningly.",
-                            "hisses, 'I'll send you beyond Known Space to Azathoth!'",
-                            "waves nasty-looking tentacles about.",
-                            "picks its teeth with the bones of former players.",
-                            "opens your mind to a vista of nameless cosmic horror!",
-                            "opens your mind to a vista of endless 'Three's Company' reruns!",
-                            "snorts and slobbers with glee."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                850, /*Carcharoth, the Jaws of Thirst*/
-                846, /*Fenris Wolf*/
-                840 /*Draugluin, Sire of All Werewolves*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "barks and bellows frighteningly!",
-                            "says, 'Oh good, another chew toy!'",
-                            "says, 'Yummy! I was getting tired of chicken...'",
-                            "lets out an earsplitting howl.",
-                            "drools all over the dungeon.",
-                            "lifts his leg at the nearest wall.",
-                            "says, 'Bad adventurer! No more living for you!'",
-                            "snarls and howls."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                819 /*Klingsor, Evil Master of Magic*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "states, 'The time has come.'",
-                            "bellows, 'Your master calls! Obey!'",
-                            "grunts, 'Beware!'",
-                            "states, 'You will fall into my power, you will remain my slave!'",
-                            "cries, 'Halt! I have the right weapon to fell you!'",
-                            "yells, 'I will cut you down with your master's spear!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                830, /*Cantoras, the Skeletal Lord*/
-                831, /*Mephistopheles, Lord of Hell*/
-                818, /*The Mouth of Sauron*/
-                804, /*Vecna, the Emperor Lich*/
-                844, /*Kaschei the Immortal*/
-                856 /*Gothmog, the High Captain of Balrogs*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "brags, 'My power is beyond compare!'",
-                            "snorts, 'A mere mortal dares challenge my might? HA!'",
-                            "says, 'Not another one! I just finished chewing on the last!'",
-                            "wonders aloud how many XP you're worth.",
-                            "leafs through 'Evil Geniuses For Dummies.'",
-                            "mutters, 'Another damn loser to kill...'",
-                            "says, 'Hell shall claim your remains!'",
-                            "says, 'Another 12 skulls and I get that reward from the Boss!'",
-                            "yawns at your pathetic efforts to kill him.",
-                            "says, 'Minions, slaughter this fool!'",
-                            "says, 'Set thine house in order, for thou shalt die...'",
-                            "says, 'I'm no god... God has MERCY!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                862, /*The Serpent of Chaos*/
-                883 /*Zombified Serpent of Chaos*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Foolish worm, you are DOOMED!'",
-                            "says, 'I'm the Big Bad Guy, and you're toast!'",
-                            "shouts, 'MOO HA HA HA! I am DEATH incarnate!'",
-                            "says, 'Prepare for your untimely demise!'",
-                            "opens up a can of Whoop-Ass (tm).",
-                            "picks its teeth with former adventurers' bones.",
-                            "says, 'Maybe I won't kill you... NOT!'",
-                            "yawns at your pathetic efforts to kill it.",
-                            "says, 'Another day, another bastard to slaughter...'",
-                            "says, 'I can't be bothered... minions, slaughter this fool!'",
-                            "says, 'Such a doomed, pathetic gesture as yours verges on the heroic!'",
-                            "says, 'Mere mortals such as you should not meddle the affair of the Powers!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                873 /*Combat-Echizen*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Somethig comes from above! Be careful!'",
-                            "says, 'What is this stair?'",
-                            "says, 'Because it's time, I choose this red door!'",
-                            "chunters, 'Tonight, someone dies again...'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                878 /*Dio Brando*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "shouts, 'You cannot escape!'",
-                            "says, 'You are checkmated!'",
-                            "says, 'Huh! Come on!'",
-                            "shouts, 'Weak! Weak!'",
-                            "says, 'I announce beforehand that I kill you by sucking your blood!'",
-                            "shouts, 'bootless bootless bootless effort! Sing small!'",
-                            "shouts, 'bootless bootless bootless bootless bootless bootless bootless effort'",
-                            "says, 'Your slow sleepy speed never kill me!'",
-                            "says, 'A monkey cannot be a human! You are a monkey for this Dio!!'",
-                            "shouts, 'WRYYYYYYYYY!!!!!!'",
-                            "says, 'You came here to die in vain!'",
-                            "says, 'You think that you have a little possibilities that you defeat me? You are dull fish!'",
-                            "says, 'How many people I killed? Do you remember the amount of bread you ate?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                880 /*Wong*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'I knew that you come'",
-                            "says, 'Make your dream come true in the heaven'",
-                            "says, 'I am only man who actuate the time...'",
-                            "says, 'I can set forward the time and puch back the time as I like...'",
-                            "says, 'Time, move for only me!'",
-                            "says, 'What I boss is not the \"Human being\" but the \"Time\"...'",
-                            "says, 'A broken clock only have a detrimental effect on our doing.'",
-                            "says, 'I get here at any minute... And I get the world...'",
-                            "says, 'Nobody can stop the time, now...'",
-                            "says, '...For the future, I am the time...'",
-                            "says, 'I don't endure your sabotaging...'",
-                            "says, 'You are a little barrier of my plan. Die...'",
-                            "says, 'Everything is as I like... huh...'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                921 /*Internet Exploder*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "is slow.",
-                            "throws off some dorky packets.",
-                            "became unresponsive.",
-                            "displayed a screen that was different from what the technician expected.",
-                            "receives a hot look from the officials.",
-                            "is still trying to get ActiveX working.",
-                            "is still trying to get Flash working.",
-                            "is still trying to get Shockwave working.",
-                            "is still trying to get Java applet working.",
-                            "lifted Trident ... but dropped it."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                931 /*Caldarm the third*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Lookup failure, human race will go to ruin.'",
-                            "says, 'I am necessary for human race!'",
-                            "says, 'To kill me is to wipe off the future of human race!'",
-                            "says, 'Don't get in my way! You make human race go to ruin!'",
-                            "says, 'Stop the bootless effort and come back.'",
-                            "says, 'Empire have the glory back again. By me!'",
-                            "says, 'I have infinite days.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                936 /*Kenshirou of hokuto*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Count 3, then you die.'",
-                            "says, 'I came back to kill you.'",
-                            "says, 'Fist of the north star is invincible!!'",
-                            "shouts, 'AAATATATATATATATATATATATATATATATA!!!!'",
-                            "says, 'You're already dead.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1003 /*The ghost 'Q'*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Refill'",
-                            "says, 'Sho, I'm hungry..'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1004 /*Pip, the Braver from Another World*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "shouts, 'Fire-ball!'",
-                            "shouts, 'Fire-finger1!'",
-                            "shouts, 'Fire-finger2!'",
-                            "shouts, 'Blockhead!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1005 /*Antharom, Magic Master in the Castle of Darkness*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Go to 14!'",
-                            "shouts, 'Remember! Curiosity killed the cat!'",
-                            "says, 'Welcome, youth...'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1029 /*Baby satan*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_ALL",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "magically summons Cyberdemons!",
-                            "magically summons special opponents!",
-                            "invokes a mana storm.",
-                            "invokes a darkness storm.",
-                            "invokes a starburst.",
-                            "throw a Psyco-Spear.",
-                            "invokes the Hand of Doom!",
-                            "casts a Globe of Invulnerability.",
-                            "magically summons Lords of Amber!",
-                            "yells 'The World! Time has stopped!'"
+                            "says, 'Oops... me get in big trouble!'"
                         ]
                     }
                 }
@@ -5678,11 +3426,332 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「おまえもシラミになっちゃえ！」",
+                            "「そんなシラミを見るような目で俺を見るな！」",
+                            "「そらシラミ～♪」",
+                            "「死ね，死ね，強いよコイツ！」"
+                        ],
                         "en": [
                             "says, 'You, transform a louse!'",
                             "says, 'Don't look me as I was a louse!'",
                             "says, 'Here a louse.'",
                             "says, 'Die. Die. Damn thing is strong!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「ああん，やっぱり変愚って難しいよ！」"
+                        ],
+                        "en": [
+                            "says, 'Ah, Hengband is too difficult!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1069 /*魔人ウォーケン*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「物質は全て塵に帰る…………」",
+                            "「闘いこそがすべて…殺戮こそ生きがい…………」",
+                            "「熱いコーヒーはないのか！」",
+                            "「ようこそ来訪者！」",
+                            "「ある種の事がらは死ぬことより恐ろしい」",
+                            "「わたしもおまえも同じだ………『化物』だ！」",
+                            "「この手で直接闇の彼方へ沈めてやろう」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「おおお………」"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1081 /*チャージマン『研』*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「チャージーーング…ゴー！」",
+                            "「くたばれ！ジュラル星人め！」",
+                            "「盛大にやろうぜ！」",
+                            "「よーしひとまとめに片付けてやる」",
+                            "「よくもあんなキ○ガイレコードを！」",
+                            "「今度という今度は許さないぞ！」",
+                            "「今のあなたは人間ロボットなんだ！」",
+                            "「ボルガ博士、お許しください！」",
+                            "「行け！スカイロッド！」",
+                            "「院長、あなたは狂っているんだ！」",
+                            "「どうも怪しいと思ったら やっぱり そうだったのか」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「応援、ありがとー！！ 」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「よし分かった！つかの間の握手だ！」",
+                            "「さ、帰って夕食だ」",
+                            "「いくら悪い奴らでも、人間にアルファガンは撃てないよ」",
+                            "「弱いものいじめはやめるんだ！」",
+                            "「僕は世話をかけないよ！」",
+                            "「ちぇっ、…くっそぉ～」"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1083 /*Hato Poppo*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「トラスト・ミー。」",
+                            "「鳩山内閣が取り組むのは『無血の平成維新』だ。」",
+                            "「必ずしも抑止力として沖縄に存在しなければならない理由にはならないと思ってました。」",
+                            "「国というものがよく分からないのですが。」",
+                            "「人間がいなくなるのが一番地球にとって優しい。」",
+                            "「日本列島は日本人だけの所有物じゃないんですから。」",
+                            "「政治家が馬鹿者であり、そのトップの総理大臣が大馬鹿者である。そんな国が世界的にも認められるはずがない。」",
+                            "「今日は大変いい天気です。」",
+                            "「友愛精神に基づいた『人間のための経済』が日本の新たな成長をつくる。」",
+                            "「正直、政権交代する前の方が楽だった。名前には『山』がつくが、谷ばかりだ。」",
+                            "「公約というのは選挙の時の党の考え方ということ。」",
+                            "「恵まれた家庭に育ったものですから。」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「大変なことになった、予想してなかった。困ったなあ。」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FRIEND",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「トラスト・ミー。」",
+                            "「鳩山内閣が取り組むのは『無血の平成維新』だ。」",
+                            "「必ずしも抑止力として沖縄に存在しなければならない理由にはならないと思ってました。」",
+                            "「国というものがよく分からないのですが。」",
+                            "「人間がいなくなるのが一番地球にとって優しい。」",
+                            "「日本列島は日本人だけの所有物じゃないんですから。」",
+                            "「政治家が馬鹿者であり、そのトップの総理大臣が大馬鹿者である。そんな国が世界的にも認められるはずがない。」",
+                            "「今日は大変いい天気です。」",
+                            "「友愛精神に基づいた『人間のための経済』が日本の新たな成長をつくる。」",
+                            "「正直、政権交代する前の方が楽だった。名前には『山』がつくが、谷ばかりだ。」",
+                            "「公約というのは選挙の時の党の考え方ということ。」",
+                            "「大変なことになった、予想してなかった。困ったなあ。」",
+                            "「恵まれた家庭に育ったものですから。」"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1089 /*『ジュラルの魔王』*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「ア゛ア゛ア゛ア゛ァ゛ァ゛ァ゛ァ゛ァ゛！！！！！！！！」"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1090 /*『ボルガ博士』*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「お菓子好きかい？」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "！お許し下さい！"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「何をする！？」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FRIEND",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「お菓子好きかい？」"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1096 /*濃尾無双『岩本虎眼』*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "について「剣術流祖録」はこのような詩を記す―　狂ほしく　血のごとき　月はのぼれり　秘めおきし　魔剣　いずこぞや",
+                            "が構えたる星流れの型が蘇らせた忌まわしき記憶は鮮明であったが　目の前の＠がその一件と無関係であることは明確だろうか？",
+                            "について「剣術流祖録」はこう記している―　『虎眼流に「流れ星」なる秘剣あり　掛川城主松平隠岐守定勝をして「神妙古今に比類なし」と言わしめたり』",
+                            "の脳裏に浮かぶは　鮮明なる勝利の幻 虎眼流秘剣「流れ星」　何人もこの魔技から逃れることは出来ない　",
+                            "について「剣術流祖録」はこう記している―　常人よりも一指多い虎眼の右手の掴みは　猫科動物が爪を立てるが如き異様なもの　今一つは刀身を万力の如く掴む左手の存在",
+                            "「あの折儂が指を伏せたるは宗矩が指図　はかった喃　はかってくれた喃」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "の大脳がうどん玉の如くこぼれ落ちた。"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「い、いくぅ・・・」",
+                            "「た、種ぇ・・・」",
+                            "「う　うま　うまれたあ」"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1106 /*光の堕天使『エミリオ・ミハイロフ』*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「ははは、変な格好ぉ」",
+                            "「僕は今とっても楽しいんだ」",
+                            "「いい歌だな、もっと歌ってよ」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「何で僕がーー！」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「こんな力があるから……」",
+                            "「痛いなぁ……痛いよ」",
+                            "「うぅっ！あ、頭が…」"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1123 /*巴流『葦名弦一郎』*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_ALL",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「俺が芦名を守る」",
+                            "「踏みにじらせはせぬぞ」",
+                            "「卑怯とは言うまいな」",
+                            "「巴の雷、見せてやろう」"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「あし…な……」"
                         ]
                     }
                 }
@@ -5697,6 +3766,22 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「逃げろ、雲の影を飛べ！」",
+                            "「何としても振り切るんだ！！」",
+                            "「しまった、燃料噴くぞ！」",
+                            "「バカ！　まだ敵が見えん。お前を切り離すのは敵が見えてからだ」",
+                            "「はっはっは！　まだ飛べるぜよ！」",
+                            "「後は任せたぞ！」",
+                            "「あっはっはっは！　行った行った！　あいつめ、ロケットを全部いっぺんに点火していきよった！」",
+                            "「逃げろ、雲の影を飛べ！」",
+                            "「何としても振り切るんだ！！」",
+                            "「しまった、燃料噴くぞ！」",
+                            "「バカ！　まだ敵が見えん。お前を切り離すのは敵が見えてからだ」",
+                            "「はっはっは！　まだ飛べるぜよ！」",
+                            "「後は任せたぞ！」",
+                            "「あっはっはっは！　行った行った！　あいつめ、ロケットを全部いっぺんに点火していきよった！」"
+                        ],
                         "en": [
                             "says, 'Run away, fly back the clouds!!'",
                             "says, 'Shake off no matter what!!'",
@@ -5712,6 +3797,44 @@
         },
         {
             "id_list": [
+                1164 /*Senior, the nameless member of Demon Slayer Corps*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "の身体はあなたの闘気でサイコロ状に切り刻まれた！"
+                        ],
+                        "en": [
+                            "'s body is chopped into dice by your fighting spirit!"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
+                1203 /*Mirmulnir, the vanguard of Alduin*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「ドヴ＠ーキン、やめろぉ！」"
+                        ],
+                        "en": [
+                            "screams, 'Dov@hkiin! No!!'"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
                 1240 /*Yamato, the sword master*/
             ],
             "message": [
@@ -5719,6 +3842,24 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「パンツだけは…許さない！」",
+                            "「オレの肉しみは消えないんだ！」",
+                            "「オレはポテトだ！」",
+                            "「オレの新しい脇を見せてやる！」",
+                            "「まそっぷ」",
+                            "「チクショオオオオ！」",
+                            "「新必殺技音速火炎剣！」",
+                            "「くらええええ！」",
+                            "「やった…ついに四天王を倒したぞ…」",
+                            "「これでベルゼバブのいる魔籠城の扉が開かれる！！」",
+                            "「こ…ここが魔籠城だったのか…！」",
+                            "「感じる…ベルゼバブの魔力を…」",
+                            "「な　なんだって！？」",
+                            "「フ…上等だ…オレも一つ言っておくことがある」",
+                            "「このオレに生き別れた妹がいるような気がしていたが別にそんなことはなかったぜ！」",
+                            "「ウオオオいくぞオオオ！」"
+                        ],
                         "en": [
                             "says, 'I don't forgive only pants ...!'",
                             "says, 'My meatred never disappears!'",
@@ -5738,6 +3879,18 @@
                             "says, 'Woooooooooooooo! Be prepared!'"
                         ]
                     }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "の勇気が世界を救うと信じて…！　ご愛読ありがとうございました！"
+                        ],
+                        "en": [
+                            "'s editor says, 'Believe that Yamato's bravery will save the world...!  Thank you for reading!'"
+                        ]
+                    }
                 }
             ]
         },
@@ -5750,6 +3903,14 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "はインターネット・エクスプローダーの残骸を踏み潰した。",
+                            "はインターネット・エクスプローダーを見て嘲笑した。",
+                            "は機密データを勝手に送信している。",
+                            "はあなたのメールアドレスに広告を送った。",
+                            "に誰かがクラックを試みたが、プロテクトは突破されなかった。",
+                            "はあなたの性癖を把握した。"
+                        ],
                         "en": [
                             "trampled the wreckage of the Internet Exploder.",
                             "ridiculed when he saw the Internet Exploder.",
@@ -5771,6 +3932,14 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "は尻がどうとか言っている。",
+                            "は教祖たるスティーヴンの肖像画を表示した。",
+                            "はエンジンをクラックしてWebKitに差し替えた。",
+                            "は課金画面を表示させなかった。",
+                            "は落ちて割れた。",
+                            "はアイコンのサイズ変更を拒否した。"
+                        ],
                         "en": [
                             "says your ass somehow.",
                             "displayed a portrait of Guru Steven.",
@@ -5792,6 +3961,31 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「今日のネクタイは赤だと？　オレは赤が嫌いなんだ！　貴様はクビだ！！」",
+                            "「今日のネクタイは青だと？　オレは青が嫌いなんだ！　貴様はクビだ！！」",
+                            "「今日のネクタイは緑だと？　オレは緑が嫌いなんだ！　貴様はクビだ！！」",
+                            "「今日のネクタイは黄色だと？　オレは黄色が嫌いなんだ！　貴様はクビだ！！」",
+                            "「今日のネクタイは紫だと？　オレは紫が嫌いなんだ！　貴様はクビだ！！」",
+                            "「今日のネクタイはオレンジだと？　オレはオレンジが嫌いなんだ！　貴様はクビだ！！」",
+                            "「今日のネクタイは青だと？　オレは赤しか好かん！　貴様はクビだ！！」",
+                            "「今日のネクタイは緑だと？　オレは赤しか好かん！　貴様はクビだ！！」",
+                            "「今日のネクタイは黄色だと？　オレは赤しか好かん！　貴様はクビだ！！」",
+                            "「今日のネクタイは紫だと？　オレは赤しか好かん！　貴様はクビだ！！」",
+                            "「今日のネクタイはオレンジだと？　オレは赤しか好かん！　貴様はクビだ！！」",
+                            "「アシッドをキメればいつだっていいアイディアが浮かんでくる！　貴様もキメろ！！」",
+                            "「なんだその新機種のアイディアは！　そんなつまらん製品を世に送り出すつもりか！？　貴様はクビだ！！」",
+                            "「素晴らしい新機種のアイディアが浮かんだぞ！　なに、『それは先週自分で却下した』だと！？　ウソをこけ！　オレのアイディアは完璧なのだ！」",
+                            "「素晴らしい新機種のアイディアが浮かんだぞ！　なに、『それは私のアイディアです』だと！？　ウソをこけ！　オレのアイディアに決まっている！！」",
+                            "「株式を上場する！　手元の株主はオレ一人だ！！」",
+                            "「明日までにこのコードを書き上げろ！　できれば２０万ドル、できなきゃクビだ！！」",
+                            "「オレが想定した使い方しか認めない！　他の使い方は全てロックしてやる！！」",
+                            "「このオレが？ ユーザ様の意見を聞き入れる、だと！？ 断じてあり得ない！ 逆だバカどもが！ オレ様の意見を！ ユーザが聞き入れるのだ！」",
+                            "「無知蒙昧な客の意見など聞くに値せん！ オレ様は忙しいのだ！」",
+                            "「このオレ様が生み出した最高のリンゴにカバーを被せるだと！？　ありえない！！」",
+                            "「須らく馬鹿に決まっているユーザ様にコマンドなぞ見せるな！　これだからゲイツのOSはSM-DOSなのだ！」",
+                            "「絶対にrootを取らせるな！　どんな開発よりも優先して脱獄を阻止しろ！　このオレ様が作った完璧なOSと完璧なデザインを改造するような奴は全員死刑だ！！」"
+                        ],
                         "en": [
                             "says, 'Is your tie red today?  I hate red! You are fired!!'",
                             "says, 'Is your tie blue today?  I hate blue! You are fired!!'",
@@ -5831,6 +4025,16 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「ばっど・いぶにんぐ！」",
+                            "「ユビワヲヨコセ！」",
+                            "「オマエニモウアサハコナイ！」",
+                            "「どぅりんノワザワイニクラベタラヘデモネエナテメーハ！」",
+                            "「オメーハ『める＝ろん』デハナイ！」",
+                            "「カトウセイブツメ！」",
+                            "「トンチキガ！」",
+                            "「コレガキカイノチカラダ！」"
+                        ],
                         "en": [
                             "says, 'BaD EVeninG!'",
                             "says, 'givE mE a rINg!'",
@@ -5847,6 +4051,25 @@
         },
         {
             "id_list": [
+                1268 /*Raphael, the Big Raven*/
+            ],
+            "message": [
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "はお星さまになった！"
+                        ],
+                        "en": [
+                            "became a constellation!"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id_list": [
                 1282 /*Nezumi-Kozou, the Thief*/
             ],
             "message": [
@@ -5854,6 +4077,13 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "はあなたの財布を物欲しそうに見つめている。",
+                            "「おぬし奉行所の手の者のようだな！」",
+                            "「おぬしから盗んでみせるさ、賭けてもいい...」",
+                            "「痛い目を見る前に金子を置いて失せな！」",
+                            "「女ねずみは俺の名前を地に落とした！」"
+                        ],
                         "en": [
                             "says, 'You look like Bugyosyo's man to me!'",
                             "says, 'I bet I can steal from you...'",
@@ -5873,6 +4103,10 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「とうおるるるるるるるる、とうおるるるるるるるる」",
+                            "「......もしもし、はい　ドッピオです」 "
+                        ],
                         "en": [
                             "calls, 'RIIIIIIIIIIING, RIIIIIIIIIIING'",
                             "says, '......hello, yes, Doppio'"
@@ -5890,9 +4124,37 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「消したつもりでも……『過去』というものは人間の真の平和をがんじがらめにする」",
+                            "「おまえごときの浅知恵で『キング・クリムゾン』の予測の上を行くことは絶対にない……くぐり抜けることもないッ！」"
+                        ],
                         "en": [
                             "says, ' Even if I intended to erase it... The \"past\" makes the true peace of human beings hard.'",
                             "says, 'You will never go beyond the predictions of \"King Crimson\" with your shallow thinking... you will never go through!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「オレのそばに近寄るなああーーーーーーーーッ！！！！！！」"
+                        ],
+                        "en": [
+                            "says, 'Don't get close to me Ahhhhhhh!!!!!!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「オ、オレは、何回死ぬんだ!?　次はど……どこから……　い…いつ『襲って』くるんだ!?　オレは！　オレはッ！」"
+                        ],
+                        "en": [
+                            "cries, 'Oh, how many times will I die !? Next... Where... I... When will I \"attack\"!? Will I!? Will I!!'"
                         ]
                     }
                 }
@@ -5907,9 +4169,37 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「生命エネルギーはこの『グリーン・ディ』の敵ではない…」",
+                            "「よおーく見せるんだッ！希望が尽きて…命を終える瞬間の顔をッ！」"
+                        ],
                         "en": [
                             "says, 'Life energy is not the enemy of this \"Green Day\"...'",
                             "says, 'I'll show you! Hope is exhausted... The face of the moment when life ends!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "は「ヤッダーバァアァァァァアアアアア！！！」と叫んで、ゴミ収集車にぶち込まれた。"
+                        ],
+                        "en": [
+                            "shouts, \"Yadder Baaaaaaaaaaaa!!!\" and is thrown into a garbage truck."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「なんてひどい野郎だ！」"
+                        ],
+                        "en": [
+                            "cries, 'What a terrible bastard!'"
                         ]
                     }
                 }
@@ -5924,11 +4214,41 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「なぁ、俺のリンギルを知らないか？」",
+                            "は地面を探している。",
+                            "は手持ちの剣を片っ端から鑑定している。",
+                            "は虚ろな目でぶつぶつ呟いている。"
+                        ],
                         "en": [
                             "says, 'Hey, do you know where my Ringil is?'",
                             "is looking for the ground.",
                             "perceives the sword on hand from one end.",
                             "is muttering with hollow eyes."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「リンギルが！　俺のリンギルが！！」"
+                        ],
+                        "en": [
+                            "shouts, 'Ringil! My Ringil!!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「ここにはリンギルはない！　退却だ！」"
+                        ],
+                        "en": [
+                            "shouts, \"Ringil is not here! Retreat!!\""
                         ]
                     }
                 }
@@ -5943,9 +4263,37 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "は気持ち悪い音を発している。",
+                            "は気持ち悪い悪臭を放っている。"
+                        ],
                         "en": [
                             "makes an unpleasant sound.",
                             "gives off an unpleasant stench."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「お助けください、父よ、父なるヨグ=ソトートよ！」"
+                        ],
+                        "en": [
+                            "says, 'Please help me, Father, Father Yog-Sothoth!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "は半ば音、半ば意識の中枢に入り込む絶叫を上げた。"
+                        ],
+                        "en": [
+                            "screams in the middle of the sound, in the middle of consciousness."
                         ]
                     }
                 }
@@ -5960,6 +4308,10 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「猪八戒は置いてきた、忙しいらしいからな」",
+                            "「お師匠様も沙悟浄も死んじまった……」"
+                        ],
                         "en": [
                             "says, 'We left Pigsy. He seemed to be very busy.'",
                             "says, 'Both Tripitaka and Sandy has been dead...'"
@@ -5977,6 +4329,39 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「誰だ、このファックなアイテムを実装した奴は！」",
+                            "「誰だ、このファックなアーティファクトを実装した奴は！」",
+                            "「誰だ、このファックなエゴを実装した奴は！」",
+                            "「誰だ、このファックなモンスターを実装した奴は！」",
+                            "「誰だ、このファックなユニークを実装した奴は！」",
+                            "「誰だ、このファックなコードを書いた奴は！」",
+                            "「このカーネルにはファッキンコードをマージさせない！」",
+                            "「ソースコードが非公開？　そんなファッキンソフトをインストールするな！」",
+                            "「ソースコードが非公開？　そんなファッキンドライバは不要だ！」",
+                            "「C++はファッキン言語だ！　拡張したのはケツの穴だけだ！」",
+                            "「モリアがカーネルより年上なら、ファッキンコードの量もモリアの方が多いな！」",
+                            "「ファッキュー！！」",
+                            "「ファック！　ファック！　ファック！」",
+                            "は中指を突き立てている！",
+                            "がダンジョンの主を召喚した。しかし、誰も来てくれなかった…。",
+                            "がサイバーデーモンを召喚した！　しかし、ロケットしか飛んでこなかった…。",
+                            "が魔法で仲間を召喚した！　しかし、彼に仲間はいなかった…。",
+                            "が魔法でモンスターを召喚した！　しかし、誰も彼に従ってくれなかった…。",
+                            "が魔法でアリを召喚した。しかし、一匹も来てくれなかった…。",
+                            "が魔法でクモを召喚した。しかし、一匹も来てくれなかった…。",
+                            "が魔法でハウンドを召喚した。しかし、一匹も来てくれなかった…。",
+                            "が魔法でヒドラを召喚した。しかし、一匹も来てくれなかった…。",
+                            "が魔法で天使を召喚した！　しかし、天使も堕天使も来てくれなかった…。",
+                            "は魔法で混沌の宮廷から悪魔を召喚した！　しかし、最弱のインプすらも応じてくれなかった…。",
+                            "が魔法で強力なアンデッドを召喚した！　しかし、屍は応じてくれなかった…。",
+                            "が魔法でアンデッドの強敵を召喚した！　しかし、屍は応じてくれなかった…。",
+                            "が魔法でアンデッドを召喚した。しかし、骨一本たりとも応じてくれなかった…。",
+                            "が魔法でドラゴンを召喚した！　しかし、ドラゴンはつばを吐きかけて逃げていった…。",
+                            "が魔法で古代ドラゴンを召喚した！　しかし、古代ドラゴンは彼に侮蔑の目線を向けただけだった…。",
+                            "がアンバーの王族を召喚した！　しかし、アンバーの王族は誰もパターンを渡ってこなかった…。",
+                            "が魔法で特別な強敵を召喚した！　しかしカリスマが足りない！"
+                        ],
                         "en": [
                             "says, 'Who the fuck implemented this fucking item!?'",
                             "says, 'Who the fuck implemented this fucking ego!?'",
@@ -6025,11 +4410,29 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「どうやら、生き残ったのは、俺達だけのようだな。」",
+                            "「ディーンよ、手出しは無用だ。こいつは俺が仕留める！」",
+                            "「バインドアウト帝国を、俺は再興する！」",
+                            "は、雄叫びを上げながら、あなたに近づいてくる。"
+                        ],
                         "en": [
                             "says, 'Apparently, you and we were the only ones who survived.'",
                             "says, 'Dean, you don't have to do anything. This enemy I can kill!'",
                             "says, 'I will revive the Bindout Empire!'",
                             "approaches you with a war cry."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「ディーンよ！弟よ！手を貸してくれ！助けてくれ！」"
+                        ],
+                        "en": [
+                            "says, 'Dean! Brother! Help me! Help me!'"
                         ]
                     }
                 }
@@ -6044,11 +4447,41 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「私もプラズマ・パワーを見せてやる！！」",
+                            "「パターンウォーク、あれもプラズマで説明できる！」",
+                            "「お前が混沌のサーペントを倒せる科学的根拠はないのだ！」",
+                            "「私のプラズマ・パワーはついに限界を超えた！！絶対に負けん！！」"
+                        ],
                         "en": [
                             "says, 'I also show you the power of plasma!!'",
                             "says, 'I can explain even the pattern walk as plasma!!'",
                             "says, 'There is not the scientific evidence that you can defeat the Serpent of Chaos!!'",
                             "says, 'My power of plasma exceeds the limitation of human!!  I will never lose!!'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「なぜ…私のプラズマ・パワーが負けるのだ…全身を改造したのに」"
+                        ],
+                        "en": [
+                            "says, 'Why... my plasma power loses... even though I remodeled my whole body...'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「私が負ける…科学的根拠を示せ…」"
+                        ],
+                        "en": [
+                            "says, 'Show me... the scientific evidence for losing...'"
                         ]
                     }
                 }
@@ -6063,11 +4496,41 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "の迫力がボディソニックの振動となって伝わってくる。",
+                            "は美しいBGMを纏っている。",
+                            "はバーストビームをチャージしている。",
+                            "IS APPROACHING FAST."
+                        ],
                         "en": [
                             "'s power is transmitted as the vibration of the body sonic.",
                             "wears beautiful background music.",
                             "is charging the burst beam.",
                             "IS APPROACHING FAST."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "を撃破した。FINAL ZONE IS OVER."
+                        ],
+                        "en": [
+                            "is destroyed.  FINAL ZONE IS OVER."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "はチカチカ光っている。"
+                        ],
+                        "en": [
+                            "is shimmering."
                         ]
                     }
                 }
@@ -6082,6 +4545,14 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「君も、光の剣を撃ってみたくはないかね？」",
+                            "「ルターよりは、気骨のある所を見せて欲しいものだ。」",
+                            "「神の方が悪魔よりも狭量で、多くの命を奪う。違うかね？」",
+                            "「有意義に語らおうではないか。」",
+                            "「君さえその気であれば、私がルシファー様に口添えをしてもよいのだが。」",
+                            "「こんな薄暗いダンジョンで、人生を終える気かね？」"
+                        ],
                         "en": [
                             "says, 'Are you also interested in shooting a psycho spear?'",
                             "says, 'I expect you rather than Luther to show me a strong spirit.'",
@@ -6089,6 +4560,20 @@
                             "says, 'Let's talk meaningfully.'",
                             "says, 'If you want, I can introduce you to Lord Lucifer.'",
                             "says, 'Do you feel like ending your life in such a dimly-lit dungeon?'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_FEAR",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "「グザファン！そいつを、地獄の釜の炎にくべてしまえ！」",
+                            "「議論をしようというのに！野蛮人め！」"
+                        ],
+                        "en": [
+                            "says, 'Xaphan! Put that fucking bastard in the flames of the hell cauldron!'",
+                            "says, 'It's time for discussion! You barbarian!'"
                         ]
                     }
                 }
@@ -6103,12 +4588,31 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「接続完了、展開…！」",
+                            "「撃てる限り、諦めない…」",
+                            "「まずは敵を倒す…うん、早く…」",
+                            "「目標発見、殲滅開始…！」",
+                            "「「不死身の船」、簡単には沈まない…」"
+                        ],
                         "en": [
                             "says, 'Connection established. Deploying...!'",
                             "says, 'As long as I can shoot, I won't give up...'",
                             "says, 'First things first, we gotta beat baddies... Yep, hurry...'",
                             "says, 'Located a target, I'll begin to eliminate...!'",
                             "says, '\"The Ship That Would Not Die\" won't go down that easy...'"
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「ラフィーの戦いは…これで終わりじゃない…うん」"
+                        ],
+                        "en": [
+                            "says, 'My battle... isn't over yet... Nope.'"
                         ]
                     }
                 }
@@ -6123,6 +4627,14 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「あなた、退いてもらってもいい？……退く気ないみたいね。じゃあ消し飛ばすね？」",
+                            "「サオリは……恐らく向こうにいるかな？」",
+                            "「邪魔だなぁ……また一人冒険者が私を殺しに来てる。」",
+                            "「復讐の邪魔だからさ……消えてくれないかな？」",
+                            "は全てを奪いたそうな目で誰かを探し回っている…",
+                            "は「サオリ」という人物への怨み言を呟いている。"
+                        ],
                         "en": [
                             "says, 'Hi, can you get out of my way? ...Can't? Okay, I'll kill you.'",
                             "says, 'Saori is... there probably, isn't she?'",
@@ -6130,6 +4642,18 @@
                             "says, 'Because you are an obstructor for my revenge... Can you vanish from me?'",
                             "is looking for a certain person to take everything from that person...",
                             "murmurs the grudge against the person called Saori."
+                        ]
+                    }
+                },
+                {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "は「まだ…まだあの女を…」と涙ながらに最期の言葉を紡ぎ、ヘイローが砕け散ってそのまま倒れた。"
+                        ],
+                        "en": [
+                            "sobs and says, 'I... I haven't wreaked my revenge on her yet... no...' Her halo breaks, and then she falls down."
                         ]
                     }
                 }
@@ -6144,6 +4668,10 @@
                     "action": "SPEAK_ALL",
                     "chance": 8,
                     "message": {
+                        "ja": [
+                            "「おにぎりをくれぇ！ おにぎりをくれぇぇーー！」",
+                            "「うはっ、うはははははーーーーーー！」"
+                        ],
                         "en": [
                             "says, 'Give me food! Give me food!'",
                             "says, 'Uh, Uhhhhhhhhhhhhhhhhhhh!'"
@@ -6153,1819 +4681,56 @@
             ]
         },
         {
-            "id_list": [
-                8 /*Farmer Maggot*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'Don't hurt a poor helpless hobbit!'",
-                            "yells, 'Where are my vicious dogs when I need them?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                19, /*Lion Heart*/
-                1059, /*Mori troll*/
-                1060 /*Noborta Kesyta*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "yells, 'I'm a head of state!  You can't *do* this!'",
-                            "yells, 'Help! Psycho on the loose!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                53, /*Grip, Farmer Maggot's dog*/
-                54, /*Wolf, Farmer Maggot's dog*/
-                55 /*Fang, Farmer Maggot's dog*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "whimpers.",
-                            "pines.",
-                            "limps away, howling.",
-                            "howls.",
-                            "looks at you sadly."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                63 /*Smeagol*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Don't hurt us, mastersisis.'",
-                            "says, 'Poor Smeagol, poor Smeagol.'",
-                            "says, 'No AH! Don't hurtsis us.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                135 /*Mughash the Kobold Lord*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'Cowards! Why did you abandon me?'",
-                            "begs for mercy."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                137 /*Wormtongue, Agent of Saruman*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "begs you to spare his miserable life.",
-                            "whines, 'This is not my fault!'",
-                            "screams, 'Help! Help!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                138 /*Robin Hood, the Outlaw*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "begs you to spare his life.",
-                            "says, 'But I'm a GOOD guy, really!'",
-                            "says, 'Money? Sure, take it all back!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                180, /*Orfax, Son of Boldor*/
-                237 /*Boldor, King of the Yeeks*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "sobs, 'I didn't MEAN it...'",
-                            "whimpers and moans."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                200 /*Hobbes the Tiger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "yells, 'Ow! Get me back to the comics!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                140, /*Lagduf, the Snaga*/
-                186, /*Grishnakh, the Hill Orc*/
-                215, /*Golfimbul, the Hill Orc Chief*/
-                260, /*Ufthak of Cirith Ungol*/
-                314, /*Shagrat, the Orc Captain*/
-                315, /*Gorbag, the Orc Captain*/
-                330, /*Bolg, Son of Azog*/
-                350, /*Ugluk, the Uruk*/
-                356, /*Lugdush, the Uruk*/
-                373 /*Azog, King of the Uruk-Hai*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'Hey, orcs have rights too!'",
-                            "says, 'You're just prejudiced against orc-kind, aren't you?'",
-                            "begs, 'Spare me and I'll get you Ringil! Really!'",
-                            "says, 'Next time, I'm bringing more Uruks with me!'",
-                            "says, 'Don't hate me because I'm ugly!'",
-                            "whimpers and grovels."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                382 /*Mime, the Nibelung*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "sobs.",
-                            "sobs and whines.",
-                            "screams, 'Ohe! Ohe! Au! Au!'",
-                            "pleads, 'Let me go!'",
-                            "wails, 'Au! Au! Au!'",
-                            "says, 'I was so good to you, and this is my reward?'",
-                            "moans, 'Such ingratitude!'",
-                            "says, 'Go now, on your way!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                383 /*Hagen, son of Alberich*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "shouts, 'Vassals, rouse yourselves! Take your weapons, good strong weapons!'",
-                            "shouts, 'There is danger! Danger!'",
-                            "cries, 'Woe! Woe!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                419 /*Alberich the Nibelung King*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'Help! Murder! Murder!'",
-                            "screams, 'Aaah! Crushed! Shattered!'",
-                            "moans, 'Base trickery, foul deceit!'",
-                            "pleads, 'I have paid, now let me depart!'",
-                            "cries, 'O shameful humiliation!'",
-                            "shouts, 'Rascally rogue! Robber! Ruffian!'",
-                            "grumbles, 'You will regret this outrage, you wretch!'",
-                            "moans, 'Terrible vengeance I vow for this wrong!'",
-                            "says, 'Smile now, but you can never escape my curse!'",
-                            "wails, 'Alas! Alas! Woe is me!'",
-                            "moans, 'Do you mock me?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                393 /*It*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "howls, 'I'll be back!'",
-                            "whimpers, 'They said this invisibility thing was better than it is!'",
-                            "teleports away."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                409 /*Kharis the Powerslave*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "howls, 'Nnnnooo!'",
-                            "says, 'I don't want to die, I'm a god, why can't I live on?'",
-                            "curses you."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                431 /*Grendel*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "whines, 'Mommy, save me!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                441, /*Gachapin*/
-                1061 /*Barney the Dinosaur*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "begs, 'Don't! Think of the children!'",
-                            "screams, 'But I'm a big TV star!'",
-                            "sobs, 'All right! I apologize! I really really do!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                493, /*Bert the Stone Troll*/
-                494, /*Bill the Stone Troll*/
-                495, /*Tom the Stone Troll*/
-                551 /*Rogrog the Black Troll*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Now, stop it!'",
-                            "yells, 'Ey, watch it, you cheeky sod!'",
-                            "screams, 'Me mates'll settle yer hash!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1062 /*Groo the Wanderer*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Oops... me get in big trouble!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                506 /*Fasolt the Giant*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "cries, 'Take my life, but not my gold!'",
-                            "complains, 'Why do you rush at me? I sought justice, my just payment!'",
-                            "whines, 'Why do you threaten me?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                595, /*Father Dagon*/
-                596 /*Mother Hydra*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "sobs, 'No! I'm an endangered aquatic species!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                606 /*Loge, Spirit of Fire*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "pants and gasps."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                615 /*Moire, Queen of Rebma*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "wails, 'Help! Murder! Murder!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                616 /*Kavlax the Many-Headed*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'This is YOUR fault!' and bites itself.",
-                            "blames its problems on the head you've managed to kill."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                628 /*Malekith the Accursed*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'C'mon! I'm sure we can work this out...'",
-                            "pleads for his miserable life."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                642 /*Jasra, Brand's Mistress*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "hisses, 'We don't die, we multiply!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                660, /*Rinaldo, son of Brand*/
-                670 /*Jack of Shadows*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'Not the face! Not the face!'",
-                            "says, 'Yikes! Where'd I put my mail-order Cyberdemon?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                686, /*Judge Death*/
-                674, /*Judge Fear*/
-                654, /*Judge Fire*/
-                656 /*Judge Mortis*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'You'll never get away with this...'",
-                            "says, 'Hey! I've got LAWYERS!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                697 /*Smaug the Golden*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "groans in disbelief.",
-                            "roars furiously.",
-                            "howls, 'Black Arrow? NOOOO!'",
-                            "howls, 'This CAN'T be happening!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                712 /*Fafner the Dragon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "wails, 'Who are you that have wounded me so? Speak me your name!'",
-                            "complains, 'Who kindled your childish courage to this deadly deed?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                715 /*Glaurung, Father of the Dragons*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "writhes as he spouts black blood from many wounds.",
-                            "says, 'I shall be avenged!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                732 /*Bull Gates*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "sobs, 'OK, Linux doesn't suck. Let me live?'",
-                            "screams, 'Is megalomania THAT bad?'",
-                            "apologizes for MS-DOS."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                733 /*Santa Claus*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "sobs, 'Think of the children you'll disappoint!'",
-                            "sobs, 'No, Virginia, there isn't... not any more...'",
-                            "attempts to buy you off with offers of goodies."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                743 /*The Phoenix*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "defiantly caws, 'I shall rise again!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                764, /*Uriel, Angel of Fire*/
-                765, /*Azriel, Angel of Death*/
-                769 /*Raphael, the Messenger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'Help! I am undone!'",
-                            "says, 'The Most High hath ordained this; I must follow.'",
-                            "screams, 'My God, my God, why hast thou forsaken me?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                766 /*Ancalagon the Black*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "writhes as he spouts acidic blood from many wounds.",
-                            "says, 'My friends the Wyrms of Power will get you!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                771 /*Saruman of Many Colours*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Wait! Look behind you!'",
-                            "howls, 'Wormtongue! Where are you, you bastard?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                772 /*Gandalf the Grey*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'How have things come to this... again?!'",
-                            "yells, 'Ouch!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                777 /*Bast, Goddess of Cats*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "spits, 'I'll be back, worse than ever!'",
-                            "snarls weakly."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                780 /*Vlad Dracula, Prince of Darkness*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "howls with pain and fear."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                820 /*Corwin, Lord of Avalon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Who am I? Where is here? Why do you attack me?'",
-                            "says, 'Let's make it a clean game as Olympics'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                773, /*Brand, Mad Visionary of Amber*/
-                789, /*Bleys, Master of Manipulation*/
-                791, /*Fiona the Sorceress*/
-                794, /*Julian, Master of Forest Amber*/
-                799, /*Caine, the Conspirator*/
-                807, /*Gerard, Strongman of Amber*/
-                813, /*Eric the Usurper*/
-                824 /*Benedict, the Ideal Warrior*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Do you know the terrors of Amberite blood curse?!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                825 /*The Witch-King of Angmar*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "wails, 'Nooooo!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                817, /*Hela, Queen of the Dead*/
-                834, /*Ymir the Ice Giant*/
-                835, /*Loki the Trickster*/
-                837 /*Surtur the Giant Fire Demon*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "shouts, 'Why didn't I just stay in Asgard?'",
-                            "offers you everything in exchange for life.",
-                            "yells, 'I'll be back, with a squad of Cyberdemons!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                655, /*Ubbo-Sathla, the Unbegotten Source*/
-                695, /*Zoth-Ommog*/
-                706, /*Yibb-Tstll the Patient One*/
-                734, /*Eihort, the Thing in the Labyrinth*/
-                735, /*The King in Yellow*/
-                757, /*Hastur the Unspeakable*/
-                760, /*Nyogtha, the Thing that Should not Be*/
-                761, /*Ahtu, Avatar of Nyarlathotep*/
-                767, /*Daoloth, the Render of the Veils*/
-                788, /*Glaaki*/
-                797, /*Rhan-Tegoth*/
-                806, /*Tsathoggua, the Sleeper of N'kai*/
-                809, /*Atlach-Nacha, the Spider God*/
-                810, /*Y'golonac*/
-                826, /*Cyaegha*/
-                833, /*Abhoth, Source of Uncleanness*/
-                841, /*Shuma-Gorath*/
-                845, /*Yog-Sothoth, the All-in-One*/
-                848, /*Shub-Niggurath, Black Goat of the Woods*/
-                849, /*Nodens, Lord of the Great Abyss*/
-                851, /*Nyarlathotep, the Crawling Chaos*/
-                857 /*Great Cthulhu*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "sobs, 'I'm not bad, I was just born like this!'",
-                            "gibbers weakly.",
-                            "mumbles, 'kill -9 adventurer, kill -9 adventurer', and you say 'No such process'",
-                            "oozes greenish blood from many wounds.",
-                            "burbles with terror."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                850, /*Carcharoth, the Jaws of Thirst*/
-                846, /*Fenris Wolf*/
-                840 /*Draugluin, Sire of All Werewolves*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "cringes and whimpers.",
-                            "says, 'Look, I promise I won't bite the mailman anymore!'",
-                            "says, 'Hey, put that rolled-up newspaper down!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                830, /*Cantoras, the Skeletal Lord*/
-                831, /*Mephistopheles, Lord of Hell*/
-                818, /*The Mouth of Sauron*/
-                819, /*Klingsor, Evil Master of Magic*/
-                804, /*Vecna, the Emperor Lich*/
-                844, /*Kaschei the Immortal*/
-                856, /*Gothmog, the High Captain of Balrogs*/
-                858, /*Sauron, the Sorcerer*/
-                860 /*Oberon, King of Amber*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'This CAN'T be happening!'",
-                            "shouts, 'Kill me if you want, the Boss will getcha!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                862, /*The Serpent of Chaos*/
-                883 /*Zombified Serpent of Chaos*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams, 'This CAN'T be happening!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                873 /*Combat-Echizen*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says shiftlessly, 'Shit...!'",
-                            "says shiftlessly, 'Yegg...!'",
-                            "says shiftlessly, 'yariyagattana!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                878 /*Dio Brando*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'This CAN'T be happening! I feel horror?!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                880 /*Wong*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'You are no fool.'",
-                            "says, 'What you are doing is pointless.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                921 /*Internet Exploder*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "is slow.",
-                            "throws off some dorky packets."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1004 /*Pip, the Braver from Another World*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Magic ducks, Cover me. I don't shit hits the fan!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1005 /*Antharom, Magic Master in the Castle of Darkness*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "cries, 'Oh! My gun dogs was dead! Damn it!'",
-                            "shouts, 'You! have been and killed my darling gun dogs!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1029 /*Baby satan*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "teleports away.",
-                            "casts a Globe of Invulnerability.",
-                            "magically summons Cyberdemons!",
-                            "magically summons special opponents!",
-                            "invokes a mana storm.",
-                            "invokes a darkness storm.",
-                            "invokes a starburst.",
-                            "throw a Psyco-Spear.",
-                            "invokes the Hand of Doom!",
-                            "casts a Globe of Invulnerability.",
-                            "concentrates its wounds.",
-                            "magically summons Lords of Amber!",
-                            "yells 'The World! Time has stopped!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1291 /*Diavolo*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "cries, 'Oh, how many times will I die !? Next... Where... I... When will I \"attack\"!? Will I!? Will I!!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1292 /*Cioccolata*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "cries, 'What a terrible bastard!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1299 /*The Colonel Lostringil*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "shouts, \"Ringil is not here! Retreat!!\""
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1303 /*Spawn of Yog-Sothoth*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "screams in the middle of the sound, in the middle of consciousness."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1323 /*Bastral, the berserker*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Dean! Brother! Help me! Help me!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1333 /*Professor Ootsuki*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Show me... the scientific evidence for losing...'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1345 /*GREAT THING, the Huge Battle Ship*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "is shimmering."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1346 /*Caim, the disputant of hell*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FEAR",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Xaphan! Put that fucking bastard in the flames of the hell cauldron!'",
-                            "says, 'It's time for discussion! You barbarian!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                63 /*Smeagol*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'We hates, hates, hatesss!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                393 /*It*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'It's appalling.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                573 /*Lord Borel*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'Oh, basely done! I had hoped for better of thee!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                670 /*Jack of Shadows*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'I'll get even! Next time I see you, Death is yours!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                732 /*Bull Gates*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'Empire Micro$oft is eternal!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                764, /*Uriel, Angel of Fire*/
-                765, /*Azriel, Angel of Death*/
-                769 /*Raphael, the Messenger*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'My God, Please visit a punishment upon this unrighteous sinner!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                780 /*Vlad Dracula, Prince of Darkness*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'Faugh, I'll be back...so long as human psyche has a blackness. Ho-ho.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                815 /*Unmaker*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "sprinkled the remaining incense from Logrus!"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                873 /*Combat-Echizen*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says shiftlessly, 'Oh. No.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                878 /*Dio Brando*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "shouts, 'This CAN'T be happening! I am Dying....!!!!!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                880 /*Wong, Master of Time*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "shouts, 'This CAN'T be happening!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                921 /*Internet Exploder*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "is deleted."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                931 /*Caldarm the third*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'I desire peace ... for all people... '"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                936 /*Kenshirou of hokuto*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "shouts, 'JuliaAAAAAAA!!!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1004 /*Pip, the Braver from Another World*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "is killed by a cruel venturer. Go to 14."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1013 /*Rolento*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "blew himself up with grenades!"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1018 /*Raou*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "points at himself and shouts, 'I finished my life with no regrets!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1063 /*lousy, the King of louses*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'Ah, Hengband is too difficult!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1164 /*Senior, the nameless member of Demon Slayer Corps*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "'s body is chopped into dice by your fighting spirit!"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1203 /*Mirmulnir, the vanguard of Alduin*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "screams, 'Dov@hkiin! No!!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1240 /*Yamato, the sword master*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "'s editor says, 'Believe that Yamato's bravery will save the world...!  Thank you for reading!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1268 /*Raphael, the Big Raven*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "became a constellation!"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1291 /*Diavolo*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'Don't get close to me Ahhhhhhh!!!!!!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1292 /*Cioccolata*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "shouts, \"Yadder Baaaaaaaaaaaa!!!\" and is thrown into a garbage truck."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1299 /*The Colonel Lostringil*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "shouts, 'Ringil! My Ringil!!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1303 /*Spawn of Yog-Sothoth*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'Please help me, Father, Father Yog-Sothoth!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1333 /*Professor Ootsuki*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'Why... my plasma power loses... even though I remodeled my whole body...'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1345 /*GREAT THING, the Huge Battle Ship*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "is destroyed.  FINAL ZONE IS OVER."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1356 /*Laffey II*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "says, 'My battle... isn't over yet... Nope.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1362 /*Mika Misono, a witch of the Tea Party*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "en": [
-                            "sobs and says, 'I... I haven't wreaked my revenge on her yet... no...' Her halo breaks, and then she falls down."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                8 /*Farmer Maggot*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "seems sad about something.",
-                            "asks if you have seen his dogs.",
-                            "mumbles something about mushrooms."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                19 /*Lion Heart*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'We must stand up with firm resolve to strive for the eradication of terrorism, together with other nations of the world'",
-                            "says, 'Japan supports the U.S. position that it will not bow to terrorism. I think it is only natural for President Bush to hunt down the culprits and take firm steps against this serious crime.'",
-                            "says, 'The terrorist acts are extremely heinous and outrageous and cannot be forgiven.'",
-                            "says, 'It is a challenge not only to the U.S. but also to democracy, and I am outraged.'",
-                            "says, 'Japan-U.S. alliance is becoming bigger and bigger.'",
-                            "says, 'Not only for borth countries, but in the Asia-Pacific region and the entire world.'",
-                            "says, 'The safe society is crumbling and this is a significant incident.'",
-                            "sings, 'As K*izumi as the day is long...'",
-                            "says, 'I don't think there's any going back to what politics was in this country even three weeks ago.'",
-                            "says, 'What will the prime minister do if the anti-reform forces within the Liberal Democratic Party regain power?'",
-                            "says, 'People are driving the LDP members, and the LDP members are driving the party. That is a total reversal of the past.'",
-                            "says, 'No pain, no gain.'",
-                            "says, 'Here's a present for you. A compact disc of X-JAPAN!'",
-                            "sings, 'Forever...'",
-                            "is composing haiku, 'Liberal Democrats, You said it's good, Let's go voting.'",
-                            "says, 'Perfect circle, round, round, Perfect circle.'",
-                            "says, 'You stuck it out despite the pain. I was thrilled. Congratulations.'",
-                            "says, 'The illegal entry was one thing and the abduction issue was another, although I think it is necessary for the government to take sufficient measures toward families of the abducted people.'",
-                            "says, 'I am starting with the issue that is the most difficalt and which draws the strongest resistance.'",
-                            "says, 'Though the ministry is making a hard effort to consider reforms, all of you will just have to wait and see.'",
-                            "says, 'People call me a eccentric, but I am a man of reform.'",
-                            "says, 'Structural reforms without sanctuaries.'",
-                            "says, 'No structural reforms, no economic recovery.'",
-                            "says, 'The belief -A pain of today makes affluence of tommorow- '"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1059 /*Noborta Kesyta*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Haw iz my 100,000,000 gold kasino?'",
-                            "says, 'I speek cleerly, My speech is anbiguity.'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1060 /*Mori troll*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'We hope the Japanese people acknowledge that Japan is a divine nation centering on the emperor.'",
-                            "says, 'Lowbrow sex industries are always created first in Osaka. Excuse my language, but it is a spittoon.'",
-                            "says, 'When there was a Y2K problem, the Japanese bought water and noodles. Americans bought pistols and guns.'",
-                            "says, 'If a blackout happens in America, gangsters and murderers will always come out. It is that kind of society.'",
-                            "says, 'I don't have the intention to do a job like this for long.'",
-                            "says, 'In rugby, one person doesn't become a star, one person plays for all and all play for one.'",
-                            "says, 'None of the Party executives, which whom I met Saturday night, think that I announced my resignation. '",
-                            "says, 'The Japanese media have decided that that's what happend, and they feel they have to keep writing that regardless of what we actually said.'",
-                            "says, 'How would I be able to leave the country when we must do everything to have the budget pass?'",
-                            "says, 'I have been mistreated by the media as if I'm baby picked up under an overpass.'",
-                            "blurts out, 'How then could we ensure Japan's public safety and secure the nation's \"kokutai\"?'",
-                            "says, 'It was not a slip of the tongue. I didn't say I have retracted it.'",
-                            "says, 'Sorry, at that time.'",
-                            "says, 'I'm not fool.'",
-                            "says, 'Berry fine today.'",
-                            "says, 'I think I didn't mistake.'",
-                            "says, 'foo are yu?'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                772 /*Gandalf the Grey*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "says, 'Don't space out. Cover me! Bogan!'",
-                            "says, 'I'll invoke fire magic. Attack concurrently with me!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                921 /*Internet Exploder*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "is slow.",
-                            "throws off some dorky packets."
-                        ]
-                    }
-                }
-            ]
-        },
-        {
-            "id_list": [
-                1004 /*Pip, the Braver from Another World*/
-            ],
-            "message": [
-                {
-                    "action": "SPEAK_FRIEND",
-                    "chance": 8,
-                    "message": {
-                        "en": [
-                            "shouts, 'Fire-ball!'",
-                            "shouts, 'Fire-finger1!'",
-                            "shouts, 'Fire-finger2!'",
-                            "shouts, 'Blockhead!'"
-                        ]
-                    }
-                }
-            ]
-        },
-        {
             "name": "DEFAULT",
             "message": [
+                {
+                    "action": "MESSAGE_REFLECT",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "攻撃は跳ね返った！"
+                        ],
+                        "en": [
+                            "The attack bounces!"
+                        ]
+                    }
+                },
+                {
+                    "action": "MESSAGE_STALKER",
+                    "chance": 8,
+                    "message": {
+                        "ja": [
+                            "があなたの傍に忍び寄った。"
+                        ],
+                        "en": [
+                            "crept up beside you."
+                        ]
+                    }
+                },
+                {
+                    "action": "MESSAGE_TIMESTART",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「時は動きだす…」"
+                        ],
+                        "en": [
+                            "You feel time flowing around you once more."
+                        ]
+                    }
+                },
+                {
+                    "action": "MESSAGE_TIMESTOP",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "は時を止めた！"
+                        ],
+                        "en": [
+                            "stops the time!"
+                        ]
+                    }
+                },
                 {
                     "action": "SPEAK_ALL",
                     "chance": 8,
@@ -8183,6 +4948,18 @@
                     }
                 },
                 {
+                    "action": "SPEAK_DEATH",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "「グアァァァ！」"
+                        ],
+                        "en": [
+                            "shouts, 'AAAARRRGGGHHH!!!'"
+                        ]
+                    }
+                },
+                {
                     "action": "SPEAK_FEAR",
                     "chance": 8,
                     "message": {
@@ -8193,7 +4970,6 @@
                             "「んがあ！何なんだ！助けてくれ！」",
                             "「憶えてろよ！」",
                             "「暴力は何の解決にもならないぞ！」",
-                            "says: 'I thought you liked me.'",
                             "「お前は私の事が好きだと思ってたのに！」",
                             "「なんてばかげた暴力だ！俺には理解できん！」",
                             "「うわぁ。人殺し！人殺し！」",
@@ -8322,68 +5098,6 @@
                         ],
                         "en": [
                             ""
-                        ]
-                    }
-                },
-                {
-                    "action": "SPEAK_DEATH",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "「グアァァァ！」"
-                        ],
-                        "en": [
-                            "shouts, 'AAAARRRGGGHHH!!!'"
-                        ]
-                    }
-                },
-                {
-                    "action": "MESSAGE_STALKER",
-                    "chance": 8,
-                    "message": {
-                        "ja": [
-                            "があなたの傍に忍び寄った。"
-                        ],
-                        "en": [
-                            "crept up beside you."
-                        ]
-                    }
-                },
-                {
-                    "action": "MESSAGE_REFLECT",
-                    "chance": 1,
-                    "use_name": false,
-                    "message": {
-                        "ja": [
-                            "攻撃は跳ね返った！"
-                        ],
-                        "en": [
-                            "The attack bounces!"
-                        ]
-                    }
-                },
-                {
-                    "action": "MESSAGE_TIMESTOP",
-                    "chance": 1,
-                    "message": {
-                        "ja": [
-                            "は時を止めた！"
-                        ],
-                        "en": [
-                            "stops the time!"
-                        ]
-                    }
-                },
-                {
-                    "action": "MESSAGE_TIMESTART",
-                    "chance": 1,
-                    "use_name": false,
-                    "message": {
-                        "ja": [
-                            "「時は動きだす…」"
-                        ],
-                        "en": [
-                            "You feel time flowing around you once more."
                         ]
                     }
                 }


### PR DESCRIPTION
元txtからの抽出順になっていたメッセージをid_listをベースに整理した。
単純なソートと統合であるため動作変更はなし。