### PR TITLE
[Fix] 閃光免疫がダメージを0にするよう変更

### DIFF
--- a/src/player/player-status-resist.cpp
+++ b/src/player/player-status-resist.cpp
@@ -240,6 +240,10 @@ PERCENTAGE calc_lite_damage_rate(PlayerType *player_ptr, rate_calc_type_mode mod
 {
     PERCENTAGE per = 100;
 
+    if (has_immune_lite(player_ptr)) {
+        return 0;
+    }
+
     PlayerRace race(player_ptr);
 
     if (race.tr_flags().has(TR_VUL_LITE)) {


### PR DESCRIPTION
これまで内部的に閃光耐性と閃光免疫が同じものであった。
破邪のDEMIGOD変化によって初めてプレイヤーが閃光免疫を獲得することになったので、これに合わせて閃光ダメージ無効を実装する。