### PR TITLE
[Fix] 射撃を行うとクラッシュする

### DIFF
--- a/src/cmd-action/cmd-shoot.cpp
+++ b/src/cmd-action/cmd-shoot.cpp
@@ -32,15 +32,15 @@ void do_cmd_fire(PlayerType *player_ptr, SPELL_IDX snipe_type)
     }
 
     player_ptr->is_fired = false;
-    auto *item_ptr = player_ptr->inventory[INVEN_BOW].get();
-    const auto tval = item_ptr->bi_key.tval();
+    auto *bow_ptr = player_ptr->inventory[INVEN_BOW].get();
+    const auto tval = bow_ptr->bi_key.tval();
     if (tval == ItemKindType::NONE) {
         msg_print(_("射撃用の武器を持っていない。", "You have nothing to fire with."));
         flush();
         return;
     }
 
-    const auto sval = item_ptr->bi_key.sval();
+    const auto sval = bow_ptr->bi_key.sval();
     if (sval == SV_CRIMSON) {
         msg_print(_("この武器は発動して使うもののようだ。", "It's already activated."));
         flush();
@@ -56,13 +56,13 @@ void do_cmd_fire(PlayerType *player_ptr, SPELL_IDX snipe_type)
     PlayerClass(player_ptr).break_samurai_stance({ SamuraiStanceType::MUSOU });
     constexpr auto q = _("どれを撃ちますか? ", "Fire which item? ");
     constexpr auto s = _("発射されるアイテムがありません。", "You have nothing to fire.");
-    const auto &[item, i_idx] = choose_item(player_ptr, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(player_ptr->tval_ammo));
-    if (!item) {
+    const auto &[ammo, ammo_idx] = choose_item(player_ptr, q, s, USE_INVEN | USE_FLOOR, TvalItemTester(player_ptr->tval_ammo));
+    if (!ammo) {
         flush();
         return;
     }
 
-    exe_fire(player_ptr, i_idx, item.get(), snipe_type);
+    exe_fire(player_ptr, ammo_idx, bow_ptr, snipe_type);
     if (!player_ptr->is_fired || !PlayerClass(player_ptr).equals(PlayerClassType::SNIPER)) {
         return;
     }


### PR DESCRIPTION
cf79c57 のリファクタリングで射撃武器への参照ポインタを渡すべきところ
射撃する矢弾の参照ポインタを渡すように誤って修正したことが原因。
元の通り射撃武器への参照ポインタを渡すようにするとともに、射撃武器と
矢弾で両方 item という名称を使っているのが間違いを引き起こした原因なので
bowとammoという具体的な種別を示す変数名に変更する。

Resolves #5345
