### PR TITLE
[Feature] X11版でbitmapフォントとTrueTypeフォントを切り替えられるようにする

### DIFF
--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -173,12 +173,15 @@
 
 /*
  * An X11 pixell specifier
+ * When compiled with XFT support, keep both XftColor and raw pixel value
+ * so both XFT and bitmap code can be compiled and selected at runtime.
  */
+typedef struct {
 #ifdef USE_XFT
-typedef XftColor Pixell;
-#else
-typedef unsigned long Pixell;
+    XftColor xft;
 #endif
+    unsigned long pixel;
+} Pixell;
 
 /*
  * A structure summarizing a given Display.
@@ -229,9 +232,7 @@ struct metadpy {
 
     Pixell bg;
     Pixell fg;
-#ifndef USE_XFT
-    Pixell zg;
-#endif
+    unsigned long zg;
 
     uint mono : 1;
     uint color : 1;
@@ -308,9 +309,7 @@ struct infowin {
  *	- Bit Flag: Destroy 'gc' at Nuke time.
  */
 struct infoclr {
-#ifndef USE_XFT
     GC gc;
-#endif
 
     Pixell fg;
     Pixell bg;
@@ -338,10 +337,9 @@ struct infoclr {
  */
 struct infofnt {
 #ifdef USE_XFT
-    XftFont *info;
-#else
-    XFontSet info;
+    XftFont *xft_info;
 #endif
+    XFontSet fontset_info;
     std::string name;
 
     int16_t wid;
@@ -414,6 +412,11 @@ static infowin *Focuswin = (infowin *)(nullptr);
 #endif
 static infoclr *Infoclr = (infoclr *)(nullptr);
 static infofnt *Infofnt = (infofnt *)(nullptr);
+#ifdef USE_XFT
+static bool use_xft_runtime = true;
+#else
+static bool use_xft_runtime = false;
+#endif
 
 /*
  * Init the current metadpy, with various initialization stuff.
@@ -455,19 +458,27 @@ static errr Metadpy_init_2(Display *dpy, concptr name)
 
 #ifdef USE_XFT
     Visual *vis = DefaultVisual(dpy, 0);
-    XftColorAllocName(dpy, vis, m->cmap, "black", &m->black);
-    XftColorAllocName(dpy, vis, m->cmap, "white", &m->white);
+    if (!XftColorAllocName(dpy, vis, m->cmap, "black", &m->black.xft)) {
+        m->black.pixel = BlackPixelOfScreen(m->screen);
+        m->black.xft.pixel = m->black.pixel;
+    } else {
+        m->black.pixel = m->black.xft.pixel;
+    }
+    if (!XftColorAllocName(dpy, vis, m->cmap, "white", &m->white.xft)) {
+        m->white.pixel = WhitePixelOfScreen(m->screen);
+        m->white.xft.pixel = m->white.pixel;
+    } else {
+        m->white.pixel = m->white.xft.pixel;
+    }
 #else
-    m->black = BlackPixelOfScreen(m->screen);
-    m->white = WhitePixelOfScreen(m->screen);
+    m->black.pixel = BlackPixelOfScreen(m->screen);
+    m->white.pixel = WhitePixelOfScreen(m->screen);
 #endif
 
     m->bg = m->black;
     m->fg = m->white;
 
-#ifndef USE_XFT
     m->zg = (1 << m->depth) - 1;
-#endif
 
     m->color = ((m->depth > 1) ? 1 : 0);
     m->mono = ((m->color) ? 0 : 1);
@@ -565,17 +576,12 @@ static errr Infowin_prepare(Window xid)
  */
 static errr Infowin_init_data(Window dad, int x, int y, int w, int h, int b, Pixell fg, Pixell bg)
 {
-    Window xid;
     *Infowin = {};
     if (dad == None) {
         dad = Metadpy->root;
     }
 
-#ifdef USE_XFT
-    xid = XCreateSimpleWindow(Metadpy->dpy, dad, x, y, w, h, b, fg.pixel, bg.pixel);
-#else
-    xid = XCreateSimpleWindow(Metadpy->dpy, dad, x, y, w, h, b, fg, bg);
-#endif
+    Window xid = XCreateSimpleWindow(Metadpy->dpy, dad, x, y, w, h, b, fg.pixel, bg.pixel);
 
     XSelectInput(Metadpy->dpy, xid, 0L);
     Infowin->nuke = 1;
@@ -705,44 +711,40 @@ static errr Infoclr_init_data(Pixell fg, Pixell bg, int op, int stip)
 {
     infoclr *iclr = Infoclr;
 
-#ifndef USE_XFT
-    GC gc;
+    GC gc = (GC)0;
     XGCValues gcv;
-    unsigned long gc_mask;
-#endif
+    unsigned long gc_mask = 0UL;
 
-#ifndef USE_XFT
-    if (bg > Metadpy->zg) {
-        return -1;
-    }
-    if (fg > Metadpy->zg) {
-        return -1;
-    }
-    if ((op < 0) || (op > 15)) {
-        return -1;
-    }
+    if (!use_xft_runtime) {
+        if (bg.pixel > Metadpy->zg) {
+            return -1;
+        }
+        if (fg.pixel > Metadpy->zg) {
+            return -1;
+        }
+        if ((op < 0) || (op > 15)) {
+            return -1;
+        }
 
-    gcv.function = op;
-    gcv.background = bg;
-    gcv.foreground = fg;
-    if (op == 6) {
-        gcv.background = 0;
-    }
-    if (op == 6) {
-        gcv.foreground = (bg ^ fg);
-    }
+        gcv.function = op;
+        gcv.background = bg.pixel;
+        gcv.foreground = fg.pixel;
+        if (op == 6) {
+            gcv.background = 0;
+        }
+        if (op == 6) {
+            gcv.foreground = (bg.pixel ^ fg.pixel);
+        }
 
-    gcv.fill_style = (stip ? FillStippled : FillSolid);
-    gcv.graphics_exposures = False;
-    gc_mask = (GCFunction | GCBackground | GCForeground | GCFillStyle | GCGraphicsExposures);
-    gc = XCreateGC(Metadpy->dpy, Metadpy->root, gc_mask, &gcv);
-#endif
+        gcv.fill_style = (stip ? FillStippled : FillSolid);
+        gcv.graphics_exposures = False;
+        gc_mask = (GCFunction | GCBackground | GCForeground | GCFillStyle | GCGraphicsExposures);
+        gc = XCreateGC(Metadpy->dpy, Metadpy->root, gc_mask, &gcv);
+    }
 
     *iclr = {};
 
-#ifndef USE_XFT
     iclr->gc = gc;
-#endif
 
     iclr->nuke = 1;
     iclr->fg = fg;
@@ -762,15 +764,16 @@ static errr Infoclr_change_fg(Pixell fg)
 {
     infoclr *iclr = Infoclr;
 
-#ifdef USE_XFT
-    iclr->fg = fg;
-#else
-    if (fg > Metadpy->zg) {
-        return -1;
+    if (use_xft_runtime) {
+        iclr->fg = fg;
+        return 0;
     }
 
-    XSetForeground(Metadpy->dpy, iclr->gc, fg);
-#endif
+    if (fg.pixel > Metadpy->zg) {
+        return -1;
+    }
+    XSetForeground(Metadpy->dpy, iclr->gc, fg.pixel);
+    iclr->fg = fg;
 
     return 0;
 }
@@ -779,32 +782,35 @@ static errr Infoclr_change_fg(Pixell fg)
  * Prepare a new 'infofnt'
  */
 #ifdef USE_XFT
-static errr Infofnt_prepare(XftFont *info)
-#else
-static errr Infofnt_prepare(XFontSet info)
-#endif
+static void Infofnt_prepare_xft(XftFont *info)
 {
     infofnt *ifnt = Infofnt;
+    ifnt->xft_info = info;
 
-#ifndef USE_XFT
-    XCharStruct *cs;
-    XFontStruct **fontinfo;
-    char **fontname;
-    int n_fonts;
-    int ascent, descent, width;
-#endif
-
-    ifnt->info = info;
-
-#ifdef USE_XFT
     ifnt->asc = info->ascent;
     ifnt->hgt = info->height;
     const char *text = "A";
     XGlyphInfo extent;
     XftTextExtentsUtf8(Metadpy->dpy, info, (FcChar8 *)text, strlen(text), &extent);
     ifnt->wid = extent.xOff;
-#else
+}
+#endif
+
+static errr Infofnt_prepare_fontset(XFontSet info)
+{
+    infofnt *ifnt = Infofnt;
+    XCharStruct *cs;
+    XFontStruct **fontinfo;
+    char **fontname;
+    int n_fonts;
+    int ascent, descent, width;
+
+    ifnt->fontset_info = info;
+
     n_fonts = XFontsOfFontSet(info, &fontinfo, &fontname);
+    if (n_fonts <= 0) {
+        return -1;
+    }
 
     ascent = descent = width = 0;
     while (n_fonts-- > 0) {
@@ -831,15 +837,18 @@ static errr Infofnt_prepare(XFontSet info)
     ifnt->asc = ascent;
     ifnt->hgt = ascent + descent;
     ifnt->wid = width;
-#endif
 
+    return 0;
+}
+
+static void Infofnt_prepare_tile_width()
+{
+    infofnt *ifnt = Infofnt;
     if (use_bigtile) {
         ifnt->twid = 2 * ifnt->wid;
     } else {
         ifnt->twid = ifnt->wid;
     }
-
-    return 0;
 }
 
 /*
@@ -851,24 +860,32 @@ static errr Infofnt_prepare(XFontSet info)
 static void Infofnt_init_data(concptr name)
 
 {
-#ifdef USE_XFT
-    XftFont *info;
-#else
-    XFontSet info;
-    char **missing_list;
-    int missing_count;
-    char *default_font;
-#endif
-
     if (!name || !*name) {
         quit("Missing font!");
     }
 
+    *Infofnt = {};
+    Infofnt->name = name;
+    Infofnt->nuke = 1;
+
 #ifdef USE_XFT
-    info = XftFontOpenName(Metadpy->dpy, 0, name);
-    /* TODO: error handling */
-#else
-    info = XCreateFontSet(Metadpy->dpy, name, &missing_list, &missing_count, &default_font);
+    if (use_xft_runtime) {
+        XftFont *info = XftFontOpenName(Metadpy->dpy, 0, name);
+        if (!info) {
+            quit_fmt("Failed to find font:\"%s\"", name);
+        }
+        Infofnt_prepare_xft(info);
+        Infofnt_prepare_tile_width();
+
+        return;
+    }
+#endif
+
+    char **missing_list;
+    int missing_count;
+    char *default_font;
+
+    XFontSet info = XCreateFontSet(Metadpy->dpy, name, &missing_list, &missing_count, &default_font);
     if (missing_count > 0) {
         printf("missing font(s): \n");
         while (missing_count-- > 0) {
@@ -876,24 +893,14 @@ static void Infofnt_init_data(concptr name)
         }
         XFreeStringList(missing_list);
     }
-#endif
-
     if (!info) {
         quit_fmt("Failed to find font:\"%s\"", name);
     }
-
-    *Infofnt = {};
-    if (Infofnt_prepare(info)) {
-#ifdef USE_XFT
-        XftFontClose(Metadpy->dpy, info);
-#else
+    if (Infofnt_prepare_fontset(info) < 0) {
         XFreeFontSet(Metadpy->dpy, info);
-#endif
         quit_fmt("Failed to prepare font:\"%s\"", name);
     }
-
-    Infofnt->name = name;
-    Infofnt->nuke = 1;
+    Infofnt_prepare_tile_width();
 }
 
 #ifdef USE_XFT
@@ -907,7 +914,7 @@ static void Infofnt_text_std_xft_draw_str(int px, int py, const XftColor &fg, co
             return;
         }
 
-        XftDrawStringUtf8(Infowin->draw, &fg, Infofnt->info, px + Infofnt->wid * offset, py, (const FcChar8 *)str, byte_len);
+        XftDrawStringUtf8(Infowin->draw, &fg, Infofnt->xft_info, px + Infofnt->wid * offset, py, (const FcChar8 *)str, byte_len);
         offset += (byte_len > 1 ? 2 : 1);
         str += byte_len;
     }
@@ -941,19 +948,23 @@ static errr Infofnt_text_std(int x, int y, concptr str, int len)
         len = strlen(str);
     }
 
-#ifndef USE_XFT
-    y = (y * Infofnt->hgt) + Infofnt->asc + Infowin->oy;
-    x = (x * Infofnt->wid) + Infowin->ox;
-#endif
+    /* If using bitmap/fontset at runtime, convert cell coords to pixels */
+    if (!use_xft_runtime) {
+        y = (y * Infofnt->hgt) + Infofnt->asc + Infowin->oy;
+        x = (x * Infofnt->wid) + Infowin->ox;
+    }
 
     if (Infofnt->mono) {
-#ifndef USE_XFT
-        int i;
-        for (i = 0; i < len; ++i) {
-            XDrawImageString(Metadpy->dpy, Infowin->win, Infoclr->gc, x + i * Infofnt->wid + Infofnt->off, y, str + i, 1);
+        if (!use_xft_runtime) {
+            int i;
+            for (i = 0; i < len; ++i) {
+                XDrawImageString(Metadpy->dpy, Infowin->win, Infoclr->gc, x + i * Infofnt->wid + Infofnt->off, y, str + i, 1);
+            }
+            return 0;
         }
-#endif
-    } else {
+    }
+
+    if (!Infofnt->mono) {
 #ifdef JP
         char utf8_buf[1024];
         int utf8_len = euc_to_utf8(str, len, utf8_buf, sizeof(utf8_buf));
@@ -962,11 +973,15 @@ static errr Infofnt_text_std(int x, int y, concptr str, int len)
         }
 #endif
 
+        if (use_xft_runtime) {
 #ifdef USE_XFT
-        Infofnt_text_std_xft(x, y, len, Infoclr->fg, Infoclr->bg, _(utf8_buf, str), _(utf8_len, len));
+            Infofnt_text_std_xft(x, y, len, Infoclr->fg.xft, Infoclr->bg.xft, _(utf8_buf, str), _(utf8_len, len));
 #else
-        XmbDrawImageString(Metadpy->dpy, Infowin->win, Infofnt->info, Infoclr->gc, x, y, _(utf8_buf, str), _(utf8_len, len));
+            /* unreachable when XFT not compiled */
 #endif
+        } else {
+            XmbDrawImageString(Metadpy->dpy, Infowin->win, Infofnt->fontset_info, Infoclr->gc, x, y, _(utf8_buf, str), _(utf8_len, len));
+        }
     }
 
     return 0;
@@ -988,10 +1003,12 @@ static errr Infofnt_text_non(int x, int y, concptr str, int len)
     y = y * h + Infowin->oy;
 
 #ifdef USE_XFT
-    XftDrawRect(Infowin->draw, &Infoclr->fg, x, y, w, h);
-#else
-    XFillRectangle(Metadpy->dpy, Infowin->win, Infoclr->gc, x, y, w, h);
+    if (use_xft_runtime) {
+        XftDrawRect(Infowin->draw, &Infoclr->fg.xft, x, y, w, h);
+        return 0;
+    }
 #endif
+    XFillRectangle(Metadpy->dpy, Infowin->win, Infoclr->gc, x, y, w, h);
 
     return 0;
 }
@@ -1262,20 +1279,23 @@ static void draw_cursor_xft(int x, int y, int len)
         return;
     }
 #endif
-    Infofnt_text_std_xft(x, y, len, Infoclr->bg, Infoclr->fg, _(utf8_buf, cursor_chars.data()), _(utf8_len, len));
+    Infofnt_text_std_xft(x, y, len, Infoclr->bg.xft, Infoclr->fg.xft, _(utf8_buf, cursor_chars.data()), _(utf8_len, len));
 }
 #endif
 
 static void draw_cursor(int x, int y, int len)
 {
 #ifdef USE_XFT
-    draw_cursor_xft(x, y, len);
-#else
+    if (use_xft_runtime) {
+        draw_cursor_xft(x, y, len);
+        return;
+    }
+#endif
+
     square_to_pixel(&x, &y, x, y);
     const auto width = Infofnt->wid * len;
     const auto height = Infofnt->hgt;
     XFillRectangle(Metadpy->dpy, Infowin->win, Infoclr->gc, x, y, width, height);
-#endif
 }
 
 /*
@@ -1968,7 +1988,13 @@ static errr game_term_xtra_x11_react(void)
                 color_table[i][1] = angband_color_table[i][1];
                 color_table[i][2] = angband_color_table[i][2];
                 color_table[i][3] = angband_color_table[i][3];
-                pixel = create_pixel(Metadpy->dpy, color_table[i][1], color_table[i][2], color_table[i][3]);
+#ifdef USE_XFT
+                XftColor c = create_pixel(Metadpy->dpy, color_table[i][1], color_table[i][2], color_table[i][3]);
+                pixel.xft = c;
+                pixel.pixel = c.pixel;
+#else
+                pixel.pixel = create_pixel(Metadpy->dpy, color_table[i][1], color_table[i][2], color_table[i][3]);
+#endif
                 Infoclr_set(clr[i].get());
                 Infoclr_change_fg(pixel);
             }
@@ -2049,14 +2075,16 @@ static errr game_term_curs_x11(int x, int y)
 {
     if (use_graphics) {
 #ifdef USE_XFT
-        XftDrawRect(Infowin->draw, &xor_->fg, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->wid - 1, Infofnt->hgt - 1);
-        XftDrawRect(Infowin->draw, &xor_->fg, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->wid - 3, Infofnt->hgt - 3);
-#else
+        if (use_xft_runtime) {
+            XftDrawRect(Infowin->draw, &xor_->fg.xft, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->wid - 1, Infofnt->hgt - 1);
+            XftDrawRect(Infowin->draw, &xor_->fg.xft, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->wid - 3, Infofnt->hgt - 3);
+            return 0;
+        }
+#endif
         XDrawRectangle(
             Metadpy->dpy, Infowin->win, xor_->gc, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->wid - 1, Infofnt->hgt - 1);
         XDrawRectangle(
             Metadpy->dpy, Infowin->win, xor_->gc, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->wid - 3, Infofnt->hgt - 3);
-#endif
     } else {
         Infoclr_set(xor_.get());
         draw_cursor(x, y, 1);
@@ -2072,14 +2100,16 @@ static errr game_term_bigcurs_x11(int x, int y)
 {
     if (use_graphics) {
 #ifdef USE_XFT
-        XftDrawRect(Infowin->draw, &xor_->fg, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->twid - 1, Infofnt->hgt - 1);
-        XftDrawRect(Infowin->draw, &xor_->fg, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->twid - 3, Infofnt->hgt - 3);
-#else
+        if (use_xft_runtime) {
+            XftDrawRect(Infowin->draw, &xor_->fg.xft, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->twid - 1, Infofnt->hgt - 1);
+            XftDrawRect(Infowin->draw, &xor_->fg.xft, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->twid - 3, Infofnt->hgt - 3);
+            return 0;
+        }
+#endif
         XDrawRectangle(
             Metadpy->dpy, Infowin->win, xor_->gc, x * Infofnt->wid + Infowin->ox, y * Infofnt->hgt + Infowin->oy, Infofnt->twid - 1, Infofnt->hgt - 1);
         XDrawRectangle(
             Metadpy->dpy, Infowin->win, xor_->gc, x * Infofnt->wid + Infowin->ox + 1, y * Infofnt->hgt + Infowin->oy + 1, Infofnt->twid - 3, Infofnt->hgt - 3);
-#endif
     } else {
         Infoclr_set(xor_.get());
         draw_cursor(x, y, 2);
@@ -2269,12 +2299,16 @@ static void game_term_nuke_x11(term_type *)
     for (auto i = 0; i < MAX_TERM_DATA; i++) {
         infofnt *ifnt = data[i].fnt.get();
         infowin *iwin = data[i].win.get();
-        if (ifnt && ifnt->info)
+        if (ifnt) {
 #ifdef USE_XFT
-            XftFontClose(Metadpy->dpy, ifnt->info);
-#else
-            XFreeFontSet(Metadpy->dpy, ifnt->info);
+            if (ifnt->xft_info) {
+                XftFontClose(Metadpy->dpy, ifnt->xft_info);
+            }
 #endif
+            if (ifnt->fontset_info) {
+                XFreeFontSet(Metadpy->dpy, ifnt->fontset_info);
+            }
+        }
         if (iwin && iwin->xic) {
             XDestroyIC(iwin->xic);
         }
@@ -2537,6 +2571,20 @@ errr init_x11(int argc, char *argv[])
             continue;
         }
 
+        if (streq(argv[i], "-ft")) {
+#ifdef USE_XFT
+            use_xft_runtime = true;
+#else
+            plog("TrueType fonts are not available in this build");
+#endif
+            continue;
+        }
+
+        if (streq(argv[i], "-fb")) {
+            use_xft_runtime = false;
+            continue;
+        }
+
 #ifndef USE_XFT
         if (prefix(argv[i], "-s")) {
             smoothRescaling = false;
@@ -2619,7 +2667,14 @@ errr init_x11(int argc, char *argv[])
         color_table[i][3] = angband_color_table[i][3];
         pixel = ((i == 0) ? Metadpy->bg : Metadpy->fg);
         if (Metadpy->color) {
-            pixel = create_pixel(Metadpy->dpy, color_table[i][1], color_table[i][2], color_table[i][3]);
+
+#ifdef USE_XFT
+            XftColor c = create_pixel(Metadpy->dpy, color_table[i][1], color_table[i][2], color_table[i][3]);
+            pixel.xft = c;
+            pixel.pixel = c.pixel;
+#else
+            pixel.pixel = create_pixel(Metadpy->dpy, color_table[i][1], color_table[i][2], color_table[i][3]);
+#endif
         }
 
         Infoclr_init_ppn(pixel, Metadpy->bg, "cpy", 0);

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -2422,34 +2422,29 @@ term_data_init(term_data *td, int i)
     }
 
     if (!font) {
+#ifdef USE_XFT
+        const auto font_main = use_xft_runtime ? DEFAULT_X11_FONT_TRUETYPE : DEFAULT_X11_FONT_BMP;
+        const auto font_sub = use_xft_runtime ? DEFAULT_X11_FONT_TRUETYPE_SUB : DEFAULT_X11_FONT_BMP_SUB;
+#else
+        const auto font_main = DEFAULT_X11_FONT_BMP;
+        const auto font_sub = DEFAULT_X11_FONT_BMP_SUB;
+#endif
         switch (i) {
-        case 0: {
-            font = DEFAULT_X11_FONT_0;
-        } break;
-        case 1: {
-            font = DEFAULT_X11_FONT_1;
-        } break;
-        case 2: {
-            font = DEFAULT_X11_FONT_2;
-        } break;
-        case 3: {
-            font = DEFAULT_X11_FONT_3;
-        } break;
-        case 4: {
-            font = DEFAULT_X11_FONT_4;
-        } break;
-        case 5: {
-            font = DEFAULT_X11_FONT_5;
-        } break;
-        case 6: {
-            font = DEFAULT_X11_FONT_6;
-        } break;
-        case 7: {
-            font = DEFAULT_X11_FONT_7;
-        } break;
-        default: {
-            font = DEFAULT_X11_FONT;
-        }
+        case 0:
+            font = font_main;
+            break;
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+            font = font_sub;
+            break;
+        default:
+            font = font_main;
+            break;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,6 +187,8 @@ static void display_usage(const char *program)
     puts("  -mx11    To use X11");
     puts("  --       Sub options");
     puts("  -- -d    Set display name");
+    puts("  -- -fb   Use bitmap fonts");
+    puts("  -- -ft   Use TrueType fonts");
     puts("  -- -o    Request old 8x8 tile graphics");
     puts("  -- -a    Request Adam Bolt 16x16 tile graphics");
     puts("  -- -b    Request Bigtile graphics mode");

--- a/src/system/h-config.h
+++ b/src/system/h-config.h
@@ -61,32 +61,23 @@ constexpr auto MAINTAINER = "echizen@users.sourceforge.jp";
     #define DEFAULT_LIB_PATH "./lib/"
   #endif
   
-  #ifdef USE_XFT
-    #ifdef JP
-      #define DEFAULT_X11_FONT "monospace-24:lang=ja:spacing=90"
-      #define DEFAULT_X11_FONT_SUB "sans-serif-16:lang=ja"
-    #else
-      #define DEFAULT_X11_FONT "monospace-24:lang=en:spacing=90"
-      #define DEFAULT_X11_FONT_SUB "sans-serif-16:lang=en"
-    #endif
+  #ifdef JP
+    #define DEFAULT_X11_FONT_BMP "12x24,-*-*-medium-r-normal--24-*-*-*-*-*-jisx0208.1983-0"
+    #define DEFAULT_X11_FONT_BMP_SUB "8x16,-*-*-medium-r-normal--16-*-*-*-*-*-jisx0208.1983-0"
   #else
-    #ifdef JP
-      #define DEFAULT_X11_FONT "12x24,-*-*-medium-r-normal--24-*-*-*-*-*-jisx0208.1983-0"
-      #define DEFAULT_X11_FONT_SUB "8x16,-*-*-medium-r-normal--16-*-*-*-*-*-jisx0208.1983-0"
-    #else
-      #define DEFAULT_X11_FONT "-*-*-medium-r-normal--24-*-*-*-*-*-iso8859-1"
-      #define DEFAULT_X11_FONT_SUB "-*-*-medium-r-normal--16-*-*-*-*-*-iso8859-1"
-    #endif
+    #define DEFAULT_X11_FONT_BMP "-*-*-medium-r-normal--24-*-*-*-*-*-iso8859-1"
+    #define DEFAULT_X11_FONT_BMP_SUB "-*-*-medium-r-normal--16-*-*-*-*-*-iso8859-1"
   #endif
   
-  #define DEFAULT_X11_FONT_0 DEFAULT_X11_FONT
-  #define DEFAULT_X11_FONT_1 DEFAULT_X11_FONT_SUB
-  #define DEFAULT_X11_FONT_2 DEFAULT_X11_FONT_SUB
-  #define DEFAULT_X11_FONT_3 DEFAULT_X11_FONT_SUB
-  #define DEFAULT_X11_FONT_4 DEFAULT_X11_FONT_SUB
-  #define DEFAULT_X11_FONT_5 DEFAULT_X11_FONT_SUB
-  #define DEFAULT_X11_FONT_6 DEFAULT_X11_FONT_SUB
-  #define DEFAULT_X11_FONT_7 DEFAULT_X11_FONT_SUB
+  #ifdef USE_XFT
+    #ifdef JP
+      #define DEFAULT_X11_FONT_TRUETYPE "monospace-24:lang=ja:spacing=90"
+      #define DEFAULT_X11_FONT_TRUETYPE_SUB "sans-serif-16:lang=ja"
+    #else
+      #define DEFAULT_X11_FONT_TRUETYPE "monospace-24:lang=en:spacing=90"
+      #define DEFAULT_X11_FONT_TRUETYPE_SUB "sans-serif-16:lang=en"
+    #endif
+  #endif
   
   #ifdef JP
     #ifdef EUC


### PR DESCRIPTION
これまでコンパイル時に排他的選択だったbitmapフォントとTrueTypeフォントを同時にサポートし、コマンドラインオプションで切り替えられるようにする。

これまでは `--enable-xft` を指定して `./configure` を実行すると、TrueTypeフォントを使用できるようになる一方bitmapフォントが使用不可となっていたが、このコミットで両方を起動時オプションにより切り替えて使用可能となる。

起動時オプションで `--` の後に `-fb` を指定するとbitmapフォント、 `-ft` を指定するとTrueTypeフォントを使用する。
