### PR TITLE
[Refactor] 関数 `random_misc()` と `invest_powers()` の `PlayerType *` 引数が無用だったので削除。

### DIFF
--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -233,7 +233,7 @@ static void invest_powers(PlayerType *player_ptr, ItemEntity *o_ptr, int *powers
 
             break;
         case 5:
-            random_misc(player_ptr, o_ptr);
+            random_misc(o_ptr);
             break;
         case 6:
         case 7:

--- a/src/artifact/random-art-generator.cpp
+++ b/src/artifact/random-art-generator.cpp
@@ -200,7 +200,7 @@ static int decide_random_art_power(const bool a_cursed)
     return powers;
 }
 
-static void invest_powers(PlayerType *player_ptr, ItemEntity *o_ptr, int *powers, bool *has_pval, const bool a_cursed)
+static void invest_powers(ItemEntity *o_ptr, int *powers, bool *has_pval, const bool a_cursed)
 {
     const auto &world = AngbandWorld::get_instance();
     const auto max_type = o_ptr->is_weapon_ammo() ? 7 : 5;
@@ -448,7 +448,7 @@ bool become_random_artifact(PlayerType *player_ptr, ItemEntity *o_ptr, bool a_sc
     bool a_cursed = decide_random_art_cursed(a_scroll, o_ptr);
     int powers = decide_random_art_power(a_cursed);
     int max_powers = powers;
-    invest_powers(player_ptr, o_ptr, &powers, &has_pval, a_cursed);
+    invest_powers(o_ptr, &powers, &has_pval, a_cursed);
     if (has_pval) {
         strengthen_pval(o_ptr);
     }

--- a/src/artifact/random-art-misc.cpp
+++ b/src/artifact/random-art-misc.cpp
@@ -9,7 +9,6 @@
 #include "object-hook/hook-armor.h"
 #include "object/tval-types.h"
 #include "system/item-entity.h"
-#include "system/player-type-definition.h"
 #include "util/bit-flags-calculator.h"
 
 static bool invest_misc_ranger(ItemEntity *o_ptr)

--- a/src/artifact/random-art-misc.cpp
+++ b/src/artifact/random-art-misc.cpp
@@ -258,7 +258,7 @@ static void invest_misc_weak_esps(ItemEntity *o_ptr)
  * @attention オブジェクトのtval、svalに依存したハードコーディング処理がある。
  * @param o_ptr 対象のオブジェクト構造体ポインタ
  */
-void random_misc(PlayerType *player_ptr, ItemEntity *o_ptr)
+void random_misc(ItemEntity *o_ptr)
 {
     if (switch_misc_bias(o_ptr)) {
         return;
@@ -349,7 +349,7 @@ void random_misc(PlayerType *player_ptr, ItemEntity *o_ptr)
     case 25:
     case 26:
         if (o_ptr->is_protector()) {
-            random_misc(player_ptr, o_ptr);
+            random_misc(o_ptr);
         } else {
             o_ptr->to_a = 4 + randint1(11);
         }

--- a/src/artifact/random-art-misc.h
+++ b/src/artifact/random-art-misc.h
@@ -5,5 +5,4 @@
  */
 
 class ItemEntity;
-class PlayerType;
-void random_misc(PlayerType *player_ptr, ItemEntity *o_ptr);
+void random_misc(ItemEntity *o_ptr);


### PR DESCRIPTION
馬鹿馬鹿いじっている間に気付いたので。