### PR TITLE
[Fix] UTF-8 character width in macOS Terminal with ncurses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,13 @@ AX_CXX_COMPILE_STDCXX(20, [noext], [mandatory])
 CXXFLAGS="$saved_CXXFLAGS"
 PKG_PROG_PKG_CONFIG
 
+dnl Detect macOS host
+AC_CANONICAL_HOST
+is_macos=no
+case "${host_os}" in
+  darwin*) is_macos=yes ;;
+esac
+
 AC_MSG_CHECKING([whether the compiler is Clang])
 AC_COMPILE_IFELSE(
   [AC_LANG_SOURCE([[
@@ -86,15 +93,22 @@ AM_CONDITIONAL([PCH], [test x$enable_pch = xyes])
 
 dnl Checks for libraries.
 dnl Replace `main' with a function in -lncurses:
-AC_CHECK_LIB(ncursesw, initscr, [AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) AC_DEFINE(USE_NCURSES, 1, [Use ncurses]) LIBS="$LIBS -lncursesw"])
+use_ncurses=no
+ncurses_actions="AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) AC_DEFINE(USE_NCURSES, 1, [Use ncurses]) use_ncurses=yes"
+AC_CHECK_LIB(ncursesw, initscr, [$ncurses_actions LIBS="$LIBS -lncursesw"])
 if test "$ac_cv_lib_ncursesw_initscr" != yes; then
-  AC_CHECK_LIB(ncurses, initscr, [AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) AC_DEFINE(USE_NCURSES, 1, [Use ncurses]) LIBS="$LIBS -lncurses"])
+  AC_CHECK_LIB(ncurses, initscr, [$ncurses_actions LIBS="$LIBS -lncurses"]) 
   if test "$ac_cv_lib_ncurses_initscr" != yes; then
     AC_CHECK_LIB(curses, initscr, [AC_DEFINE(USE_GCU, 1, [Allow -mGCU environment]) LIBS="$LIBS -lcurses"])
     if test "$ac_cv_lib_curses_initscr" != yes; then
       AC_CHECK_LIB(termcap, tgetent, [AC_DEFINE(USE_CAP, 1, [Allow -mCAP environment]) LIBS="$LIBS -ltermcap"])
     fi
   fi
+fi
+
+dnl Define MACOS_TERMINAL_UTF8 for macOS ncurses builds
+if test "x$is_macos" = "xyes" && test "x$use_ncurses" = "xyes"; then
+  AC_DEFINE(MACOS_TERMINAL_UTF8, 1, [Enable width fix for macOS terminal])
 fi
 
 AC_CHECK_LIB(iconv, iconv_open)


### PR DESCRIPTION
Fix character alignment issues on macOS.

Fixes #2142
Fixes #2143

## 概要 / Description
macOSの標準ターミナル等のUTF-8環境において、日本語版をncurses（-mgcu）でプレイした際に「★」「☆」「…」などの記号の後に文字が重なって表示される問題を修正しました。

Fixed visual overlapping issues with ambiguous-width characters (★, ☆, …) when playing the Japanese build on macOS terminal via ncurses.

## 修正内容 / Changes
- `configure.ac`: macOSかつncursesビルド時にのみ `MACOS_TERMINAL_UTF8` マクロを定義するようにしました。
- `src/main-gcu.cpp`: 描画の最終出力直前で、対象の記号の後にスペースを1つ挿入して出力するようにしました。

## この修正のポイント / Key Points
1. **データへの影響なし**: 修正は表示レイヤーのみで行っているため、キャラクターダンプ、saveファイル、およびサーバーへのスコア送信データには一切影響を与えません。
   (The fix is applied only at the rendering level; it does not affect character dumps, save files, or score submission data.)
2. **安全な条件分岐**: `MACOS_TERMINAL_UTF8` および `JP` マクロで保護されているため、Windows版、Linux版、および英語版のビルドには一切影響しません。
   (Strictly guarded by macros. No impact on Windows, Linux, or English builds.)
3. **互換性**: macOS App版(Cocoa版)など、ncursesを使わないビルドにも影響しません。