### PR TITLE
[Chore] VSCodeのprettier拡張用のワークアラウンド

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,1 +1,9 @@
 printWidth: 100
+overrides:
+  # VSCodeのPrettier拡張が使用する古いバージョンのPrettierに対応するためのワークアラウンド
+  # 拡張子jsoncのファイルに対し強制的にjson5パーサを指定することで、trailingCommaの設定が確実に有効になる
+  - files: "**/*.jsonc"
+    options:
+      parser: json5
+      trailingComma: all
+      quoteProps: preserve


### PR DESCRIPTION
VSCodeに含まれるprettierのバージョンが古いのが原因で、VSCodeでjsoncファイルを整形するとtrailingCommaが削除されてしまう。
拡張子jsoncのパーサにjson5をを強制的に指定すると古いバージョンにおいてもこの問題を回避できることがわかったので、ワークアラウンドとして導入する。
