### PR TITLE
[Feature] #5304 バフ解除の効果音定義および再生処理の追加

### DIFF
--- a/src/main/sound-definitions-table.cpp
+++ b/src/main/sound-definitions-table.cpp
@@ -38,6 +38,7 @@ const std::map<SoundKind, std::string> sound_names = {
     { SoundKind::BUY, "buy" },
     { SoundKind::SELL, "sell" },
     { SoundKind::WARN, "warn" },
+    { SoundKind::BUFF_EXPIRE, "buff_expire" },
     { SoundKind::ROCKET, "rocket" },
     { SoundKind::N_KILL, "n_kill" },
     { SoundKind::U_KILL, "u_kill" },

--- a/src/main/sound-definitions-table.h
+++ b/src/main/sound-definitions-table.h
@@ -40,6 +40,7 @@ enum class SoundKind {
     BUY,
     SELL,
     WARN,
+    BUFF_EXPIRE,
     ROCKET, /*!< (unused) Somebody's shooting rockets */
     N_KILL, /*!< The player kills a non-living/undead monster */
     U_KILL, /*!< (unused) The player kills a unique*/

--- a/src/mind/mind-force-trainer.cpp
+++ b/src/mind/mind-force-trainer.cpp
@@ -8,6 +8,8 @@
 #include "floor/geometry.h"
 #include "game-option/disturbance-options.h"
 #include "grid/grid.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "mind/mind-magic-resistance.h"
 #include "mind/mind-numbers.h"
 #include "monster-floor/monster-summon.h"
@@ -125,6 +127,7 @@ void set_lightspeed(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->lightspeed) {
             msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/mind/mind-magic-resistance.cpp
+++ b/src/mind/mind-magic-resistance.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -35,6 +37,7 @@ bool set_resist_magic(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->resist_magic) {
             msg_print(_("魔法に弱くなった。", "You are no longer protected from magic."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/mind/mind-mirror-master.cpp
+++ b/src/mind/mind-mirror-master.cpp
@@ -22,6 +22,8 @@
 #include "grid/grid.h"
 #include "io/cursor.h"
 #include "io/screen-util.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "mind/mind-magic-resistance.h"
 #include "mind/mind-numbers.h"
 #include "pet/pet-util.h"
@@ -272,6 +274,7 @@ bool set_multishadow(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->multishadow) {
             msg_print(_("幻影が消えた。", "Your Shadow disappears."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -320,6 +323,7 @@ bool set_dustrobe(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->dustrobe) {
             msg_print(_("鏡のオーラが消えた。", "The mirror shards disappear."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -35,6 +37,7 @@ bool set_leveling(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tsubureru) {
             msg_print(_("もう横に伸びていない。", "Your body returns to normal."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/realm/realm-song.cpp
+++ b/src/realm/realm-song.cpp
@@ -3,6 +3,8 @@
 #include "effect/effect-characteristics.h"
 #include "effect/effect-processor.h"
 #include "hpmp/hp-mp-processor.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-info/class-info.h"
 #include "player/attack-defense-types.h"
 #include "player/player-status.h"
@@ -107,6 +109,7 @@ tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (stop) {
             if (!player_ptr->blessed) {
                 msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
+                sound(SoundKind::BUFF_EXPIRE);
             }
         }
 
@@ -249,6 +252,7 @@ tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (stop) {
             if (!player_ptr->hero) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
+                sound(SoundKind::BUFF_EXPIRE);
                 RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
         }
@@ -384,6 +388,7 @@ tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (stop) {
             if (!player_ptr->tim_stealth) {
                 msg_print(_("姿がはっきりと見えるようになった。", "You are no longer hidden."));
+                sound(SoundKind::BUFF_EXPIRE);
             }
         }
 
@@ -510,24 +515,42 @@ tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell
         }
 
         if (stop) {
+            auto sound_played = false;
             if (!player_ptr->oppose_acid) {
                 msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
+                sound(SoundKind::BUFF_EXPIRE);
+                sound_played = true;
             }
 
             if (!player_ptr->oppose_elec) {
                 msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to elec."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                    sound_played = true;
+                }
             }
 
             if (!player_ptr->oppose_fire) {
                 msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                    sound_played = true;
+                }
             }
 
             if (!player_ptr->oppose_cold) {
                 msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                    sound_played = true;
+                }
             }
 
             if (!player_ptr->oppose_pois) {
                 msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to pois."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                }
             }
         }
 
@@ -547,6 +570,7 @@ tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (stop) {
             if (!player_ptr->effects()->acceleration().is_fast()) {
                 msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+                sound(SoundKind::BUFF_EXPIRE);
             }
         }
 
@@ -741,13 +765,19 @@ tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell
         }
 
         if (stop) {
+            auto sound_played = false;
             if (!player_ptr->hero) {
                 msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
+                sound(SoundKind::BUFF_EXPIRE);
+                sound_played = true;
                 RedrawingFlagsUpdater::get_instance().set_flag(StatusRecalculatingFlag::HP);
             }
 
             if (!player_ptr->effects()->acceleration().is_fast()) {
                 msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+                if (!sound_played) {
+                    sound(SoundKind::BUFF_EXPIRE);
+                }
             }
         }
 
@@ -846,6 +876,7 @@ tl::optional<std::string> do_music_spell(PlayerType *player_ptr, SPELL_IDX spell
         if (stop) {
             if (!player_ptr->invuln) {
                 msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
+                sound(SoundKind::BUFF_EXPIRE);
                 auto &rfu = RedrawingFlagsUpdater::get_instance();
                 rfu.set_flag(MainWindowRedrawingFlag::MAP);
                 rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);

--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -9,6 +9,8 @@
 #include "game-option/disturbance-options.h"
 #include "inventory/inventory-slot-types.h"
 #include "io/input-key-acceptor.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "object-enchant/object-ego.h"
 #include "object/item-use-flags.h"
 #include "player-info/equipment-info.h"
@@ -38,26 +40,31 @@ bool set_ele_attack(PlayerType *player_ptr, uint32_t attack_type, TIME_EFFECT v)
     if ((player_ptr->special_attack & (ATTACK_ACID)) && (attack_type != ATTACK_ACID)) {
         player_ptr->special_attack &= ~(ATTACK_ACID);
         msg_print(_("酸で攻撃できなくなった。", "Your temporary acidic brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_attack & (ATTACK_ELEC)) && (attack_type != ATTACK_ELEC)) {
         player_ptr->special_attack &= ~(ATTACK_ELEC);
         msg_print(_("電撃で攻撃できなくなった。", "Your temporary electrical brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_attack & (ATTACK_FIRE)) && (attack_type != ATTACK_FIRE)) {
         player_ptr->special_attack &= ~(ATTACK_FIRE);
         msg_print(_("火炎で攻撃できなくなった。", "Your temporary fiery brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_attack & (ATTACK_COLD)) && (attack_type != ATTACK_COLD)) {
         player_ptr->special_attack &= ~(ATTACK_COLD);
         msg_print(_("冷気で攻撃できなくなった。", "Your temporary frost brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_attack & (ATTACK_POIS)) && (attack_type != ATTACK_POIS)) {
         player_ptr->special_attack &= ~(ATTACK_POIS);
         msg_print(_("毒で攻撃できなくなった。", "Your temporary poison brand fades away."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((v) && (attack_type)) {
@@ -115,26 +122,31 @@ bool set_ele_immune(PlayerType *player_ptr, uint32_t immune_type, TIME_EFFECT v)
     if ((player_ptr->special_defense & (DEFENSE_ACID)) && (immune_type != DEFENSE_ACID)) {
         player_ptr->special_defense &= ~(DEFENSE_ACID);
         msg_print(_("酸の攻撃で傷つけられるようになった。。", "You are no longer immune to acid."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_ELEC)) && (immune_type != DEFENSE_ELEC)) {
         player_ptr->special_defense &= ~(DEFENSE_ELEC);
         msg_print(_("電撃の攻撃で傷つけられるようになった。。", "You are no longer immune to electricity."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_FIRE)) && (immune_type != DEFENSE_FIRE)) {
         player_ptr->special_defense &= ~(DEFENSE_FIRE);
         msg_print(_("火炎の攻撃で傷つけられるようになった。。", "You are no longer immune to fire."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_COLD)) && (immune_type != DEFENSE_COLD)) {
         player_ptr->special_defense &= ~(DEFENSE_COLD);
         msg_print(_("冷気の攻撃で傷つけられるようになった。。", "You are no longer immune to cold."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_POIS)) && (immune_type != DEFENSE_POIS)) {
         player_ptr->special_defense &= ~(DEFENSE_POIS);
         msg_print(_("毒の攻撃で傷つけられるようになった。。", "You are no longer immune to poison."));
+        sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((v) && (immune_type)) {

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -11,6 +11,8 @@
 #include "effect/effect-characteristics.h"
 #include "effect/effect-processor.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-info/race-info.h"
 #include "spell-kind/spells-detection.h"
 #include "spell-kind/spells-floor.h"
@@ -54,6 +56,7 @@ bool set_tim_sh_holy(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_sh_holy) {
             msg_print(_("聖なるオーラが消えた。", "The holy aura disappeared."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -104,6 +107,7 @@ bool set_tim_eyeeye(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_eyeeye) {
             msg_print(_("懲罰を執行することができなくなった。", "You lost your aura of retribution."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/spell-realm/spells-demon.cpp
+++ b/src/spell-realm/spells-demon.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -35,6 +37,7 @@ bool set_tim_sh_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_sh_fire) {
             msg_print(_("炎のオーラが消えた。", "The fiery aura disappeared."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/spell-realm/spells-song.cpp
+++ b/src/spell-realm/spells-song.cpp
@@ -4,6 +4,8 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-base/player-class.h"
 #include "player-info/bard-data-type.h"
 #include "player/attack-defense-types.h"
@@ -111,6 +113,7 @@ bool set_tim_stealth(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_stealth && !music_singing(player_ptr, MUSIC_STEALTH)) {
             msg_print(_("足音が大きくなった。", "You no longer walk silently."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/body-improvement.cpp
+++ b/src/status/body-improvement.cpp
@@ -6,6 +6,8 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player/player-status.h"
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
@@ -59,6 +61,7 @@ void BodyImprovement::set_protection(short v, bool is_decrease)
     } else {
         if (is_protected) {
             msg_print(_("邪悪なる存在から守られている感じがなくなった。", "You no longer feel safe from evil."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -117,6 +120,7 @@ bool set_invuln(PlayerType *player_ptr, short v, bool do_dec)
     } else {
         if (player_ptr->invuln && !music_singing(player_ptr, MUSIC_INVULN)) {
             msg_print(_("無敵ではなくなった。", "The invulnerability wears off."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
             rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
@@ -169,6 +173,7 @@ bool set_tim_regen(PlayerType *player_ptr, short v, bool do_dec)
     } else {
         if (player_ptr->tim_regen) {
             msg_print(_("素早く回復する感じがなくなった。", "You feel you are no longer regenerating quickly."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -217,6 +222,7 @@ bool set_tim_reflect(PlayerType *player_ptr, short v, bool do_dec)
     } else {
         if (player_ptr->tim_reflect) {
             msg_print(_("体の表面が滑かでなくなった。", "Your body is no longer smooth."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -265,6 +271,7 @@ bool set_pass_wall(PlayerType *player_ptr, short v, bool do_dec)
     } else {
         if (player_ptr->tim_pass_wall) {
             msg_print(_("体が物質化した。", "You are no longer ethereal."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -313,6 +320,7 @@ bool set_tim_emission(PlayerType *player_ptr, short v, bool do_dec)
     } else {
         if (player_ptr->tim_emission) {
             msg_print(_("体の光が消え去った。", "Your body stopped emitting light."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -361,6 +369,7 @@ bool set_tim_exorcism(PlayerType *player_ptr, short v, bool do_dec)
     } else {
         if (player_ptr->tim_exorcism) {
             msg_print(_("浄化の力を失った。", "You are no longer exorcist."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/buff-setter.cpp
+++ b/src/status/buff-setter.cpp
@@ -6,6 +6,8 @@
 #include "core/stuff-handler.h"
 #include "core/window-redrawer.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "monster/monster-status-setter.h"
 #include "player-base/player-class.h"
 #include "player-info/class-info.h"
@@ -144,6 +146,7 @@ bool set_acceleration(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
             is_singing |= music_singing(player_ptr, MUSIC_SHERO);
             if (!is_singing) {
                 msg_print(_("動きの素早さがなくなったようだ。", "You feel yourself slow down."));
+                sound(SoundKind::BUFF_EXPIRE);
                 notice = true;
             }
         }
@@ -195,6 +198,7 @@ bool set_shield(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->shield) {
             msg_print(_("肌が元に戻った。", "Your skin returns to normal."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -243,6 +247,7 @@ bool set_magicdef(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->magicdef) {
             msg_print(_("魔法の防御力が元に戻った。", "You feel less resistant to magic."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -291,6 +296,7 @@ bool set_blessed(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->blessed && !music_singing(player_ptr, MUSIC_BLESS)) {
             msg_print(_("高潔な気分が消え失せた。", "The prayer has expired."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -339,6 +345,7 @@ bool set_hero(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->hero && !music_singing(player_ptr, MUSIC_HERO) && !music_singing(player_ptr, MUSIC_SHERO)) {
             msg_print(_("ヒーローの気分が消え失せた。", "The heroism wears off."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -395,6 +402,7 @@ bool set_mimic(PlayerType *player_ptr, TIME_EFFECT v, MimicKindType mimic_race_i
     else {
         if (player_ptr->tim_mimic) {
             msg_print(_("変身が解けた。", "You are no longer transformed."));
+            sound(SoundKind::BUFF_EXPIRE);
             if (player_ptr->mimic_form == MimicKindType::DEMON) {
                 set_oppose_fire(player_ptr, 0, true);
             }
@@ -460,6 +468,7 @@ bool set_berserk(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->berserk) {
+            sound(SoundKind::BUFF_EXPIRE);
             msg_print(_("野蛮な気持ちが消え失せた。", "You feel less berserk."));
             notice = true;
         }
@@ -525,6 +534,7 @@ bool set_wraith_form(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->wraith_form) {
             msg_print(_("不透明になった感じがする。", "You feel opaque."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
             rfu.set_flag(MainWindowRedrawingFlag::MAP);
             rfu.set_flag(StatusRecalculatingFlag::MONSTER_STATUSES);
@@ -575,6 +585,7 @@ bool set_tsuyoshi(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         }
     } else {
         if (player_ptr->tsuyoshi) {
+            sound(SoundKind::BUFF_EXPIRE);
             msg_print(_("肉体が急速にしぼんでいった。", "Your body has quickly shriveled."));
 
             (void)dec_stat(player_ptr, A_CON, 20, true);

--- a/src/status/element-resistance.cpp
+++ b/src/status/element-resistance.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player-base/player-class.h"
 #include "player-base/player-race.h"
 #include "player-info/race-info.h"
@@ -42,6 +44,7 @@ bool set_oppose_acid(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         if (player_ptr->oppose_acid && !music_singing(player_ptr, MUSIC_RESIST) &&
             !PlayerClass(player_ptr).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("酸への耐性が薄れた気がする。", "You feel less resistant to acid."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -89,6 +92,7 @@ bool set_oppose_elec(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         if (player_ptr->oppose_elec && !music_singing(player_ptr, MUSIC_RESIST) &&
             !PlayerClass(player_ptr).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("電撃への耐性が薄れた気がする。", "You feel less resistant to electricity."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -138,6 +142,7 @@ bool set_oppose_fire(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         if (player_ptr->oppose_fire && !music_singing(player_ptr, MUSIC_RESIST) &&
             !PlayerClass(player_ptr).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("火への耐性が薄れた気がする。", "You feel less resistant to fire."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -184,6 +189,7 @@ bool set_oppose_cold(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         if (player_ptr->oppose_cold && !music_singing(player_ptr, MUSIC_RESIST) &&
             !PlayerClass(player_ptr).samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("冷気への耐性が薄れた気がする。", "You feel less resistant to cold."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -234,6 +240,7 @@ bool set_oppose_pois(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         if (player_ptr->oppose_pois && !music_singing(player_ptr, MUSIC_RESIST) &&
             !pc.samurai_stance_is(SamuraiStanceType::MUSOU)) {
             msg_print(_("毒への耐性が薄れた気がする。", "You feel less resistant to poison."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/sight-setter.cpp
+++ b/src/status/sight-setter.cpp
@@ -2,6 +2,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "player/player-status.h"
 #include "realm/realm-song-numbers.h"
 #include "spell-realm/spells-song.h"
@@ -58,6 +60,7 @@ bool set_tim_esp(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_esp && !music_singing(player_ptr, MUSIC_MIND)) {
             msg_print(_("意識は元に戻った。", "Your consciousness contracts again."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -94,6 +97,7 @@ bool set_tim_invis(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_invis) {
             msg_print(_("目の敏感さがなくなったようだ。", "Your eyes feel less sensitive."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -130,6 +134,7 @@ bool set_tim_infra(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_infra) {
             msg_print(_("目の輝きがなくなった。", "Your eyes stop tingling."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }

--- a/src/status/temporary-resistance.cpp
+++ b/src/status/temporary-resistance.cpp
@@ -3,6 +3,8 @@
 #include "core/disturbance.h"
 #include "core/stuff-handler.h"
 #include "game-option/disturbance-options.h"
+#include "main/sound-definitions-table.h"
+#include "main/sound-of-music.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
 #include "view/display-messages.h"
@@ -35,6 +37,7 @@ bool set_tim_levitation(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_levitation) {
             msg_print(_("もう宙に浮かべなくなった。", "You stop flying."));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -77,6 +80,7 @@ bool set_ultimate_res(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->ult_res) {
             msg_print(_("あらゆることに対する耐性が薄れた気がする。", "You feel less resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -121,6 +125,7 @@ bool set_tim_res_nether(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     else {
         if (player_ptr->tim_res_nether) {
             msg_print(_("地獄の力に対する耐性が薄れた気がする。", "You feel less nether-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -162,6 +167,7 @@ bool set_tim_res_lite(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_res_lite) {
             msg_print(_("閃光の力に対する耐性が薄れた気がする。", "You feel less lite-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -203,6 +209,7 @@ bool set_tim_res_dark(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_res_dark) {
             msg_print(_("暗黒の力に対する耐性が薄れた気がする。", "You feel less dark-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -243,6 +250,7 @@ bool set_tim_res_fear(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_res_fear) {
             msg_print(_("恐怖の力に対する耐性が薄れた気がする。", "You feel less fear-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -281,6 +289,7 @@ bool set_tim_res_time(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_res_time) {
             msg_print(_("時間逆転の力に対する耐性が薄れた気がする。", "You feel less time-resistant"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
@@ -321,6 +330,7 @@ bool set_tim_imm_dark(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
     } else {
         if (player_ptr->tim_imm_dark) {
             msg_print(_("暗黒の力に対する完全な耐性を喪った気がする。", "You feel lose dark-immunity"));
+            sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }


### PR DESCRIPTION
SoundKind::BUFF_EXPIREを追加。
プレイヤーにかかる、時間経過で解除されうる良性の状態変化が対象。歌によるものを含む。
時止め、変わり身、超隠密、混乱打撃、帰還、現実変容からの解除は対象外とした。