### PR TITLE
[Fix] トラベルコマンド関連のデバッグ

### DIFF
--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -61,7 +61,7 @@ int travel_flow_cost(PlayerType *player_ptr, const Pos2D &pos)
         cost += lava;
     }
 
-    if (grid.is_mark()) {
+    if (!grid.is_hidden()) {
         if (terrain.flags.has(TerrainCharacteristics::DOOR)) {
             cost += 1;
         }

--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -266,6 +266,7 @@ int Travel::get_cost(const Pos2D &pos) const
  */
 void Travel::step(PlayerType *player_ptr)
 {
+
     this->dir = decide_travel_step_dir(player_ptr, this->dir, this->costs);
     if (!this->dir) {
         if (this->state != TravelState::EXECUTING) {
@@ -279,6 +280,9 @@ void Travel::step(PlayerType *player_ptr)
 
     PlayerEnergy(player_ptr).set_player_turn_energy(100);
     exe_movement(player_ptr, this->dir, always_pickup, false);
+    if (this->state == TravelState::STOP) {
+        return;
+    }
     if (player_ptr->get_position() == this->get_goal()) {
         this->reset_goal();
     } else {

--- a/src/cmd-item/cmd-usestaff.cpp
+++ b/src/cmd-item/cmd-usestaff.cpp
@@ -198,7 +198,7 @@ int staff_effect(PlayerType *player_ptr, int sval, bool *use_charge, bool powerf
 
     case SV_STAFF_CURING: {
         ident = true_healing(player_ptr, 0);
-        if (set_shero(player_ptr, 0, true)) {
+        if (set_berserk(player_ptr, 0, true)) {
             ident = true;
         }
         break;
@@ -216,7 +216,7 @@ int staff_effect(PlayerType *player_ptr, int sval, bool *use_charge, bool powerf
             ident = true;
         }
         ident |= restore_mana(player_ptr, false);
-        if (set_shero(player_ptr, 0, true)) {
+        if (set_berserk(player_ptr, 0, true)) {
             ident = true;
         }
         break;

--- a/src/cmd-item/cmd-zaprod.cpp
+++ b/src/cmd-item/cmd-zaprod.cpp
@@ -121,7 +121,7 @@ int rod_effect(PlayerType *player_ptr, int sval, const Direction &dir, bool *use
         if (true_healing(player_ptr, 0)) {
             ident = true;
         }
-        if (set_shero(player_ptr, 0, true)) {
+        if (set_berserk(player_ptr, 0, true)) {
             ident = true;
         }
         break;

--- a/src/core/disturbance.h
+++ b/src/core/disturbance.h
@@ -1,4 +1,4 @@
 #pragma once
 
 class PlayerType;
-void disturb(PlayerType *player_ptr, bool stop_search, bool flush_output);
+void disturb(PlayerType *player_ptr, bool stop_search, bool stop_travel);

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -173,8 +173,8 @@ void reduce_magic_effects_timeout(PlayerType *player_ptr)
         (void)set_hero(player_ptr, player_ptr->hero - 1, true);
     }
 
-    if (player_ptr->shero) {
-        (void)set_shero(player_ptr, player_ptr->shero - 1, true);
+    if (player_ptr->berserk) {
+        (void)set_berserk(player_ptr, player_ptr->berserk - 1, true);
     }
 
     if (player_ptr->blessed) {

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -409,7 +409,7 @@ static void curse_berserk_rage(PlayerType *player_ptr)
     disturb(player_ptr, false, true);
     msg_print(_("ウガァァア！", "RAAAAGHH!"));
     msg_print(_("激怒の発作に襲われた！", "You feel a fit of rage coming over you!"));
-    (void)set_shero(player_ptr, duration, false);
+    (void)set_berserk(player_ptr, duration, false);
     (void)BadStatusSetter(player_ptr).set_fear(0);
 }
 

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -532,7 +532,7 @@ static void rd_player_status(PlayerType *player_ptr)
     rd_energy(player_ptr);
     rd_status(player_ptr);
     player_ptr->hero = rd_s16b();
-    player_ptr->shero = rd_s16b();
+    player_ptr->berserk = rd_s16b();
     player_ptr->shield = rd_s16b();
     player_ptr->blessed = rd_s16b();
     player_ptr->tim_invis = rd_s16b();

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -1,4 +1,5 @@
 #include "mind/mind-force-trainer.h"
+#include "action/travel-execution.h"
 #include "avatar/avatar.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
@@ -179,8 +180,8 @@ bool set_tim_sh_force(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     handle_stuff(player_ptr);

--- a/src/mind/mind-magic-resistance.cpp
+++ b/src/mind/mind-magic-resistance.cpp
@@ -1,4 +1,5 @@
 #include "mind/mind-magic-resistance.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
@@ -45,8 +46,8 @@ bool set_resist_magic(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "mind/mind-mirror-master.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "effect/attribute-types.h"
@@ -282,8 +283,8 @@ bool set_multishadow(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -330,8 +331,8 @@ bool set_dustrobe(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/mspell/mspell-dispel.cpp
+++ b/src/mspell/mspell-dispel.cpp
@@ -44,7 +44,7 @@ static void dispel_player(PlayerType *player_ptr)
     (void)set_blessed(player_ptr, 0, true);
     (void)set_tsuyoshi(player_ptr, 0, true);
     (void)set_hero(player_ptr, 0, true);
-    (void)set_shero(player_ptr, 0, true);
+    (void)set_berserk(player_ptr, 0, true);
     BodyImprovement(player_ptr).set_protection(0, true);
     (void)set_invuln(player_ptr, 0, true);
     (void)set_wraith_form(player_ptr, 0, true);

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -241,7 +241,7 @@ bool dispel_check(PlayerType *player_ptr, MONSTER_IDX m_idx)
     }
 
     PlayerClass pc(player_ptr);
-    if (player_ptr->shero && !pc.equals(PlayerClassType::BERSERKER)) {
+    if (player_ptr->berserk && !pc.equals(PlayerClassType::BERSERKER)) {
         return true;
     }
 

--- a/src/mutation/mutation-processor.cpp
+++ b/src/mutation/mutation-processor.cpp
@@ -71,7 +71,7 @@ void process_world_aux_mutation(PlayerType *player_ptr)
         disturb(player_ptr, false, true);
         msg_print(_("ウガァァア！", "RAAAAGHH!"));
         msg_print(_("激怒の発作に襲われた！", "You feel a fit of rage coming over you!"));
-        (void)set_shero(player_ptr, 10 + randint1(player_ptr->lev), false);
+        (void)set_berserk(player_ptr, 10 + randint1(player_ptr->lev), false);
         (void)bss.set_fear(0);
     }
 

--- a/src/player-info/self-info.cpp
+++ b/src/player-info/self-info.cpp
@@ -355,7 +355,7 @@ void report_magics(PlayerType *player_ptr)
     }
 
     if (is_shero(player_ptr)) {
-        info.emplace_back(report_magics_aux(player_ptr->shero),
+        info.emplace_back(report_magics_aux(player_ptr->berserk),
             _("あなたは戦闘狂だ", "You are in a battle rage"));
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -3118,7 +3118,7 @@ bool is_hero(PlayerType *player_ptr)
 
 bool is_shero(PlayerType *player_ptr)
 {
-    return player_ptr->shero || PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER);
+    return player_ptr->berserk || PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER);
 }
 
 bool is_echizen(PlayerType *player_ptr)

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -1,4 +1,5 @@
 #include "racial/racial-kutar.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
@@ -45,8 +46,8 @@ bool set_leveling(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -182,7 +182,7 @@ void wr_player(PlayerType *player_ptr)
     wr_s16b(player_ptr->invuln);
     wr_s16b(player_ptr->ult_res);
     wr_s16b(player_ptr->hero);
-    wr_s16b(player_ptr->shero);
+    wr_s16b(player_ptr->berserk);
     wr_s16b(player_ptr->shield);
     wr_s16b(player_ptr->blessed);
     wr_s16b(player_ptr->tim_invis);

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -1,4 +1,5 @@
 #include "spell-realm/spells-craft.h"
+#include "action/travel-execution.h"
 #include "avatar/avatar.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
@@ -88,7 +89,7 @@ bool set_ele_attack(PlayerType *player_ptr, uint32_t attack_type, TIME_EFFECT v)
         msg_format(mes, element.data());
     }
 
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, false);
     }
 
@@ -164,8 +165,8 @@ bool set_ele_immune(PlayerType *player_ptr, uint32_t immune_type, TIME_EFFECT v)
         msg_format(_("%sの攻撃を受けつけなくなった！", "For a while, you are immune to %s"), element.data());
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "spell-realm/spells-crusade.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "effect/effect-characteristics.h"
@@ -65,8 +66,8 @@ bool set_tim_sh_holy(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -115,8 +116,8 @@ bool set_tim_eyeeye(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/spell-realm/spells-demon.cpp
+++ b/src/spell-realm/spells-demon.cpp
@@ -1,4 +1,5 @@
 #include "spell-realm/spells-demon.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
@@ -46,8 +47,8 @@ bool set_tim_sh_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -1,4 +1,5 @@
 #include "spell-realm/spells-song.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
@@ -121,8 +122,8 @@ bool set_tim_stealth(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/spell/spells-status.cpp
+++ b/src/spell/spells-status.cpp
@@ -298,7 +298,7 @@ bool life_stream(PlayerType *player_ptr, bool message, bool virtue_change)
     (void)bss.set_cut(0);
     (void)bss.set_paralysis(0);
     (void)restore_all_status(player_ptr);
-    (void)set_shero(player_ptr, 0, true);
+    (void)set_berserk(player_ptr, 0, true);
     handle_stuff(player_ptr);
     hp_player(player_ptr, 5000);
 
@@ -330,7 +330,7 @@ bool berserk(PlayerType *player_ptr, int base)
         ident = true;
     }
 
-    if (set_shero(player_ptr, player_ptr->shero + randint1(base) + base, false)) {
+    if (set_berserk(player_ptr, player_ptr->berserk + randint1(base) + base, false)) {
         ident = true;
     }
 
@@ -357,7 +357,7 @@ bool cure_light_wounds(PlayerType *player_ptr, int pow)
         ident = true;
     }
 
-    if (set_shero(player_ptr, 0, true)) {
+    if (set_berserk(player_ptr, 0, true)) {
         ident = true;
     }
 
@@ -384,7 +384,7 @@ bool cure_serious_wounds(PlayerType *player_ptr, int pow)
         ident = true;
     }
 
-    if (set_shero(player_ptr, 0, true)) {
+    if (set_berserk(player_ptr, 0, true)) {
         ident = true;
     }
 
@@ -419,7 +419,7 @@ bool cure_critical_wounds(PlayerType *player_ptr, int pow)
         ident = true;
     }
 
-    if (set_shero(player_ptr, 0, true)) {
+    if (set_berserk(player_ptr, 0, true)) {
         ident = true;
     }
 
@@ -604,7 +604,7 @@ bool cosmic_cast_off(PlayerType *player_ptr, ItemEntity **o_ptr_ptr)
     (void)set_hero(player_ptr, player_ptr->hero + t, false);
     (void)set_blessed(player_ptr, player_ptr->blessed + t, false);
     (void)mod_acceleration(player_ptr, t, false);
-    (void)set_shero(player_ptr, player_ptr->shero + t, false);
+    (void)set_berserk(player_ptr, player_ptr->berserk + t, false);
     if (PlayerClass(player_ptr).equals(PlayerClassType::FORCETRAINER)) {
         set_current_ki(player_ptr, true, player_ptr->lev * 5 + 190);
         msg_print(_("気が爆発寸前になった。", "Your force absorbs the explosion."));

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -1,4 +1,5 @@
 #include "status/body-improvement.h"
+#include "action/travel-execution.h"
 #include "avatar/avatar.h"
 #include "core/disturbance.h"
 #include "core/speed-table.h"
@@ -68,8 +69,8 @@ void BodyImprovement::set_protection(short v, bool is_decrease)
         return;
     }
 
-    if (disturb_state) {
-        disturb(this->player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     handle_stuff(this->player_ptr);
@@ -131,8 +132,8 @@ bool set_invuln(PlayerType *player_ptr, short v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -179,8 +180,8 @@ bool set_tim_regen(PlayerType *player_ptr, short v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -227,8 +228,8 @@ bool set_tim_reflect(PlayerType *player_ptr, short v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -275,8 +276,8 @@ bool set_pass_wall(PlayerType *player_ptr, short v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -323,8 +324,8 @@ bool set_tim_emission(PlayerType *player_ptr, short v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -371,8 +372,8 @@ bool set_tim_exorcism(PlayerType *player_ptr, short v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -1,4 +1,5 @@
 #include "status/buff-setter.h"
+#include "action/travel-execution.h"
 #include "avatar/avatar.h"
 #include "core/disturbance.h"
 #include "core/speed-table.h"
@@ -43,7 +44,7 @@ void reset_tim_flags(PlayerType *player_ptr)
     player_ptr->invuln = 0; /* Timed -- Invulnerable */
     player_ptr->ult_res = 0;
     player_ptr->hero = 0; /* Timed -- Heroism */
-    player_ptr->shero = 0; /* Timed -- Super Heroism */
+    player_ptr->berserk = 0; /* Timed -- Super Heroism */
     player_ptr->shield = 0; /* Timed -- Shield Spell */
     player_ptr->blessed = 0; /* Timed -- Blessed */
     player_ptr->tim_invis = 0; /* Timed -- Invisibility */
@@ -153,8 +154,8 @@ bool set_acceleration(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
     RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
@@ -205,8 +206,8 @@ bool set_shield(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -253,8 +254,8 @@ bool set_magicdef(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -301,8 +302,8 @@ bool set_blessed(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -349,8 +350,8 @@ bool set_hero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     static constexpr auto flags = {
@@ -408,7 +409,7 @@ bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_i
         return false;
     }
 
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, true);
     }
 
@@ -433,7 +434,7 @@ bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_i
  * @param do_dec FALSEの場合現在の継続時間より長い値のみ上書きする
  * @return ステータスに影響を及ぼす変化があった場合TRUEを返す。
  */
-bool set_shero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
+bool set_berserk(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
 {
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
@@ -449,30 +450,30 @@ bool set_shero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     if (v) {
-        if (player_ptr->shero && !do_dec) {
-            if (player_ptr->shero > v) {
+        if (player_ptr->berserk && !do_dec) {
+            if (player_ptr->berserk > v) {
                 return false;
             }
-        } else if (!player_ptr->shero) {
+        } else if (!player_ptr->berserk) {
             msg_print(_("殺戮マシーンになった気がする！", "You feel like a killing machine!"));
             notice = true;
         }
     } else {
-        if (player_ptr->shero) {
+        if (player_ptr->berserk) {
             msg_print(_("野蛮な気持ちが消え失せた。", "You feel less berserk."));
             notice = true;
         }
     }
 
-    player_ptr->shero = v;
+    player_ptr->berserk = v;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     static constexpr auto flags = {
@@ -537,8 +538,8 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -591,8 +592,8 @@ bool set_tsuyoshi(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     static constexpr auto flags = {

--- a/src/status/buff-setter.h
+++ b/src/status/buff-setter.h
@@ -12,6 +12,6 @@ bool set_magicdef(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_blessed(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_hero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_idx, bool do_dec);
-bool set_shero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
+bool set_berserk(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);
 bool set_tsuyoshi(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec);

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -1,4 +1,5 @@
 #include "status/element-resistance.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
@@ -51,7 +52,7 @@ bool set_oppose_acid(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, true);
     }
 
@@ -98,7 +99,7 @@ bool set_oppose_elec(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, true);
     }
 
@@ -147,7 +148,7 @@ bool set_oppose_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, true);
     }
 
@@ -193,7 +194,7 @@ bool set_oppose_cold(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, true);
     }
 
@@ -243,7 +244,7 @@ bool set_oppose_pois(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, true);
     }
 

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -52,7 +52,7 @@ bool set_oppose_acid(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (disturb_state) {
-        disturb(player_ptr, false, false);
+        disturb(player_ptr, false, true);
     }
 
     handle_stuff(player_ptr);
@@ -99,7 +99,7 @@ bool set_oppose_elec(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (disturb_state) {
-        disturb(player_ptr, false, false);
+        disturb(player_ptr, false, true);
     }
 
     handle_stuff(player_ptr);
@@ -148,7 +148,7 @@ bool set_oppose_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (disturb_state) {
-        disturb(player_ptr, false, false);
+        disturb(player_ptr, false, true);
     }
 
     handle_stuff(player_ptr);
@@ -194,7 +194,7 @@ bool set_oppose_cold(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (disturb_state) {
-        disturb(player_ptr, false, false);
+        disturb(player_ptr, false, true);
     }
 
     handle_stuff(player_ptr);
@@ -244,7 +244,7 @@ bool set_oppose_pois(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
 
     RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (disturb_state) {
-        disturb(player_ptr, false, false);
+        disturb(player_ptr, false, true);
     }
 
     handle_stuff(player_ptr);

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -1,4 +1,5 @@
 #include "status/temporary-resistance.h"
+#include "action/travel-execution.h"
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
@@ -45,7 +46,7 @@ bool set_tim_levitation(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
         disturb(player_ptr, false, true);
     }
 
@@ -87,8 +88,8 @@ bool set_ultimate_res(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -131,8 +132,8 @@ bool set_tim_res_nether(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -172,8 +173,8 @@ bool set_tim_res_lite(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -213,8 +214,8 @@ bool set_tim_res_dark(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -251,8 +252,8 @@ bool set_tim_res_fear(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (!notice) {
         return false;
     }
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);
@@ -291,8 +292,8 @@ bool set_tim_res_time(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
@@ -329,8 +330,8 @@ bool set_tim_imm_dark(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     if (!notice) {
         return false;
     }
-    if (disturb_state) {
-        disturb(player_ptr, false, false);
+    if (disturb_state || Travel::get_instance().is_ongoing()) {
+        disturb(player_ptr, false, true);
     }
     rfu.set_flag(StatusRecalculatingFlag::BONUS);
     handle_stuff(player_ptr);

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -46,7 +46,7 @@ bool set_tim_levitation(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     }
 
     if (disturb_state) {
-        disturb(player_ptr, false, false);
+        disturb(player_ptr, false, true);
     }
 
     rfu.set_flag(StatusRecalculatingFlag::BONUS);

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -125,6 +125,11 @@ bool Grid::is_mark() const
     return any_bits(this->info, CAVE_MARK);
 }
 
+bool Grid::is_hidden() const
+{
+    return this->mimic > 0;
+}
+
 bool Grid::is_mirror() const
 {
     return this->is_object() && TerrainList::get_instance().get_terrain(this->mimic).flags.has(TerrainCharacteristics::MIRROR);

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -82,6 +82,7 @@ public:
     bool is_view() const;
     bool is_object() const;
     bool is_mark() const;
+    bool is_hidden() const;
     bool is_mirror() const;
     bool is_rune_protection() const;
     bool is_rune_explosion() const;

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -92,7 +92,7 @@ public:
     TIME_EFFECT invuln{}; /* Timed -- Invulnerable */
     TIME_EFFECT ult_res{}; /* Timed -- Ultimate Resistance */
     TIME_EFFECT hero{}; /* Timed -- Heroism */
-    TIME_EFFECT shero{}; /* Timed -- Super Heroism */
+    TIME_EFFECT berserk{}; /* Timed -- Super Heroism */
     TIME_EFFECT shield{}; /* Timed -- Shield Spell */
     TIME_EFFECT blessed{}; /* Timed -- Blessed */
     TIME_EFFECT tim_invis{}; /* Timed -- See Invisible */


### PR DESCRIPTION
fix #5280
fix #5212

一時的浮遊、一時元素耐性が切れたときにトラベルを中断するように修正。
警告による移動キャンセル時に正しくトラベルが中断されるように修正。

fix https://github.com/hengband/hengband/issues/5218
「未発見の罠・扉」を判別するフラグが正しくない