### PR TITLE
[Refactor] `process_player()` 中の `current_floor_ptr` 参照を整理

### DIFF
--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -170,14 +170,15 @@ void process_player(PlayerType *player_ptr)
     if (player_ptr->riding && !effects->confusion().is_confused() && !effects->blindness().is_blind()) {
         const auto &monster = player_ptr->current_floor_ptr->m_list[player_ptr->riding];
         const auto &monrace = monster.get_monrace();
+        auto &floor = *player_ptr->current_floor_ptr;
         if (monster.is_asleep()) {
             const auto m_name = monster_desc(player_ptr, monster, 0);
-            (void)set_monster_csleep(*player_ptr->current_floor_ptr, player_ptr->riding, 0);
+            (void)set_monster_csleep(floor, player_ptr->riding, 0);
             msg_format(_("%s^を起こした。", "You have woken %s up."), m_name.data());
         }
 
         if (monster.is_stunned()) {
-            if (set_monster_stunned(*player_ptr->current_floor_ptr, player_ptr->riding,
+            if (set_monster_stunned(floor, player_ptr->riding,
                     (randint0(monrace.level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_stun() - 1))) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^を朦朧状態から立ち直らせた。", "%s^ is no longer stunned."), m_name.data());
@@ -185,7 +186,7 @@ void process_player(PlayerType *player_ptr)
         }
 
         if (monster.is_confused()) {
-            if (set_monster_confused(*player_ptr->current_floor_ptr, player_ptr->riding,
+            if (set_monster_confused(floor, player_ptr->riding,
                     (randint0(monrace.level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_confusion() - 1))) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^を混乱状態から立ち直らせた。", "%s^ is no longer confused."), m_name.data());
@@ -193,7 +194,7 @@ void process_player(PlayerType *player_ptr)
         }
 
         if (monster.is_fearful()) {
-            if (set_monster_monfear(*player_ptr->current_floor_ptr, player_ptr->riding,
+            if (set_monster_monfear(floor, player_ptr->riding,
                     (randint0(monrace.level) < player_ptr->skill_exp[PlayerSkillKindType::RIDING]) ? 0 : (monster.get_remaining_fear() - 1))) {
                 const auto m_name = monster_desc(player_ptr, monster, 0);
                 msg_format(_("%s^を恐怖から立ち直らせた。", "%s^ is no longer fearful."), m_name.data());


### PR DESCRIPTION
これも https://github.com/hengband/hengband/pull/5284
 の後続、単純置換のあかんところが出ていたので。
