### PR TITLE
unix-musicに関連した小修正

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -251,3 +251,29 @@ source code, you may redistribute such embedded portions in such object form
 without including the above copyright and permission notices.
 
 ---------------------------------------------------------
+
+simpleini v4.25 - MIT
+https://github.com/brofield/simpleini
+
+The MIT License (MIT)
+
+Copyright (c) 2006-2024 Brodie Thiesfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------

--- a/src/main-unix/unix-cfg-reader.cpp
+++ b/src/main-unix/unix-cfg-reader.cpp
@@ -5,13 +5,13 @@
  */
 
 #include "main-unix/unix-cfg-reader.h"
-#include "external-lib/include/simpleini/SimpleIni.h"
 #include "locale/japanese.h"
 #include "main/sound-definitions-table.h"
 #include "term/z-term.h"
 #include "util/angband-files.h"
 #include <cstring>
 #include <ctype.h>
+#include <simpleini/SimpleIni.h>
 #include <span>
 #include <tl/optional.hpp>
 

--- a/src/main-unix/unix-music.cpp
+++ b/src/main-unix/unix-music.cpp
@@ -47,6 +47,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <range/v3/all.hpp>
 #include <spawn.h>
 #include <string>
 #include <sys/types.h>
@@ -255,15 +256,16 @@ bool play_music(int type, int val)
         stop_music();
     }
 
-    auto music_player = "./playmusic.sh";
+    const std::string_view music_player = "./playmusic.sh";
+    auto argv_music_player_buf = music_player | ranges::to_vector;
+    argv_music_player_buf.push_back('\0');
+    auto argv_path_music_buf = path_music.string() | ranges::to_vector;
+    argv_path_music_buf.push_back('\0');
     //  argv must has null end
-    //  strdup()ed variables must be manually free()
-    char *argv[] = { strdup(music_player), strdup(path_music.c_str()), nullptr };
+    char *const argv[] = { argv_music_player_buf.data(), argv_path_music_buf.data(), nullptr };
     // explicitly pass environment
     char **envp = environ;
-    auto ret = posix_spawnp(&music_player_pid, argv[0], nullptr, nullptr, argv, envp);
-    free(argv[0]);
-    free(argv[1]);
+    auto ret = posix_spawnp(&music_player_pid, music_player.data(), nullptr, nullptr, argv, envp);
     if (ret != 0) { // failed to spawn process
         music_player_pid = 0;
         return false;

--- a/src/main-unix/unix-music.cpp
+++ b/src/main-unix/unix-music.cpp
@@ -29,7 +29,6 @@
 
 #include "main-unix/unix-music.h"
 #include "dungeon/quest.h"
-#include "external-lib/include/simpleini/SimpleIni.h"
 #include "main-unix/unix-cfg-reader.h"
 #include "main/music-definitions-table.h"
 #include "main/scene-table.h"
@@ -48,6 +47,7 @@
 #include <cstring>
 #include <limits>
 #include <range/v3/all.hpp>
+#include <simpleini/SimpleIni.h>
 #include <spawn.h>
 #include <string>
 #include <sys/types.h>


### PR DESCRIPTION
#5310 で追加いただいたBGM機能に関する小さな修正。

- THIRD-PARTY-NOTICE.txt に simpleini のライセンスを追記
- 基本的にCのメモリ管理APIは使用しない方針なので、 strdup/free の代わりに std::string を使用。