### PR TITLE
[Refactor] モンスターの `set_monster_*()` 関数シグネチャを `PlayerType *` から `FloorType &` に差し替え

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -160,7 +160,7 @@ void exe_movement(PlayerType *player_ptr, const Direction &dir, bool do_pickup, 
         can_cast &= !is_stunned;
         can_cast &= player_ptr->muta.has_not(PlayerMutationType::BERS_RAGE) || !is_shero(player_ptr);
         if (!monster.is_hostile() && can_cast && pattern_seq(player_ptr, pos) && (p_can_enter || p_can_kill_walls)) {
-            (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+            (void)set_monster_csleep(*player_ptr->current_floor_ptr, grid.m_idx, 0);
             m_name = monster_desc(player_ptr, monster, 0);
             if (monster.ml) {
                 if (!is_hallucinated) {

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -233,7 +233,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
             msg_format(_("そっちには何か恐いものがいる！", "There is something scary in your way!"));
         }
 
-        (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+        (void)set_monster_csleep(*player_ptr->current_floor_ptr, grid.m_idx, 0);
         return false;
     }
 

--- a/src/cmd-action/cmd-pet.cpp
+++ b/src/cmd-action/cmd-pet.cpp
@@ -262,7 +262,7 @@ bool do_cmd_riding(PlayerType *player_ptr, bool force)
 
         if (monster.is_asleep()) {
             const auto m_name = monster_desc(player_ptr, monster, 0);
-            (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+            (void)set_monster_csleep(*player_ptr->current_floor_ptr, grid.m_idx, 0);
             msg_format(_("%sを起こした。", "You have woken %s up."), m_name.data());
         }
 

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -172,12 +172,12 @@ void process_player(PlayerType *player_ptr)
         const auto &monrace = monster.get_monrace();
         if (monster.is_asleep()) {
             const auto m_name = monster_desc(player_ptr, monster, 0);
-            (void)set_monster_csleep(player_ptr, player_ptr->riding, 0);
+            (void)set_monster_csleep(*player_ptr->current_floor_ptr, player_ptr->riding, 0);
             msg_format(_("%s^を起こした。", "You have woken %s up."), m_name.data());
         }
 
         if (monster.is_stunned()) {
-            if (set_monster_stunned(player_ptr, player_ptr->riding,
+            if (set_monster_stunned(*player_ptr->current_floor_ptr, player_ptr->riding,
                     (randint0(monrace.level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_stun() - 1))) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^を朦朧状態から立ち直らせた。", "%s^ is no longer stunned."), m_name.data());
@@ -185,7 +185,7 @@ void process_player(PlayerType *player_ptr)
         }
 
         if (monster.is_confused()) {
-            if (set_monster_confused(player_ptr, player_ptr->riding,
+            if (set_monster_confused(*player_ptr->current_floor_ptr, player_ptr->riding,
                     (randint0(monrace.level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_confusion() - 1))) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^を混乱状態から立ち直らせた。", "%s^ is no longer confused."), m_name.data());
@@ -193,7 +193,7 @@ void process_player(PlayerType *player_ptr)
         }
 
         if (monster.is_fearful()) {
-            if (set_monster_monfear(player_ptr, player_ptr->riding,
+            if (set_monster_monfear(*player_ptr->current_floor_ptr, player_ptr->riding,
                     (randint0(monrace.level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_fear() - 1))) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^を恐怖から立ち直らせた。", "%s^ is no longer fearful."), m_name.data());

--- a/src/effect/effect-monster-charm.cpp
+++ b/src/effect/effect-monster-charm.cpp
@@ -326,7 +326,7 @@ static bool effect_monster_crusade_domination(PlayerType *player_ptr, EffectMons
 
     if (em_ptr->m_ptr->is_pet()) {
         em_ptr->note = _("の動きが速くなった。", " starts moving faster.");
-        (void)set_monster_fast(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
+        (void)set_monster_fast(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
         return true;
     }
 
@@ -346,7 +346,7 @@ static bool effect_monster_crusade_domination(PlayerType *player_ptr, EffectMons
 
     em_ptr->note = _("を支配した。", " is tamed!");
     set_pet(player_ptr, *em_ptr->m_ptr);
-    (void)set_monster_fast(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
+    (void)set_monster_fast(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100);
     if (is_original_ap_and_seen(player_ptr, *em_ptr->m_ptr)) {
         em_ptr->r_ptr->r_kind_flags.set(MonsterKindType::GOOD);
     }

--- a/src/effect/effect-monster-oldies.cpp
+++ b/src/effect/effect-monster-oldies.cpp
@@ -72,7 +72,7 @@ ProcessResult effect_monster_star_heal(PlayerType *player_ptr, EffectMonster *em
         em_ptr->obvious = true;
     }
 
-    (void)set_monster_csleep(player_ptr, em_ptr->g_ptr->m_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
 
     if (em_ptr->m_ptr->maxhp < em_ptr->m_ptr->max_maxhp) {
         if (em_ptr->seen_msg) {
@@ -128,7 +128,7 @@ static void effect_monster_old_heal_recovery(PlayerType *player_ptr, EffectMonst
             msg_format(_("%s^は朦朧状態から立ち直った。", "%s^ is no longer stunned."), em_ptr->m_name);
         }
 
-        (void)set_monster_stunned(player_ptr, em_ptr->g_ptr->m_idx, 0);
+        (void)set_monster_stunned(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
     }
 
     if (em_ptr->m_ptr->is_confused()) {
@@ -136,7 +136,7 @@ static void effect_monster_old_heal_recovery(PlayerType *player_ptr, EffectMonst
             msg_format(_("%s^は混乱から立ち直った。", "%s^ is no longer confused."), em_ptr->m_name);
         }
 
-        (void)set_monster_confused(player_ptr, em_ptr->g_ptr->m_idx, 0);
+        (void)set_monster_confused(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
     }
 
     if (em_ptr->m_ptr->is_fearful()) {
@@ -144,7 +144,7 @@ static void effect_monster_old_heal_recovery(PlayerType *player_ptr, EffectMonst
             msg_print(_(format("%s^は勇気を取り戻した。", em_ptr->m_name), format("%s^ recovers %s courage.", em_ptr->m_name, em_ptr->m_poss)));
         }
 
-        (void)set_monster_monfear(player_ptr, em_ptr->g_ptr->m_idx, 0);
+        (void)set_monster_monfear(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
     }
 }
 
@@ -155,7 +155,7 @@ ProcessResult effect_monster_old_heal(PlayerType *player_ptr, EffectMonster *em_
     }
 
     /* Wake up */
-    (void)set_monster_csleep(player_ptr, em_ptr->g_ptr->m_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
     effect_monster_old_heal_recovery(player_ptr, em_ptr);
     if (em_ptr->m_ptr->hp < MONSTER_MAXHP) {
         em_ptr->m_ptr->hp += em_ptr->dam;
@@ -188,7 +188,7 @@ ProcessResult effect_monster_old_speed(PlayerType *player_ptr, EffectMonster *em
         em_ptr->obvious = true;
     }
 
-    if (set_monster_fast(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100)) {
+    if (set_monster_fast(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_acceleration() + 100)) {
         em_ptr->note = _("の動きが速くなった。", " starts moving faster.");
     }
 
@@ -222,7 +222,7 @@ ProcessResult effect_monster_old_slow(PlayerType *player_ptr, EffectMonster *em_
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (set_monster_slow(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+    if (set_monster_slow(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
         em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
     }
 

--- a/src/effect/effect-monster-resist-hurt.cpp
+++ b/src/effect/effect-monster-resist-hurt.cpp
@@ -500,7 +500,7 @@ ProcessResult effect_monster_inertial(PlayerType *player_ptr, EffectMonster *em_
         return ProcessResult::PROCESS_CONTINUE;
     }
 
-    if (set_monster_slow(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+    if (set_monster_slow(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
         em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
     }
 
@@ -566,7 +566,7 @@ static void effect_monster_gravity_slow(PlayerType *player_ptr, EffectMonster *e
         return;
     }
 
-    if (set_monster_slow(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+    if (set_monster_slow(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
         em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
     }
     em_ptr->obvious = true;
@@ -752,7 +752,7 @@ ProcessResult effect_monster_abyss(PlayerType *player_ptr, EffectMonster *em_ptr
         em_ptr->note = _("は深淵に囚われていく。", " is trapped in the abyss.");
         em_ptr->note_dies = _("は深淵に堕ちてしまった。", " has fallen into the abyss.");
 
-        if (one_in_(3) && set_monster_slow(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+        if (one_in_(3) && set_monster_slow(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
             em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
         }
     }

--- a/src/effect/effect-monster-spirit.cpp
+++ b/src/effect/effect-monster-spirit.cpp
@@ -159,7 +159,7 @@ ProcessResult effect_monster_brain_smash(PlayerType *player_ptr, EffectMonster *
             em_ptr->do_stun = randint0(8) + 8;
         }
 
-        (void)set_monster_slow(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 10);
+        (void)set_monster_slow(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 10);
     }
 
     return ProcessResult::PROCESS_CONTINUE;

--- a/src/effect/effect-monster-switcher.cpp
+++ b/src/effect/effect-monster-switcher.cpp
@@ -190,7 +190,7 @@ ProcessResult effect_monster_engetsu(PlayerType *player_ptr, EffectMonster *em_p
         switch (randint0(4)) {
         case 0:
             if (em_ptr->r_ptr->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-                if (set_monster_slow(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
+                if (set_monster_slow(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_deceleration() + 50)) {
                     em_ptr->note = _("の動きが遅くなった。", " starts moving slower.");
                 }
                 done = true;

--- a/src/effect/effect-monster.cpp
+++ b/src/effect/effect-monster.cpp
@@ -221,7 +221,7 @@ static void effect_damage_makes_sleep(PlayerType *player_ptr, EffectMonster *em_
     }
 
     if (em_ptr->do_sleep) {
-        (void)set_monster_csleep(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
+        (void)set_monster_csleep(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
     }
 }
 
@@ -244,7 +244,7 @@ static bool deal_effect_damage_from_monster(PlayerType *player_ptr, EffectMonste
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
     }
 
-    (void)set_monster_csleep(player_ptr, em_ptr->g_ptr->m_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, 0);
     em_ptr->m_ptr->hp -= em_ptr->dam;
     if (em_ptr->m_ptr->hp < 0) {
         effect_damage_killed_pet(player_ptr, em_ptr);
@@ -353,7 +353,7 @@ static void deal_effect_damage_to_monster(PlayerType *player_ptr, EffectMonster 
     }
 
     if (em_ptr->do_sleep) {
-        (void)set_monster_csleep(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
+        (void)set_monster_csleep(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->do_sleep);
     }
 }
 
@@ -427,7 +427,7 @@ static void effect_damage_piles_stun(PlayerType *player_ptr, EffectMonster *em_p
         turns = em_ptr->do_stun;
     }
 
-    (void)set_monster_stunned(player_ptr, em_ptr->g_ptr->m_idx, turns);
+    (void)set_monster_stunned(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, turns);
     em_ptr->get_angry = true;
 }
 
@@ -456,7 +456,7 @@ static void effect_damage_piles_confusion(PlayerType *player_ptr, EffectMonster 
         turns = em_ptr->do_conf;
     }
 
-    (void)set_monster_confused(player_ptr, em_ptr->g_ptr->m_idx, turns);
+    (void)set_monster_confused(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, turns);
     em_ptr->get_angry = true;
 }
 
@@ -474,7 +474,7 @@ static void effect_damage_piles_fear(PlayerType *player_ptr, EffectMonster *em_p
         return;
     }
 
-    (void)set_monster_monfear(player_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_fear() + em_ptr->do_fear);
+    (void)set_monster_monfear(*player_ptr->current_floor_ptr, em_ptr->g_ptr->m_idx, em_ptr->m_ptr->get_remaining_fear() + em_ptr->do_fear);
     em_ptr->get_angry = true;
 }
 

--- a/src/floor/floor-changer.cpp
+++ b/src/floor/floor-changer.cpp
@@ -276,12 +276,12 @@ static void reset_unique_by_floor_change(PlayerType *player_ptr)
 
         if (!monster.is_pet()) {
             monster.hp = monster.maxhp = monster.max_maxhp;
-            (void)set_monster_fast(player_ptr, i, 0);
-            (void)set_monster_slow(player_ptr, i, 0);
-            (void)set_monster_stunned(player_ptr, i, 0);
-            (void)set_monster_confused(player_ptr, i, 0);
-            (void)set_monster_monfear(player_ptr, i, 0);
-            (void)set_monster_invulner(player_ptr, i, 0, false);
+            (void)set_monster_fast(floor, i, 0);
+            (void)set_monster_slow(floor, i, 0);
+            (void)set_monster_stunned(floor, i, 0);
+            (void)set_monster_confused(floor, i, 0);
+            (void)set_monster_monfear(floor, i, 0);
+            (void)set_monster_invulner(floor, i, 0, false);
         }
 
         const auto &monrace = monster.get_real_monrace();

--- a/src/melee/melee-postprocess.cpp
+++ b/src/melee/melee-postprocess.cpp
@@ -196,7 +196,7 @@ static void cancel_fear_by_pain(PlayerType *player_ptr, mam_pp_type *mam_pp_ptr)
 {
     const auto &m_ref = *mam_pp_ptr->m_ptr;
     const auto dam = mam_pp_ptr->dam;
-    if (!m_ref.is_fearful() || (dam <= 0) || !set_monster_monfear(player_ptr, mam_pp_ptr->m_idx, m_ref.get_remaining_fear() - randint1(dam / 4))) {
+    if (!m_ref.is_fearful() || (dam <= 0) || !set_monster_monfear(*player_ptr->current_floor_ptr, mam_pp_ptr->m_idx, m_ref.get_remaining_fear() - randint1(dam / 4))) {
         return;
     }
 
@@ -223,7 +223,7 @@ static void make_monster_fear(PlayerType *player_ptr, mam_pp_type *mam_pp_ptr)
 
     *(mam_pp_ptr->fear) = true;
     (void)set_monster_monfear(
-        player_ptr, mam_pp_ptr->m_idx, (randint1(10) + (((mam_pp_ptr->dam >= mam_pp_ptr->m_ptr->hp) && (percentage > 7)) ? 20 : ((11 - percentage) * 5))));
+        *player_ptr->current_floor_ptr, mam_pp_ptr->m_idx, (randint1(10) + (((mam_pp_ptr->dam >= mam_pp_ptr->m_ptr->hp) && (percentage > 7)) ? 20 : ((11 - percentage) * 5))));
 }
 
 /*!
@@ -265,7 +265,7 @@ void mon_take_hit_mon(PlayerType *player_ptr, MONSTER_IDX m_idx, int dam, bool *
     mam_pp_type tmp_mam_pp(player_ptr, m_idx, dam, dead, fear, note, src_idx);
     mam_pp_type *mam_pp_ptr = &tmp_mam_pp;
     prepare_redraw(mam_pp_ptr);
-    (void)set_monster_csleep(player_ptr, m_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, m_idx, 0);
 
     if (monster.is_riding()) {
         disturb(player_ptr, true, true);

--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -338,7 +338,7 @@ void describe_monster_missed_monster(PlayerType *player_ptr, mam_type *mam_ptr)
     case RaceBlowMethodType::CRUSH:
     case RaceBlowMethodType::ENGULF:
     case RaceBlowMethodType::CHARGE: {
-        (void)set_monster_csleep(player_ptr, mam_ptr->t_idx, 0);
+        (void)set_monster_csleep(*player_ptr->current_floor_ptr, mam_ptr->t_idx, 0);
         if (mam_ptr->see_m) {
 #ifdef JP
             msg_format("%sは%s^の攻撃をかわした。", mam_ptr->t_name, mam_ptr->m_name);

--- a/src/melee/monster-attack-monster.cpp
+++ b/src/melee/monster-attack-monster.cpp
@@ -239,7 +239,7 @@ static void process_melee(PlayerType *player_ptr, mam_type *mam_ptr)
         return;
     }
 
-    (void)set_monster_csleep(player_ptr, mam_ptr->t_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, mam_ptr->t_idx, 0);
     redraw_health_bar(mam_ptr);
     describe_melee_method(player_ptr, mam_ptr);
     describe_silly_melee(mam_ptr);
@@ -277,7 +277,7 @@ static void explode_monster_by_melee(PlayerType *player_ptr, mam_type *mam_ptr)
     }
 
     sound(SoundKind::EXPLODE);
-    (void)set_monster_invulner(player_ptr, mam_ptr->m_idx, 0, false);
+    (void)set_monster_invulner(*player_ptr->current_floor_ptr, mam_ptr->m_idx, 0, false);
     mon_take_hit_mon(player_ptr, mam_ptr->m_idx, mam_ptr->m_ptr->hp + 1, &mam_ptr->dead, &mam_ptr->fear,
         _("は爆発して粉々になった。", " explodes into tiny shreds."), mam_ptr->m_idx);
     mam_ptr->blinked = false;

--- a/src/mind/mind-samurai.cpp
+++ b/src/mind/mind-samurai.cpp
@@ -502,7 +502,7 @@ void mineuchi(PlayerType *player_ptr, player_attack_type *pa_ptr)
         msg_format(_("%s はもうろうとした。", "%s is dazed."), pa_ptr->m_name);
     }
 
-    (void)set_monster_stunned(player_ptr, pa_ptr->g_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + tmp);
+    (void)set_monster_stunned(*player_ptr->current_floor_ptr, pa_ptr->g_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + tmp);
 }
 
 /*!

--- a/src/mind/monk-attack.cpp
+++ b/src/mind/monk-attack.cpp
@@ -230,7 +230,7 @@ static void print_stun_effect(PlayerType *player_ptr, player_attack_type *pa_ptr
     const auto &monrace = pa_ptr->m_ptr->get_monrace();
     if (stun_effect && ((pa_ptr->attack_damage + player_ptr->to_d[pa_ptr->hand]) < pa_ptr->m_ptr->hp)) {
         if (player_ptr->lev > randint1(monrace.level + resist_stun + 10)) {
-            if (set_monster_stunned(player_ptr, pa_ptr->g_ptr->m_idx, stun_effect + pa_ptr->m_ptr->get_remaining_stun())) {
+            if (set_monster_stunned(*player_ptr->current_floor_ptr, pa_ptr->g_ptr->m_idx, stun_effect + pa_ptr->m_ptr->get_remaining_stun())) {
                 msg_format(_("%s^はフラフラになった。", "%s^ is stunned."), pa_ptr->m_name);
             } else {
                 msg_format(_("%s^はさらにフラフラになった。", "%s^ is more stunned."), pa_ptr->m_name);

--- a/src/monster-attack/monster-attack-processor.cpp
+++ b/src/monster-attack/monster-attack-processor.cpp
@@ -143,7 +143,7 @@ bool process_monster_attack_to_monster(PlayerType *player_ptr, turn_flags *turn_
     if (do_move_body) {
         turn_flags_ptr->do_move = true;
         turn_flags_ptr->did_move_body = true;
-        (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+        (void)set_monster_csleep(*player_ptr->current_floor_ptr, grid.m_idx, 0);
     }
 
     return false;

--- a/src/monster-floor/monster-remover.cpp
+++ b/src/monster-floor/monster-remover.cpp
@@ -32,25 +32,25 @@ void delete_monster_idx(PlayerType *player_ptr, short m_idx)
     }
 
     if (monster.is_asleep()) {
-        (void)set_monster_csleep(player_ptr, m_idx, 0);
+        (void)set_monster_csleep(floor, m_idx, 0);
     }
     if (monster.is_accelerated()) {
-        (void)set_monster_fast(player_ptr, m_idx, 0);
+        (void)set_monster_fast(floor, m_idx, 0);
     }
     if (monster.is_decelerated()) {
-        (void)set_monster_slow(player_ptr, m_idx, 0);
+        (void)set_monster_slow(floor, m_idx, 0);
     }
     if (monster.is_stunned()) {
-        (void)set_monster_stunned(player_ptr, m_idx, 0);
+        (void)set_monster_stunned(floor, m_idx, 0);
     }
     if (monster.is_confused()) {
-        (void)set_monster_confused(player_ptr, m_idx, 0);
+        (void)set_monster_confused(floor, m_idx, 0);
     }
     if (monster.is_fearful()) {
-        (void)set_monster_monfear(player_ptr, m_idx, 0);
+        (void)set_monster_monfear(floor, m_idx, 0);
     }
     if (monster.is_invulnerable()) {
-        (void)set_monster_invulner(player_ptr, m_idx, 0, false);
+        (void)set_monster_invulner(floor, m_idx, 0, false);
     }
 
     const auto target_m_idx = Target::get_last_target().get_m_idx();

--- a/src/monster-floor/one-monster-placer.cpp
+++ b/src/monster-floor/one-monster-placer.cpp
@@ -337,7 +337,7 @@ tl::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, 
     monster.mtimed[MonsterTimedEffect::SLEEP] = 0;
     if (any_bits(mode, PM_ALLOW_SLEEP) && new_monrace.sleep && !ironman_nightmare) {
         const auto val = new_monrace.sleep;
-        (void)set_monster_csleep(player_ptr, grid.m_idx, (val * 2) + randint1(val * 10));
+        (void)set_monster_csleep(floor, grid.m_idx, (val * 2) + randint1(val * 10));
     }
 
     if (new_monrace.misc_flags.has(MonsterMiscType::FORCE_MAXHP)) {
@@ -363,7 +363,7 @@ tl::optional<MONSTER_IDX> place_monster_one(PlayerType *player_ptr, POSITION y, 
     monster.set_individual_speed(floor.inside_arena);
 
     if (any_bits(mode, PM_HASTE)) {
-        (void)set_monster_fast(player_ptr, grid.m_idx, 100);
+        (void)set_monster_fast(floor, grid.m_idx, 100);
     }
 
     if (!ironman_nightmare) {

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -118,7 +118,7 @@ bool MonsterDamageProcessor::genocide_chaos_patron()
     }
 
     this->set_redraw();
-    (void)set_monster_csleep(this->player_ptr, this->m_idx, 0);
+    (void)set_monster_csleep(*this->player_ptr->current_floor_ptr, this->m_idx, 0);
     set_superstealth(this->player_ptr, false);
 
     return this->m_idx == 0;
@@ -414,7 +414,7 @@ void MonsterDamageProcessor::add_monster_fear()
     const auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
     if (monster.is_fearful() && (this->dam > 0)) {
         auto fear_remining = monster.get_remaining_fear() - randint1(this->dam);
-        if (set_monster_monfear(this->player_ptr, this->m_idx, fear_remining)) {
+        if (set_monster_monfear(*this->player_ptr->current_floor_ptr, this->m_idx, fear_remining)) {
             *this->fear = false;
         }
     }
@@ -432,5 +432,5 @@ void MonsterDamageProcessor::add_monster_fear()
     *this->fear = true;
     auto fear_condition = (this->dam >= monster.hp) && (percentage > 7);
     auto fear_value = randint1(10) + (fear_condition ? 20 : (11 - percentage) * 5);
-    (void)set_monster_monfear(this->player_ptr, this->m_idx, fear_value);
+    (void)set_monster_monfear(*this->player_ptr->current_floor_ptr, this->m_idx, fear_value);
 }

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -373,7 +373,7 @@ bool awake_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
         return false;
     }
 
-    (void)set_monster_csleep(player_ptr, m_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, m_idx, 0);
     if (monster.ml) {
         const auto m_name = monster_desc(player_ptr, monster, 0);
         msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
@@ -595,7 +595,7 @@ bool process_monster_fear(PlayerType *player_ptr, turn_flags *turn_flags_ptr, MO
         return false;
     }
 
-    (void)set_monster_monfear(player_ptr, m_idx, 0);
+    (void)set_monster_monfear(*player_ptr->current_floor_ptr, m_idx, 0);
     if (!turn_flags_ptr->see_m) {
         return true;
     }

--- a/src/monster/monster-status-setter.cpp
+++ b/src/monster/monster-status-setter.cpp
@@ -61,14 +61,13 @@ void anger_monster(PlayerType *player_ptr, MonsterEntity &monster)
 
 /*!
  * @brief モンスターの睡眠状態値をセットする。0で起きる
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param m_idx モンスター参照ID
  * @param v セットする値
  * @return 別途更新処理が必要な場合TRUEを返す
  */
-bool set_monster_csleep(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
+bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     bool notice = false;
     v = (v > 10000) ? 10000 : (v < 0) ? 0
@@ -107,14 +106,13 @@ bool set_monster_csleep(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
 
 /*!
  * @brief モンスターの加速状態値をセット
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param m_idx モンスター参照ID
  * @param v セットする値
  * @return 別途更新処理が必要な場合TRUEを返す
  */
-bool set_monster_fast(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
+bool set_monster_fast(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     bool notice = false;
     v = (v > 200) ? 200 : (v < 0) ? 0
@@ -136,7 +134,7 @@ bool set_monster_fast(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
         return false;
     }
 
-    if (monster.is_riding() && !player_ptr->leaving) {
+    if (monster.is_riding()) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 
@@ -145,14 +143,13 @@ bool set_monster_fast(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
 
 /*
  * @brief モンスターの原則状態値をセット
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param m_idx モンスター参照ID
  * @param v セットする値
  * @return 別途更新処理が必要な場合TRUEを返す
  */
-bool set_monster_slow(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
+bool set_monster_slow(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     bool notice = false;
     v = (v > 200) ? 200 : (v < 0) ? 0
@@ -174,7 +171,7 @@ bool set_monster_slow(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
         return false;
     }
 
-    if (monster.is_riding() && !player_ptr->leaving) {
+    if (monster.is_riding()) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::BONUS);
     }
 
@@ -183,14 +180,13 @@ bool set_monster_slow(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
 
 /*!
  * @brief モンスターの朦朧状態値をセット
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param m_idx モンスター参照ID
  * @param v セットする値
  * @return 別途更新処理が必要な場合TRUEを返す
  */
-bool set_monster_stunned(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
+bool set_monster_stunned(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     bool notice = false;
     v = (v > 200) ? 200 : (v < 0) ? 0
@@ -213,14 +209,13 @@ bool set_monster_stunned(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
 
 /*!
  * @brief モンスターの混乱状態値をセット
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param m_idx モンスター参照ID
  * @param v セットする値
  * @return 別途更新処理が必要な場合TRUEを返す
  */
-bool set_monster_confused(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
+bool set_monster_confused(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     bool notice = false;
     v = (v > 200) ? 200 : (v < 0) ? 0
@@ -243,14 +238,13 @@ bool set_monster_confused(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
 
 /*!
  * @brief モンスターの恐慌状態値をセット
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param m_idx モンスター参照ID
  * @param v セットする値
  * @return 別途更新処理が必要な場合TRUEを返す
  */
-bool set_monster_monfear(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
+bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v)
 {
-    auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     bool notice = false;
     v = (v > 200) ? 200 : (v < 0) ? 0
@@ -285,15 +279,14 @@ bool set_monster_monfear(PlayerType *player_ptr, MONSTER_IDX m_idx, int v)
 
 /*!
  * @brief モンスターの無敵状態値をセット
- * @param player_ptr プレイヤーへの参照ポインタ
+ * @param floor フロアへの参照
  * @param m_idx モンスター参照ID
  * @param v セットする値
  * @param energy_need TRUEならば無敵解除時に行動ターン消費を行う
  * @return 別途更新処理が必要な場合TRUEを返す
  */
-bool set_monster_invulner(PlayerType *player_ptr, MONSTER_IDX m_idx, int v, bool energy_need)
+bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energy_need)
 {
-    auto &floor = *player_ptr->current_floor_ptr;
     auto &monster = floor.m_list[m_idx];
     bool notice = false;
     v = (v > 200) ? 200 : (v < 0) ? 0

--- a/src/monster/monster-status-setter.h
+++ b/src/monster/monster-status-setter.h
@@ -3,15 +3,16 @@
 #include "system/angband.h"
 
 enum class MonraceId : short;
+class FloorType;
 class MonsterEntity;
 class PlayerType;
 void set_pet(PlayerType *player_ptr, MonsterEntity &monster);
 void anger_monster(PlayerType *player_ptr, MonsterEntity &monster);
-bool set_monster_csleep(PlayerType *player_ptr, MONSTER_IDX m_idx, int v);
-bool set_monster_fast(PlayerType *player_ptr, MONSTER_IDX m_idx, int v);
-bool set_monster_slow(PlayerType *player_ptr, MONSTER_IDX m_idx, int v);
-bool set_monster_stunned(PlayerType *player_ptr, MONSTER_IDX m_idx, int v);
-bool set_monster_confused(PlayerType *player_ptr, MONSTER_IDX m_idx, int v);
-bool set_monster_monfear(PlayerType *player_ptr, MONSTER_IDX m_idx, int v);
-bool set_monster_invulner(PlayerType *player_ptr, MONSTER_IDX m_idx, int v, bool energy_need);
+bool set_monster_csleep(FloorType &floor, MONSTER_IDX m_idx, int v);
+bool set_monster_fast(FloorType &floor, MONSTER_IDX m_idx, int v);
+bool set_monster_slow(FloorType &floor, MONSTER_IDX m_idx, int v);
+bool set_monster_stunned(FloorType &floor, MONSTER_IDX m_idx, int v);
+bool set_monster_confused(FloorType &floor, MONSTER_IDX m_idx, int v);
+bool set_monster_monfear(FloorType &floor, MONSTER_IDX m_idx, int v);
+bool set_monster_invulner(FloorType &floor, MONSTER_IDX m_idx, int v, bool energy_need);
 bool set_monster_timewalk(PlayerType *player_ptr, MONSTER_IDX m_idx, int num, bool vs_player);

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -156,7 +156,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         /* Monster wakes up "a little bit" */
 
         /* Still asleep */
-        if (!set_monster_csleep(player_ptr, m_idx, monster.get_remaining_sleep() - d)) {
+        if (!set_monster_csleep(floor, m_idx, monster.get_remaining_sleep() - d)) {
             /* Notice the "not waking up" */
             if (is_original_ap_and_seen(player_ptr, monster)) {
                 /* Hack -- Count the ignores */
@@ -185,7 +185,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
     }
     case MonsterTimedEffect::FAST:
         /* Reduce by one, note if expires */
-        if (set_monster_fast(player_ptr, m_idx, monster.get_remaining_acceleration() - 1)) {
+        if (set_monster_fast(floor, m_idx, monster.get_remaining_acceleration() - 1)) {
             if (is_seen(player_ptr, monster)) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^はもう加速されていない。", "%s^ is no longer fast."), m_name.data());
@@ -195,7 +195,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         break;
     case MonsterTimedEffect::SLOW:
         /* Reduce by one, note if expires */
-        if (set_monster_slow(player_ptr, m_idx, monster.get_remaining_deceleration() - 1)) {
+        if (set_monster_slow(floor, m_idx, monster.get_remaining_deceleration() - 1)) {
             if (is_seen(player_ptr, monster)) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^はもう減速されていない。", "%s^ is no longer slow."), m_name.data());
@@ -207,7 +207,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
         int rlev = monster.get_monrace().level;
 
         /* Recover from stun */
-        if (set_monster_stunned(player_ptr, m_idx, (randint0(10000) <= rlev * rlev) ? 0 : (monster.get_remaining_stun() - 1))) {
+        if (set_monster_stunned(floor, m_idx, (randint0(10000) <= rlev * rlev) ? 0 : (monster.get_remaining_stun() - 1))) {
             /* Message if visible */
             if (is_seen(player_ptr, monster)) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
@@ -219,7 +219,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
     }
     case MonsterTimedEffect::CONFUSION: {
         /* Reduce the confusion */
-        if (!set_monster_confused(player_ptr, m_idx, monster.get_remaining_confusion() - randint1(monster.get_monrace().level / 20 + 1))) {
+        if (!set_monster_confused(floor, m_idx, monster.get_remaining_confusion() - randint1(monster.get_monrace().level / 20 + 1))) {
             break;
         }
 
@@ -233,7 +233,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
     }
     case MonsterTimedEffect::FEAR: {
         /* Reduce the fear */
-        if (!set_monster_monfear(player_ptr, m_idx, monster.get_remaining_fear() - randint1(monster.get_monrace().level / 20 + 1))) {
+        if (!set_monster_monfear(floor, m_idx, monster.get_remaining_fear() - randint1(monster.get_monrace().level / 20 + 1))) {
             break;
         }
 
@@ -256,7 +256,7 @@ static void process_monsters_mtimed_aux(PlayerType *player_ptr, MONSTER_IDX m_id
     }
     case MonsterTimedEffect::INVULNERABILITY: {
         /* Reduce by one, note if expires */
-        if (!set_monster_invulner(player_ptr, m_idx, monster.get_remaining_invulnerability() - 1, true)) {
+        if (!set_monster_invulner(floor, m_idx, monster.get_remaining_invulnerability() - 1, true)) {
             break;
         }
 
@@ -305,21 +305,22 @@ void process_monsters_mtimed(PlayerType *player_ptr, MonsterTimedEffect mte)
  */
 void dispel_monster_status(PlayerType *player_ptr, MONSTER_IDX m_idx)
 {
-    const auto &monster = player_ptr->current_floor_ptr->m_list[m_idx];
+    auto &floor = *player_ptr->current_floor_ptr;
+    const auto &monster = floor.m_list[m_idx];
     const auto m_name = monster_desc(player_ptr, monster, 0);
-    if (set_monster_invulner(player_ptr, m_idx, 0, true)) {
+    if (set_monster_invulner(floor, m_idx, 0, true)) {
         if (monster.ml) {
             msg_format(_("%sはもう無敵ではない。", "%s^ is no longer invulnerable."), m_name.data());
         }
     }
 
-    if (set_monster_fast(player_ptr, m_idx, 0)) {
+    if (set_monster_fast(floor, m_idx, 0)) {
         if (monster.ml) {
             msg_format(_("%sはもう加速されていない。", "%s^ is no longer fast."), m_name.data());
         }
     }
 
-    if (set_monster_slow(player_ptr, m_idx, 0)) {
+    if (set_monster_slow(floor, m_idx, 0)) {
         if (monster.ml) {
             msg_format(_("%sはもう減速されていない。", "%s^ is no longer slow."), m_name.data());
         }

--- a/src/mspell/mspell-floor.cpp
+++ b/src/mspell/mspell-floor.cpp
@@ -68,7 +68,7 @@ MonsterSpellResult spell_RF4_SHRIEK(MONSTER_IDX m_idx, PlayerType *player_ptr, M
     if (target_type == MONSTER_TO_PLAYER) {
         aggravate_monsters(player_ptr, m_idx);
     } else if (target_type == MONSTER_TO_MONSTER) {
-        set_monster_csleep(player_ptr, t_idx, 0);
+        set_monster_csleep(*player_ptr->current_floor_ptr, t_idx, 0);
     }
 
     return result;
@@ -216,7 +216,7 @@ MonsterSpellResult spell_RF6_TELE_TO(PlayerType *player_ptr, MONSTER_IDX m_idx, 
     }
 
     if (resists_tele) {
-        set_monster_csleep(player_ptr, t_idx, 0);
+        set_monster_csleep(*player_ptr->current_floor_ptr, t_idx, 0);
         return res;
     }
 
@@ -225,7 +225,7 @@ MonsterSpellResult spell_RF6_TELE_TO(PlayerType *player_ptr, MONSTER_IDX m_idx, 
     } else {
         teleport_monster_to(player_ptr, t_idx, monster.fy, monster.fx, 100, TELEPORT_PASSIVE);
     }
-    set_monster_csleep(player_ptr, t_idx, 0);
+    set_monster_csleep(*player_ptr->current_floor_ptr, t_idx, 0);
 
     return res;
 }
@@ -296,7 +296,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(PlayerType *player_ptr, MONSTER_IDX m_idx
     }
 
     if (resists_tele) {
-        set_monster_csleep(player_ptr, t_idx, 0);
+        set_monster_csleep(*player_ptr->current_floor_ptr, t_idx, 0);
         return res;
     }
 
@@ -305,7 +305,7 @@ MonsterSpellResult spell_RF6_TELE_AWAY(PlayerType *player_ptr, MONSTER_IDX m_idx
     } else {
         teleport_away(player_ptr, t_idx, MAX_PLAYER_SIGHT * 2 + 5, TELEPORT_PASSIVE);
     }
-    set_monster_csleep(player_ptr, t_idx, 0);
+    set_monster_csleep(*player_ptr->current_floor_ptr, t_idx, 0);
 
     return res;
 }

--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -122,7 +122,7 @@ void spell_badstatus_message_to_mons(PlayerType *player_ptr, MONSTER_IDX m_idx, 
         }
     }
 
-    set_monster_csleep(player_ptr, t_idx, 0);
+    set_monster_csleep(*player_ptr->current_floor_ptr, t_idx, 0);
 }
 
 /*!
@@ -287,7 +287,7 @@ MonsterSpellResult spell_RF5_SCARE(MONSTER_IDX m_idx, PlayerType *player_ptr, MO
     spell_badstatus_message_to_mons(player_ptr, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        set_monster_monfear(player_ptr, t_idx, monster_target.get_remaining_fear() + randint0(4) + 4);
+        set_monster_monfear(*player_ptr->current_floor_ptr, t_idx, monster_target.get_remaining_fear() + randint0(4) + 4);
     }
 
     return res;
@@ -352,7 +352,7 @@ MonsterSpellResult spell_RF5_BLIND(MONSTER_IDX m_idx, PlayerType *player_ptr, MO
     spell_badstatus_message_to_mons(player_ptr, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        (void)set_monster_confused(player_ptr, t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
+        (void)set_monster_confused(*player_ptr->current_floor_ptr, t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
     }
 
     return res;
@@ -410,7 +410,7 @@ MonsterSpellResult spell_RF5_CONF(MONSTER_IDX m_idx, PlayerType *player_ptr, MON
     spell_badstatus_message_to_mons(player_ptr, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        (void)set_monster_confused(player_ptr, t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
+        (void)set_monster_confused(*player_ptr->current_floor_ptr, t_idx, monster_target.get_remaining_confusion() + 12 + randint0(4));
     }
 
     return res;
@@ -466,7 +466,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, PlayerType *player_ptr, MON
     spell_badstatus_message_to_mons(player_ptr, m_idx, t_idx, msg, (bool)resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        (void)set_monster_csleep(player_ptr, t_idx, 500);
+        (void)set_monster_csleep(*player_ptr->current_floor_ptr, t_idx, 500);
     }
 
     return res;
@@ -495,7 +495,7 @@ MonsterSpellResult spell_RF6_HASTE(PlayerType *player_ptr, MONSTER_IDX m_idx, MO
 
     monspell_message_base(player_ptr, m_idx, t_idx, msg, player_ptr->effects()->blindness().is_blind(), target_type);
 
-    if (set_monster_fast(player_ptr, m_idx, monster.get_remaining_acceleration() + 100)) {
+    if (set_monster_fast(*player_ptr->current_floor_ptr, m_idx, monster.get_remaining_acceleration() + 100)) {
         if (target_type == MONSTER_TO_PLAYER || (target_type == MONSTER_TO_MONSTER && see_m)) {
             msg_format(_("%s^の動きが速くなった。", "%s^ starts moving faster."), m_name.data());
         }
@@ -563,7 +563,7 @@ MonsterSpellResult spell_RF5_SLOW(MONSTER_IDX m_idx, PlayerType *player_ptr, MON
     spell_badstatus_message_to_mons(player_ptr, m_idx, t_idx, msg, resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        set_monster_slow(player_ptr, t_idx, monster_target.get_remaining_deceleration() + 50);
+        set_monster_slow(*player_ptr->current_floor_ptr, t_idx, monster_target.get_remaining_deceleration() + 50);
     }
 
     return res;
@@ -623,7 +623,7 @@ MonsterSpellResult spell_RF6_HEAL(PlayerType *player_ptr, MONSTER_IDX m_idx, MON
         return res;
     }
 
-    (void)set_monster_monfear(player_ptr, m_idx, 0);
+    (void)set_monster_monfear(*player_ptr->current_floor_ptr, m_idx, 0);
 
     if (see_monster(player_ptr, m_idx)) {
         const auto m_name = monster_name(player_ptr, m_idx);
@@ -670,7 +670,7 @@ MonsterSpellResult spell_RF6_INVULNER(PlayerType *player_ptr, MONSTER_IDX m_idx,
     }
 
     if (!monster.is_invulnerable()) {
-        (void)set_monster_invulner(player_ptr, m_idx, randint1(4) + 4, false);
+        (void)set_monster_invulner(*player_ptr->current_floor_ptr, m_idx, randint1(4) + 4, false);
     }
 
     return MonsterSpellResult::make_valid();

--- a/src/player-attack/attack-chaos-effect.cpp
+++ b/src/player-attack/attack-chaos-effect.cpp
@@ -65,7 +65,7 @@ static void attack_confuse(PlayerType *player_ptr, player_attack_type *pa_ptr, b
         msg_format(_("%s^には効果がなかった。", "%s^ is unaffected."), pa_ptr->m_name);
     } else {
         msg_format(_("%s^は混乱したようだ。", "%s^ appears confused."), pa_ptr->m_name);
-        (void)set_monster_confused(player_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_confusion() + 10 + randint0(player_ptr->lev) / 5);
+        (void)set_monster_confused(*player_ptr->current_floor_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_confusion() + 10 + randint0(player_ptr->lev) / 5);
     }
 }
 
@@ -89,7 +89,7 @@ static void attack_stun(PlayerType *player_ptr, player_attack_type *pa_ptr, bool
         msg_format(_("%s^には効果がなかった。", "%s^ is unaffected."), pa_ptr->m_name);
     } else {
         msg_format(_("%s^は朦朧としたようだ。", "%s^ appears stunned."), pa_ptr->m_name);
-        (void)set_monster_stunned(player_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + 10 + randint0(player_ptr->lev) / 5);
+        (void)set_monster_stunned(*player_ptr->current_floor_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_stun() + 10 + randint0(player_ptr->lev) / 5);
     }
 }
 
@@ -113,7 +113,7 @@ static void attack_scare(PlayerType *player_ptr, player_attack_type *pa_ptr, boo
         msg_format(_("%s^には効果がなかった。", "%s^ is unaffected."), pa_ptr->m_name);
     } else {
         msg_format(_("%s^は恐怖して逃げ出した！", "%s^ flees in terror!"), pa_ptr->m_name);
-        (void)set_monster_monfear(player_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_fear() + 10 + randint0(player_ptr->lev) / 5);
+        (void)set_monster_monfear(*player_ptr->current_floor_ptr, pa_ptr->m_idx, pa_ptr->m_ptr->get_remaining_fear() + 10 + randint0(player_ptr->lev) / 5);
     }
 }
 

--- a/src/player-attack/player-attack.cpp
+++ b/src/player-attack/player-attack.cpp
@@ -538,7 +538,7 @@ void exe_player_attack_to_monster(PlayerType *player_ptr, POSITION y, POSITION x
     get_attack_exp(player_ptr, pa_ptr);
 
     /* Disturb the monster */
-    (void)set_monster_csleep(player_ptr, pa_ptr->m_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, pa_ptr->m_idx, 0);
     angband_strcpy(pa_ptr->m_name, monster_desc(player_ptr, *pa_ptr->m_ptr, 0), sizeof(pa_ptr->m_name));
 
     int chance = calc_attack_quality(player_ptr, pa_ptr);

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -194,7 +194,7 @@ bool process_monster_damage(PlayerType *player_ptr, MonsterEntity &monster, bool
     auto &floor = *player_ptr->current_floor_ptr;
     auto &grid = floor.get_grid(monster.get_position());
     const auto damage = (has_dodged ? Dice::roll(4, 8) : (monster.hp + 1));
-    (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+    (void)set_monster_csleep(floor, grid.m_idx, 0);
     monster.hp -= damage;
     if (monster.hp >= 0) {
         return false;

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -143,7 +143,7 @@ bool fetch_monster(PlayerType *player_ptr)
     floor.get_grid(*pos).m_idx = 0;
     floor.get_grid(pos_target).m_idx = m_idx;
     monster.set_position(pos_target);
-    (void)set_monster_csleep(player_ptr, m_idx, 0);
+    (void)set_monster_csleep(floor, m_idx, 0);
     update_monster(player_ptr, m_idx, true);
     lite_spot(player_ptr, *pos);
     lite_spot(player_ptr, pos_target);

--- a/src/spell-kind/spells-genocide.cpp
+++ b/src/spell-kind/spells-genocide.cpp
@@ -77,7 +77,7 @@ bool genocide_aux(PlayerType *player_ptr, MONSTER_IDX m_idx, int power, bool pla
         }
 
         if (monster.is_asleep()) {
-            (void)set_monster_csleep(player_ptr, m_idx, 0);
+            (void)set_monster_csleep(*player_ptr->current_floor_ptr, m_idx, 0);
             if (monster.ml) {
                 msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());
             }

--- a/src/spell-kind/spells-lite.cpp
+++ b/src/spell-kind/spells-lite.cpp
@@ -60,7 +60,7 @@ static void cave_temp_room_lite(PlayerType *player_ptr, const std::vector<Pos2D>
             }
 
             if (monster.is_asleep() && evaluate_percent(chance)) {
-                (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+                (void)set_monster_csleep(*player_ptr->current_floor_ptr, grid.m_idx, 0);
                 if (monster.ml) {
                     const auto m_name = monster_desc(player_ptr, monster, 0);
                     msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());

--- a/src/spell-kind/spells-sight.cpp
+++ b/src/spell-kind/spells-sight.cpp
@@ -226,7 +226,7 @@ void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX src_idx)
 
         if (monster.cdis < MAX_PLAYER_SIGHT * 2) {
             if (monster.is_asleep()) {
-                (void)set_monster_csleep(player_ptr, i, 0);
+                (void)set_monster_csleep(floor, i, 0);
                 sleep = true;
             }
 
@@ -236,7 +236,7 @@ void aggravate_monsters(PlayerType *player_ptr, MONSTER_IDX src_idx)
         }
 
         if (floor.has_los_at({ monster.fy, monster.fx }) && !monster.is_pet()) {
-            (void)set_monster_fast(player_ptr, i, monster.get_remaining_acceleration() + 100);
+            (void)set_monster_fast(floor, i, monster.get_remaining_acceleration() + 100);
             speed = true;
         }
     }

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -66,7 +66,7 @@ bool teleport_swap(PlayerType *player_ptr, const Direction &dir)
     const auto &monster = player_ptr->current_floor_ptr->m_list[grid.m_idx];
     auto &monrace = monster.get_monrace();
 
-    (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+    (void)set_monster_csleep(*player_ptr->current_floor_ptr, grid.m_idx, 0);
 
     if (monrace.resistance_flags.has(MonsterResistanceType::RESIST_TELEPORT)) {
         msg_print(_("テレポートを邪魔された！", "Your teleportation is blocked!"));

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -141,7 +141,7 @@ bool vanish_dungeon(PlayerType *player_ptr)
         grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
         const auto &monster = floor.m_list[grid.m_idx];
         if (grid.has_monster() && monster.is_asleep()) {
-            (void)set_monster_csleep(player_ptr, grid.m_idx, 0);
+            (void)set_monster_csleep(floor, grid.m_idx, 0);
             if (monster.ml) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^が目を覚ました。", "%s^ wakes up."), m_name.data());

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -98,9 +98,9 @@ void reset_tim_flags(PlayerType *player_ptr)
     player_ptr->timewalk = false;
 
     if (player_ptr->riding) {
-        (void)set_monster_fast(player_ptr, player_ptr->riding, 0);
-        (void)set_monster_slow(player_ptr, player_ptr->riding, 0);
-        (void)set_monster_invulner(player_ptr, player_ptr->riding, 0, false);
+        (void)set_monster_fast(*player_ptr->current_floor_ptr, player_ptr->riding, 0);
+        (void)set_monster_slow(*player_ptr->current_floor_ptr, player_ptr->riding, 0);
+        (void)set_monster_invulner(*player_ptr->current_floor_ptr, player_ptr->riding, 0, false);
     }
 
     if (PlayerClass(player_ptr).equals(PlayerClassType::BARD)) {


### PR DESCRIPTION
ちょっとリファクタリングかましてみました。PlayerType * からの依存は悲願と思われるので。