### PR TITLE
[Refactor] AutopickSearch::item に関する判定や操作をスマートポインタ向けに最適化した

### DIFF
--- a/src/autopick/autopick-finder.cpp
+++ b/src/autopick/autopick-finder.cpp
@@ -95,7 +95,7 @@ AutopickSearch get_string_for_search(PlayerType *player_ptr, const AutopickSearc
     std::string buf = as.search_str;
     constexpr auto max_len = 80;
     uint8_t color = TERM_YELLOW;
-    if (as.item != nullptr) {
+    if (as.item) {
         color = TERM_L_GREEN;
     }
 
@@ -142,12 +142,11 @@ AutopickSearch get_string_for_search(PlayerType *player_ptr, const AutopickSearc
         case '\r':
         case KTRL('s'): {
             as.result = back ? AutopickSearchResult::BACK : AutopickSearchResult::FORWARD;
-            if (as.item != nullptr) {
+            if (as.item) {
                 return as;
             }
 
             as.search_str = buf;
-            as.item = nullptr;
             return as;
         }
         case KTRL('i'):
@@ -193,7 +192,7 @@ AutopickSearch get_string_for_search(PlayerType *player_ptr, const AutopickSearc
             const auto c = static_cast<char>(skey);
             if (color != TERM_WHITE) {
                 if (color == TERM_L_GREEN) {
-                    as.item = nullptr;
+                    as.item.reset();
                     as.search_str = "";
                 }
 
@@ -230,7 +229,7 @@ AutopickSearch get_string_for_search(PlayerType *player_ptr, const AutopickSearc
             continue;
         }
 
-        as.item = nullptr;
+        as.item.reset();
         as.search_str = "";
         pos = 0;
         buf = "";


### PR DESCRIPTION
nullptr 周りで警告こそ出ていないものの生ポインタを意識した文を改善しました
修正が少ないのでチケットは特にありません