### PR TITLE
[Fix] ライトエリア済フロア境界の永久岩を視認したときの挙動を修正

### DIFF
--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -735,7 +735,7 @@ void FloorType::set_redraw_at(const Pos2D &pos)
 
 void FloorType::set_view_at(const Pos2D &pos)
 {
-    if (!this->contains(pos, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
+    if (!this->contains(pos, FloorBoundary::OUTER_WALL_INCLUSIVE)) {
         return;
     }
 


### PR DESCRIPTION
fix #5276
フロア境界の永久岩を視認したときに、ライトエリア済フロアの境界が正しく表示されない不具合を修正しました。