### PR TITLE
Update hengband.spec for 3.0.1.29 and Xft

### DIFF
--- a/hengband.spec
+++ b/hengband.spec
@@ -1,4 +1,4 @@
-%define version 3.0.1.28
+%define version 3.0.1.29
 %define release 1
 
 Summary: hengband %{version}
@@ -9,8 +9,8 @@ License: unknown
 Group: Amusements/Games
 Url: https://hengband.github.io
 Source: hengband-%{version}.tar.gz
-Requires: ncurses-libs libstdc++ libcurl libX11
-BuildRequires: autoconf automake gcc-c++ ncurses-devel libcurl-devel nkf libX11-devel
+Requires: ncurses-libs libstdc++ libcurl libX11 libXft
+BuildRequires: autoconf automake gcc-c++ ncurses-devel libcurl-devel nkf libX11-devel libXft-devel
 
 Requires: %{name}-data = %{version}
 
@@ -20,7 +20,7 @@ Summary: %{name}-data %{version}
 
 %package en
 
-Requires: ncurses-libs libstdc++ libcurl libX11
+Requires: ncurses-libs libstdc++ libcurl libX11 libXft
 Requires: %{name}-data = %{version}
 Summary: %{name}-en %{version}
 
@@ -85,10 +85,10 @@ rm -rf %{buildroot}
 ./bootstrap
 
 %build
-%configure --with-libpath=%{_datadir}/games/%{name}/lib --disable-japanese
+%configure --with-libpath=%{_datadir}/games/%{name}/lib --disable-japanese --enable-xft
 %make_build
 cp src/hengband src/hengband-en
-%configure --with-libpath=%{_datadir}/games/%{name}/lib
+%configure --with-libpath=%{_datadir}/games/%{name}/lib --enable-xft
 %make_build
 
 %install
@@ -154,6 +154,10 @@ exit 0
 %license lib/help/jlicense.txt THIRD-PARTY-NOTICES.txt
 
 %changelog
+* Sun Aug 17 2025 whitehara <white@vx-xv.com>
+- Enable Xft
+- hengband RPM 3.0.1.29(Beta)
+
 * Mon Jun 16 2025 whitehara <white@vx-xv.com>
 - hengband RPM 3.0.1.28(Beta)
 


### PR DESCRIPTION
- hengband.specのバージョンを3.0.1.29に更新
- 同バージョンのrpmをCoprにて配布開始 https://copr.fedorainfracloud.org/coprs/whitehara/hengband/
- 同バージョンのrpmより、Xftを有効化（コンパイル時に`--enable-xft`を追加）