### PR TITLE
[Fix] 素手+強撃のダメージ表示式の修正

### DIFF
--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -1176,19 +1176,19 @@ int calc_expect_crit(PlayerType *player_ptr, WEIGHT weight, int plus, int dam, i
         i = 0;
     }
 
-    auto num = 0;
+    int64_t num = 0;
 
     if (impact) {
         // 強撃クリティカル(クリティカル強度: weight + d650 + d650)のときの期待値
-        auto sum = 0;
+        int64_t sum = 0;
         for (auto d = 2; d <= CRITICAL_DIE_SIDES * 2; ++d) { // d650 + d650 で出る 2～1300 について計算する
-            const auto count = (d <= CRITICAL_DIE_SIDES + 1) ? (d - 1) : (CRITICAL_DIE_SIDES * 2 - d + 1); // d650 + d650 で出る 650*650 通りのうちdが出るパターンの数
+            const int64_t count = (d <= CRITICAL_DIE_SIDES + 1) ? (d - 1) : (CRITICAL_DIE_SIDES * 2 - d + 1); // d650 + d650 で出る 650*650 通りのうちdが出るパターンの数
             sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult)) * count;
         }
         num = sum / (CRITICAL_DIE_SIDES * CRITICAL_DIE_SIDES);
     } else {
         // 通常クリティカル(クリティカル強度: weight + d650)のときの期待値
-        auto sum = 0;
+        int64_t sum = 0;
         for (auto d = 1; d <= CRITICAL_DIE_SIDES; ++d) {
             sum += std::get<0>(apply_critical_norm_damage(weight + d, dam, mult));
         }


### PR DESCRIPTION
fix #5330

素手+強撃のクリティカル計算の途中でオーバーフローしていた変数を修正しました。