### PR TITLE
[MISC] 一時的元素免疫の効果切れメッセージ内、句点のダブりを訂正

### DIFF
--- a/src/spell-realm/spells-craft.cpp
+++ b/src/spell-realm/spells-craft.cpp
@@ -121,31 +121,31 @@ bool set_ele_immune(PlayerType *player_ptr, uint32_t immune_type, TIME_EFFECT v)
 
     if ((player_ptr->special_defense & (DEFENSE_ACID)) && (immune_type != DEFENSE_ACID)) {
         player_ptr->special_defense &= ~(DEFENSE_ACID);
-        msg_print(_("酸の攻撃で傷つけられるようになった。。", "You are no longer immune to acid."));
+        msg_print(_("酸の攻撃で傷つけられるようになった。", "You are no longer immune to acid."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_ELEC)) && (immune_type != DEFENSE_ELEC)) {
         player_ptr->special_defense &= ~(DEFENSE_ELEC);
-        msg_print(_("電撃の攻撃で傷つけられるようになった。。", "You are no longer immune to electricity."));
+        msg_print(_("電撃の攻撃で傷つけられるようになった。", "You are no longer immune to electricity."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_FIRE)) && (immune_type != DEFENSE_FIRE)) {
         player_ptr->special_defense &= ~(DEFENSE_FIRE);
-        msg_print(_("火炎の攻撃で傷つけられるようになった。。", "You are no longer immune to fire."));
+        msg_print(_("火炎の攻撃で傷つけられるようになった。", "You are no longer immune to fire."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_COLD)) && (immune_type != DEFENSE_COLD)) {
         player_ptr->special_defense &= ~(DEFENSE_COLD);
-        msg_print(_("冷気の攻撃で傷つけられるようになった。。", "You are no longer immune to cold."));
+        msg_print(_("冷気の攻撃で傷つけられるようになった。", "You are no longer immune to cold."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 
     if ((player_ptr->special_defense & (DEFENSE_POIS)) && (immune_type != DEFENSE_POIS)) {
         player_ptr->special_defense &= ~(DEFENSE_POIS);
-        msg_print(_("毒の攻撃で傷つけられるようになった。。", "You are no longer immune to poison."));
+        msg_print(_("毒の攻撃で傷つけられるようになった。", "You are no longer immune to poison."));
         sound(SoundKind::BUFF_EXPIRE);
     }
 


### PR DESCRIPTION
「◯◯の攻撃で傷つけられるようになった。。」と文末に句点が2つ付けられているものを訂正