### PR TITLE
[Refactor] 烈風剣などモンスターノックバック処理の統一

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -32,6 +32,7 @@
 #include "monster/monster-status-setter.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "object/object-broken.h"
 #include "object/object-info.h"
 #include "object/object-mark-types.h"
@@ -848,8 +849,6 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
                             //!< @details プレイヤーの場所が同一であることが保証できないので変数を再宣言する.
                             const auto p_pos1 = player_ptr->get_position();
                             auto n = randint1(5) + 3;
-                            const auto n0 = n;
-                            const auto m_idx = c_mon_ptr->m_idx;
                             for (; cur_dis <= tdis;) {
                                 const Pos2D pos_orig = { y, x };
                                 if (n == 0) {
@@ -874,17 +873,10 @@ void exe_fire(PlayerType *player_ptr, INVENTORY_IDX i_idx, ItemEntity *j_ptr, SP
                                     break;
                                 }
 
-                                floor.get_grid(pos_to).m_idx = m_idx;
-                                floor.get_grid(pos_orig).m_idx = 0;
-                                monster.set_position(pos_to);
-                                update_monster(player_ptr, m_idx, true);
+                                move_monster_to(player_ptr, monster, pos_to);
                                 if (delay_factor > 0) {
-                                    lite_spot(player_ptr, pos_to);
-                                    lite_spot(player_ptr, pos_orig);
                                     term_fresh();
                                     term_xtra(TERM_XTRA_DELAY, delay_factor);
-                                } else if (n == n0) {
-                                    lite_spot(player_ptr, pos_orig);
                                 }
 
                                 x = pos_to.x;

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -16,6 +16,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-status.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "pet/pet-util.h"
 #include "player-base/player-class.h"
 #include "player-info/equipment-info.h"
@@ -243,14 +244,8 @@ bool shock_power(PlayerType *player_ptr)
     }
 
     msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name.data());
-    floor.get_grid(pos_origin).m_idx = 0;
-    floor.get_grid(pos_target).m_idx = m_idx;
-    monster.fy = pos_target.y;
-    monster.fx = pos_target.x;
-
-    update_monster(player_ptr, m_idx, true);
-    lite_spot(player_ptr, pos_origin);
-    lite_spot(player_ptr, pos_target);
+    monster.set_target(player_ptr->get_position());
+    move_monster_to(player_ptr, monster, pos_target);
 
     if (monrace.brightness_flags.has_any_of(ld_mask)) {
         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);

--- a/src/monster/monster-util.cpp
+++ b/src/monster/monster-util.cpp
@@ -1,10 +1,12 @@
 #include "monster/monster-util.h"
 #include "dungeon/quest.h"
 #include "game-option/cheat-options.h"
+#include "grid/grid.h"
 #include "monster-floor/place-monster-types.h"
 #include "monster-race/monster-kind-mask.h"
 #include "monster-race/race-ability-mask.h"
 #include "monster/monster-info.h"
+#include "monster/monster-update.h"
 #include "mspell/summon-checker.h"
 #include "room/pit-nest-util.h"
 #include "spell/summon-types.h"
@@ -715,4 +717,17 @@ bool is_player(MONSTER_IDX m_idx)
 bool is_monster(MONSTER_IDX m_idx)
 {
     return m_idx > 0;
+}
+
+void move_monster_to(PlayerType *player_ptr, MonsterEntity &monster, const Pos2D &pos_to)
+{
+    auto &floor = *player_ptr->current_floor_ptr;
+    const auto pos_from = monster.get_position();
+    auto &grid_from = floor.get_grid(pos_from);
+    auto &grid_to = floor.get_grid(pos_to);
+    grid_to.m_idx = std::exchange(grid_from.m_idx, {});
+    monster.set_position(pos_to);
+    update_monster(player_ptr, grid_to.m_idx, true);
+    lite_spot(player_ptr, pos_from);
+    lite_spot(player_ptr, pos_to);
 }

--- a/src/monster/monster-util.h
+++ b/src/monster/monster-util.h
@@ -9,6 +9,7 @@
 enum summon_type : int;
 enum class MonraceId : short;
 class PlayerType;
+class MonsterEntity;
 void get_mon_num_prep_enum(PlayerType *player_ptr, MonraceHook hook1 = MonraceHook::NONE, MonraceHookTerrain hook2 = MonraceHookTerrain::NONE);
 void get_mon_num_prep_escort(PlayerType *player_ptr, MonraceId escorted_monrace_id, short m_idx, MonraceHookTerrain hook2);
 
@@ -57,3 +58,4 @@ void get_mon_num_prep_bounty(PlayerType *player_ptr);
 void mark_monsters_present(PlayerType *player_ptr);
 bool is_player(MONSTER_IDX m_idx);
 bool is_monster(MONSTER_IDX m_idx);
+void move_monster_to(PlayerType *player_ptr, MonsterEntity &monster, const Pos2D &pos_to);

--- a/src/realm/realm-hissatsu.cpp
+++ b/src/realm/realm-hissatsu.cpp
@@ -17,6 +17,7 @@
 #include "monster/monster-describer.h"
 #include "monster/monster-info.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "player-info/equipment-info.h"
 #include "player/player-damage.h"
 #include "player/player-move.h"
@@ -262,15 +263,8 @@ tl::optional<std::string> do_hissatsu_spell(PlayerType *player_ptr, SPELL_IDX sp
                 }
                 if (pos_target != pos_origin) {
                     msg_format(_("%sを吹き飛ばした！", "You blow %s away!"), m_name.data());
-                    floor.get_grid(pos_origin).m_idx = 0;
-                    floor.get_grid(pos_target).m_idx = m_idx;
-                    monster.fy = pos_target.y;
-                    monster.fx = pos_target.x;
-
-                    update_monster(player_ptr, m_idx, true);
-                    lite_spot(player_ptr, pos_origin);
-                    lite_spot(player_ptr, pos_target);
-
+                    monster.set_target(player_ptr->get_position());
+                    move_monster_to(player_ptr, monster, pos_target);
                     if (monster.get_monrace().brightness_flags.has_any_of(ld_mask)) {
                         RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::MONSTER_LITE);
                     }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -11,6 +11,7 @@
 #include "monster/monster-description-types.h"
 #include "monster/monster-status-setter.h"
 #include "monster/monster-update.h"
+#include "monster/monster-util.h"
 #include "player/player-damage.h"
 #include "player/player-move.h"
 #include "player/player-status-flags.h"
@@ -174,19 +175,6 @@ tl::optional<Pos2D> decide_monster_dodge_position(const FloorType &floor, const 
         ranges::to<std::vector<Pos2D>>();
 
     return pos_candidates.empty() ? tl::nullopt : tl::make_optional(rand_choice(pos_candidates));
-}
-
-void move_monster_to(PlayerType *player_ptr, MonsterEntity &monster, const Pos2D &pos_to)
-{
-    auto &floor = *player_ptr->current_floor_ptr;
-    const auto pos_from = monster.get_position();
-    auto &grid_from = floor.get_grid(pos_from);
-    auto &grid_to = floor.get_grid(pos_to);
-    grid_to.m_idx = std::exchange(grid_from.m_idx, {});
-    monster.set_position(pos_to);
-    update_monster(player_ptr, grid_to.m_idx, true);
-    lite_spot(player_ptr, pos_from);
-    lite_spot(player_ptr, pos_to);
 }
 
 bool process_monster_damage(PlayerType *player_ptr, MonsterEntity &monster, bool has_dodged)


### PR DESCRIPTION
地震時のモンスター移動のみに使われていたmove_monster_to()を汎化して烈風剣などのモンスターノックバックを生じさせる攻撃に使用する。 
これにより烈風剣、衝波で視界外にモンスターを押し出したときに反撃召喚が生じなかったバグが修正される。