### PR TITLE
[Fix] 光源で照らされた永久岩が表示されない

### DIFF
--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -703,7 +703,7 @@ void FloorType::reset_lite_area()
 
 void FloorType::set_lite_at(const Pos2D &pos)
 {
-    if (!this->contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+    if (!this->contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
         return;
     }
 
@@ -719,7 +719,7 @@ void FloorType::set_lite_at(const Pos2D &pos)
 
 void FloorType::set_redraw_at(const Pos2D &pos)
 {
-    if (!this->contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+    if (!this->contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
         return;
     }
 


### PR DESCRIPTION
fix #5234

光源で照らす判定、描写する判定の境界条件に誤りがある。