### PR TITLE
[Feature] 日数経過でブラックマーケットを強化する

### DIFF
--- a/src/store/pricing.cpp
+++ b/src/store/pricing.cpp
@@ -55,12 +55,20 @@ int price_item(PlayerType *player_ptr, int price, int greed, bool flip, StoreSal
         if (adjust < 100) {
             adjust = 100;
         }
-
+        uint64_t p = price;
         if (store_num == StoreSaleType::BLACK) {
-            price = price * 2;
+            const auto level = store_level(store_num);
+            auto mult = 20000UL;
+            const auto BM_LIMIT = 500;
+            for (int i = 1; i < std::min(level, BM_LIMIT); i++) {
+                mult = mult * 101 / 100;
+            }
+            p = p * mult / 10000UL;
         }
+        p = (p * (uint64_t)adjust + 50UL) / 100UL;
+        p = p < INT32_MAX ? p : INT32_MAX;
 
-        price = (int32_t)(((uint32_t)price * (uint32_t)adjust + 50UL) / 100UL);
+        price = (int)p;
     }
 
     if (price <= 0L) {

--- a/src/store/purchase-order.cpp
+++ b/src/store/purchase-order.cpp
@@ -239,7 +239,10 @@ void store_purchase(PlayerType *player_ptr, StoreSaleType store_num)
 
     COMMAND_CODE item_new;
     const auto purchased_item_name = describe_flavor(player_ptr, item, 0);
-    msg_format(_("%s(%c)を購入する。", "Buying %s (%c)."), purchased_item_name.data(), I2A(item_num));
+    const auto item_index = item_num % store_bottom;
+    const auto item_index_char = (item_index > 25) ? toupper(I2A(item_index - 26)) : I2A(item_index);
+
+    msg_format(_("%s(%c)を購入する。", "Buying %s (%c)."), purchased_item_name.data(), item_index_char);
     msg_erase();
 
     const auto &world = AngbandWorld::get_instance();

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -31,4 +31,5 @@ void store_maintenance(PlayerType *player_ptr, int town_num, StoreSaleType store
 void store_init(int town_num, StoreSaleType store_num);
 void store_examine(PlayerType *player_ptr, StoreSaleType store_num);
 int store_check_num(const ItemEntity *o_ptr, StoreSaleType store_num);
+int store_level(StoreSaleType store_num);
 tl::optional<short> input_stock(std::string_view fmt, int min, int max, StoreSaleType store_num);


### PR DESCRIPTION
強化する要素は3つ。
店舗の広さ、アイテムの生成レベル、売値。
仮に1000日を上限とする。要調整。

また、店舗拡張に伴って購入時の文字化けが発生していたので対応。