### PR TITLE
[Fix]  帰還なしのランクエ階でレベルテレポートを読むとクラッシュする #5239

### DIFF
--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -67,7 +67,7 @@ void teleport_level(PlayerType *player_ptr, MONSTER_IDX m_idx)
         see_m = is_seen(player_ptr, monster);
     }
 
-    if (floor.can_teleport_level(m_idx != 0)) {
+    if (floor.can_teleport_level(m_idx <= 0)) {
         if (see_m) {
             msg_print(_("効果がなかった。", "There is no effect."));
         }


### PR DESCRIPTION
fix #5239
レベルテレポート判別式の符号ミスを修正