### PR TITLE
[Feature] クエスト激戦場の報酬調整

### DIFF
--- a/lib/edit/quests/026_KillingFields.txt
+++ b/lib/edit/quests/026_KillingFields.txt
@@ -81,8 +81,8 @@ F:#:GRANITE:8
 # potion of healing
 F:1:FLOOR:12:0:242
 
-# staff of destruction
-F:2:FLOOR:12:0:307
+# Potion of Life
+F:2:FLOOR:12:0:420
 
 
 # Dungeon layout

--- a/lib/edit/towns/02_Telmora.txt
+++ b/lib/edit/towns/02_Telmora.txt
@@ -211,10 +211,10 @@ F:b:BUILDING_1:3:0:0:0:0:NONE:26
 F:b:BUILDING_1:3:0:0:0:0:NONE:26
 
 # Quest 26 rewarding, continue with quest 15,
-# Reward is a Potion of Life
+# Reward is a Staff of Destruction
 ?:[EQU $QUEST26 3]
 F:b:BUILDING_1:3:0:0:0:0:NONE:15
-F:!:FLOOR:3:0:420
+F:!:FLOOR:3:0:307
 
 # Quest 26 finished, continue with quest 15
 ?:[EQU $QUEST26 4]


### PR DESCRIPTION
クエスト激戦場の報酬を破壊の杖に、床落ちを生命の薬に交換した。
破壊の杖は有用なのでマウタウロス討伐を必須にするため。