### PR TITLE
[Fix] 強撃武器を装備中にゲームが重くなる

### DIFF
--- a/src/combat/attack-criticality.cpp
+++ b/src/combat/attack-criticality.cpp
@@ -66,9 +66,9 @@ int critical_norm(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, int1
         return dam;
     }
 
-    int k = weight + randint1(650);
+    auto k = weight + randint1(CRITICAL_DIE_SIDES);
     if (impact || (mode == HISSATSU_MAJIN) || (mode == HISSATSU_3DAN)) {
-        k += randint1(650);
+        k += randint1(CRITICAL_DIE_SIDES);
     }
 
     const auto &[critical_dam, msg, battle_sound] = apply_critical_norm_damage(k, dam);

--- a/src/combat/attack-criticality.h
+++ b/src/combat/attack-criticality.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <tuple>
 
+constexpr auto CRITICAL_DIE_SIDES = 650; //<! クリティカル時に武器重量に上乗せするダイスの面数
+
 struct player_attack_type;
 class PlayerType;
 std::tuple<int, std::string, SoundKind> apply_critical_norm_damage(int k, int base_dam, int mult = 1);

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1184,25 +1184,23 @@ int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, i
         i = 0;
     }
 
-    // 通常ダメージdam、武器重量weightでクリティカルが発生した時のクリティカルダメージ期待値
-    auto calc_weight_expect_dam = [](int dam, WEIGHT weight, int mult) {
-        int sum = 0;
-        for (int d = 1; d <= 650; ++d) {
-            int k = weight + d;
-            sum += std::get<0>(apply_critical_norm_damage(k, dam, mult));
-        }
-        return sum / 650;
-    };
-
-    uint32_t num = 0;
+    auto num = 0;
 
     if (impact) {
-        for (int d = 1; d <= 650; ++d) {
-            num += calc_weight_expect_dam(dam, weight + d, mult);
+        // 強撃クリティカル(クリティカル強度: weight + d650 + d650)のときの期待値
+        auto sum = 0;
+        for (auto d = 2; d <= 650 * 2; ++d) { // d650 + d650 で出る 2～1300 について計算する
+            const auto count = (d <= 650 + 1) ? (d - 1) : (650 * 2 - d + 1); // d650 + d650 で出る 650*650 通りのうちdが出るパターンの数
+            sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult)) * count;
         }
-        num /= 650;
+        num = sum / (650 * 650);
     } else {
-        num += calc_weight_expect_dam(dam, weight, mult);
+        // 通常クリティカル(クリティカル強度: weight + d650)のときの期待値
+        auto sum = 0;
+        for (auto d = 1; d <= 650; ++d) {
+            sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult));
+        }
+        num = sum / 650;
     }
 
     int pow = PlayerClass(player_ptr).equals(PlayerClassType::NINJA) ? 4444 : 5000;

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1189,18 +1189,18 @@ int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, i
     if (impact) {
         // 強撃クリティカル(クリティカル強度: weight + d650 + d650)のときの期待値
         auto sum = 0;
-        for (auto d = 2; d <= 650 * 2; ++d) { // d650 + d650 で出る 2～1300 について計算する
-            const auto count = (d <= 650 + 1) ? (d - 1) : (650 * 2 - d + 1); // d650 + d650 で出る 650*650 通りのうちdが出るパターンの数
+        for (auto d = 2; d <= CRITICAL_DIE_SIDES * 2; ++d) { // d650 + d650 で出る 2～1300 について計算する
+            const auto count = (d <= CRITICAL_DIE_SIDES + 1) ? (d - 1) : (CRITICAL_DIE_SIDES * 2 - d + 1); // d650 + d650 で出る 650*650 通りのうちdが出るパターンの数
             sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult)) * count;
         }
-        num = sum / (650 * 650);
+        num = sum / (CRITICAL_DIE_SIDES * CRITICAL_DIE_SIDES);
     } else {
         // 通常クリティカル(クリティカル強度: weight + d650)のときの期待値
         auto sum = 0;
-        for (auto d = 1; d <= 650; ++d) {
+        for (auto d = 1; d <= CRITICAL_DIE_SIDES; ++d) {
             sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult));
         }
-        num = sum / 650;
+        num = sum / CRITICAL_DIE_SIDES;
     }
 
     int pow = PlayerClass(player_ptr).equals(PlayerClassType::NINJA) ? 4444 : 5000;


### PR DESCRIPTION
強撃武器のクリティカル時の期待値計算において650*650通りのパターンそれぞれについて計算するナイーブな実装となっているため、ここがボトルネックとなりゲームの動作が重くなっている。
期待値計算をパターンの分布に基づき効率化することでゲームが重くならないようにする。

注記：このPR適用前後で強撃武器を装備しているときにキャラクタ情報に表示されるダメージ期待値が変わりますが、割り算の切り捨て誤差が原因であり、今回割り算の回数が減ることでむしろ正確な値に近づいたはずです。

Fix #5209 