### PR TITLE
[Fix] MS→破滅2クエスト受注処理の修正

### DIFF
--- a/lib/edit/QuestDefinitionList.txt
+++ b/lib/edit/QuestDefinitionList.txt
@@ -85,7 +85,7 @@
 
 # 破滅のクエスト2
 ?:[EQU $QUEST_NUMBER 21]
-%:quests/021_DoomQuest2.txt 
+%:quests/021_DoomQuest2.txt
 
 # オークのキャンプ
 ?:[EQU $QUEST_NUMBER 22]

--- a/lib/edit/towns/03_Morivant.txt
+++ b/lib/edit/towns/03_Morivant.txt
@@ -104,16 +104,20 @@ F:b:BUILDING_1:3:0:0:0:0:NONE:21
 ?:[AND [EQU $QUEST24 3 4] [LEQ $QUEST19 3] ]
 F:b:BUILDING_1:3
 
+# Quest 24 failed
+?:[EQU $QUEST24 5]
+F:b:BUILDING_1:3:0:0:0:0:NONE:24
+
 # "Quest 24 - The Rise and Fall of Micro$oft" failed
 # "Quest 19 - Doom Quest 1" already finished
 # Continue with "Quest 21 - Doom Quest 2
-?:[AND [EQU $QUEST24 5 6] ] [GEQ $QUEST19 4] ]
+?:[AND [EQU $QUEST24 6] [GEQ $QUEST19 4] ]
 F:b:BUILDING_1:3:0:0:0:0:NONE:21
 
 # "Quest 24 - The Rise and Fall of Micro$oft" failed
 # "Quest 19 - Doom Quest 1" unfinished
 # No new quest available
-?:[AND [EQU $QUEST24 5 6] [LEQ $QUEST19 3] ]
+?:[AND [EQU $QUEST24 6] [LEQ $QUEST19 3] ]
 F:b:BUILDING_1:3
 
 ?:1


### PR DESCRIPTION
#5246の修正。
ついでにMSクエスト失敗時のお小言が聞けなかった件を修正。