### PR TITLE
[Implement] Visual Studio 2026対応

### DIFF
--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
 
     steps:
       - uses: actions/checkout@v3

--- a/VisualStudio/Hengband.sln
+++ b/VisualStudio/Hengband.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11716.220 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Hengband", "Hengband\Hengband.vcxproj", "{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}"
 EndProject

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -45,24 +45,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -122,6 +122,9 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -161,6 +164,9 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
       <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -193,6 +199,9 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
       <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -234,6 +243,9 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <CompileAsManaged>false</CompileAsManaged>
       <ConformanceMode>true</ConformanceMode>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/floor/object-scanner.cpp
+++ b/src/floor/object-scanner.cpp
@@ -85,10 +85,10 @@ static std::string prepare_label_string_floor(const FloorType &floor, const std:
 COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION y, POSITION x, TERM_LEN *min_width, const ItemTester &item_tester)
 {
     const Pos2D pos(y, x);
-    constexpr auto max_items = 23; //!< @todo 1マスに落ちているアイテムの最大数. ヘッダに移したい.
+    constexpr size_t max_items = 23; //!< @todo 1マスに落ちているアイテムの最大数. ヘッダに移したい.
     COMMAND_CODE m;
     int j, l;
-    COMMAND_CODE out_index[max_items]{};
+    short out_index[max_items]{};
     TERM_COLOR out_color[max_items]{};
     std::array<std::string, max_items> descriptions{};
     COMMAND_CODE target_item_label = 0;
@@ -101,7 +101,7 @@ COMMAND_CODE show_floor_items(PlayerType *player_ptr, int target_item, POSITION 
     for (size_t i = 0; (i < floor_item_index.size()) && (i < max_items); i++) {
         const auto &item = *floor.o_list[floor_item_index[i]];
         const auto item_name = describe_flavor(player_ptr, item, 0);
-        out_index[k] = i;
+        out_index[k] = static_cast<short>(i);
         const auto tval = item.bi_key.tval();
         out_color[k] = tval_to_attr[enum2i(tval) & 0x7F];
         descriptions[k] = item_name;

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -754,13 +754,13 @@ tl::optional<short> get_item_floor(PlayerType *player_ptr, std::string_view pmt,
         case '8':
         case '9': {
             if (command_wrk != USE_FLOOR) {
-                const auto i_idx = get_tag(player_ptr, fis.which, command_wrk, item_tester);
-                if (!i_idx) {
+                const auto tag_opt = get_tag(player_ptr, fis.which, command_wrk, item_tester);
+                if (!tag_opt) {
                     bell();
                     break;
                 }
 
-                fis.k = *i_idx;
+                fis.k = *tag_opt;
                 if ((fis.k < INVEN_MAIN_HAND) ? !fis.inven : !fis.equip) {
                     bell();
                     break;
@@ -804,11 +804,11 @@ tl::optional<short> get_item_floor(PlayerType *player_ptr, std::string_view pmt,
             bool tag_not_found = false;
 
             if (command_wrk != USE_FLOOR) {
-                const auto i_idx = get_tag(player_ptr, fis.which, command_wrk, item_tester);
-                if (!i_idx) {
+                const auto tag_opt = get_tag(player_ptr, fis.which, command_wrk, item_tester);
+                if (!tag_opt) {
                     tag_not_found = true;
                 } else {
-                    fis.k = *i_idx;
+                    fis.k = *tag_opt;
                     if ((fis.k < INVEN_MAIN_HAND) ? !fis.inven : !fis.equip) {
                         tag_not_found = true;
                     }
@@ -847,14 +847,15 @@ tl::optional<short> get_item_floor(PlayerType *player_ptr, std::string_view pmt,
                         fis.k = label_to_equipment(player_ptr, which);
                     }
                 } else if (command_wrk == USE_FLOOR) {
+                    const auto floor_item_index_size = static_cast<short>(fis.floor_item_index.size());
                     if (which == '(') {
                         fis.k = 0;
                     } else if (which == ')') {
-                        fis.k = fis.floor_item_index.size() - 1;
+                        fis.k = floor_item_index_size - 1;
                     } else {
                         fis.k = islower(which) ? A2I(which) : -1;
                     }
-                    if (fis.k < 0 || fis.k >= static_cast<short>(fis.floor_item_index.size()) || fis.k >= 23) {
+                    if (fis.k < 0 || fis.k >= floor_item_index_size || fis.k >= 23) {
                         bell();
                         break;
                     }

--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -97,7 +97,7 @@ static tl::optional<bool> final_summon(PlayerType *player_ptr, MonsterDeath *md_
         }
 
         BIT_FLAGS mode = dead_mode(md_ptr);
-        const auto summon_src = md_ptr->m_ptr->is_pet() ? -1 : md_ptr->m_idx;
+        const short summon_src = md_ptr->m_ptr->is_pet() ? -1 : md_ptr->m_idx;
         if (summon_named_creature(player_ptr, summon_src, m_pos.y, m_pos.x, summon_data.id, mode) && player_can_see_bold(player_ptr, m_pos.y, m_pos.x)) {
             notice = true;
         }

--- a/src/specific-object/chest.cpp
+++ b/src/specific-object/chest.cpp
@@ -74,11 +74,11 @@ void Chest::open(bool scatter, const Pos2D &pos, short item_idx)
         if (small && one_in_(4)) {
             item_inner_chest = floor.make_gold();
         } else {
-            auto item = make_object(this->player_ptr, mode);
-            if (!item) {
+            auto item_inner_chest_opt = make_object(this->player_ptr, mode);
+            if (!item_inner_chest_opt) {
                 continue;
             }
-            item_inner_chest = std::move(*item);
+            item_inner_chest = std::move(*item_inner_chest_opt);
         }
 
         if (!scatter) {

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -428,12 +428,12 @@ void store_maintenance(PlayerType *player_ptr, int town_num, StoreSaleType store
     }
 
     const int level = store_level(store_num);
-    const int store_max_keep = (store_num == StoreSaleType::BLACK) ? STORE_MAX_KEEP * (level + 60) / 20 : STORE_MAX_KEEP;
-    const int store_min_keep = (store_num == StoreSaleType::BLACK) ? STORE_MIN_KEEP * (level + 60) / 20 : STORE_MIN_KEEP;
-    const int store_turnover = (store_num == StoreSaleType::BLACK) ? STORE_TURNOVER * (level + 60) / 20 : STORE_TURNOVER;
+    const short store_max_keep = (store_num == StoreSaleType::BLACK) ? STORE_MAX_KEEP * (level + 60) / 20 : STORE_MAX_KEEP;
+    const short store_min_keep = (store_num == StoreSaleType::BLACK) ? STORE_MIN_KEEP * (level + 60) / 20 : STORE_MIN_KEEP;
+    const short store_turnover = (store_num == StoreSaleType::BLACK) ? STORE_TURNOVER * (level + 60) / 20 : STORE_TURNOVER;
     chance = (store_num == StoreSaleType::BLACK) ? chance * (level + 60) / 20 : chance;
 
-    INVENTORY_IDX j = st_ptr->stock_num;
+    auto j = st_ptr->stock_num;
     int remain = store_turnover + std::max(0, j - store_max_keep);
     int turn_over = 1;
     for (int i = 0; i < chance; i++) {

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -971,9 +971,9 @@ void MonraceDefinition::increment_tkills()
     }
 }
 
-void MonraceDefinition::emplace_final_summon(MonraceId id, int probability, int min_num, int max_num, int radius)
+void MonraceDefinition::emplace_final_summon(MonraceId id, int probability, int min_summon_num, int max_summon_num, int radius)
 {
-    this->final_summons.emplace_back(MonsterSummon(id, probability, min_num, max_num, radius));
+    this->final_summons.emplace_back(MonsterSummon(id, probability, min_summon_num, max_summon_num, radius));
 }
 
 const std::vector<MonsterSummon> &MonraceDefinition::get_final_summons() const

--- a/src/view/display-lore-attacks.cpp
+++ b/src/view/display-lore-attacks.cpp
@@ -157,10 +157,10 @@ void display_monster_melee_summary_line(lore_type *lore_ptr)
     }
 
     // lore_ptr の作業領域(p/q/色)を壊さないよう退避
-    const char *saved_p = lore_ptr->p;
-    const char *saved_q = lore_ptr->q;
-    const int saved_pc = lore_ptr->pc;
-    const int saved_qc = lore_ptr->qc;
+    const auto *saved_p = lore_ptr->p;
+    const auto *saved_q = lore_ptr->q;
+    const auto saved_pc = lore_ptr->pc;
+    const auto saved_qc = lore_ptr->qc;
 
     const int max_attack_numbers = 4;
     bool any = false;


### PR DESCRIPTION
/Wall (警告レベル最大)だと、標準ライブラリ周りでコンパイルエラーが多発した
/W4に落としたところ標準ライブラリ周りのエラーが出なくなったのでこれでしばらく様子見とする

そもそもWin32API側を何とかしろと言いたいですが、現状コンパイルすら通らないのは不便すぎるので警告レベルを落としました
もし標準ライブラリ側が更新された旨を検知したら再調査します