### PR TITLE
[Fix] SPEAK_FRIENDの挙動の修正

### DIFF
--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -4492,14 +4492,6 @@
             ],
           },
         },
-        {
-          "action": "SPEAK_FRIEND",
-          "chance": 8,
-          "message": {
-            "ja": [""],
-            "en": [""],
-          },
-        },
       ],
     },
   ],


### PR DESCRIPTION
デフォルトメッセージが使われた場合の挙動が想定と違ったため、デフォルトメッセージが選択された場合にメッセージ自体を表示しないように修正する。 定義ファイルのデフォルトを""から未定義に変更することで実装。

## gemini code assist
Please write all summary and review comments in Japanese.