### PR TITLE
[Implement] 耐電のアミュレットを追加した

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -22083,5 +22083,35 @@
         },
       ],
     },
+    {
+      "id": 683,
+      "name": {
+        "ja": "耐電",
+        "en": "Resist Elec",
+      },
+      "flavor_name": {
+        "ja": "竜骨の",
+        "en": "Dragonbone",
+      },
+      "symbol": {
+        "character": "\"",
+        "color": "Light Blue",
+      },
+      "itemkind": {
+        "type_value": 40,
+        "subtype_value": 31,
+      },
+      "parameter_value": 0,
+      "level": 12,
+      "weight": 2,
+      "cost": 300,
+      "allocations": [
+        {
+          "depth": 12,
+          "rarity": 1,
+        },
+      ],
+      "flags": ["RES_ELEC", "IGNORE_ELEC"],
+    },
   ],
 }


### PR DESCRIPTION
耐火・耐冷・耐毒・耐光耐暗の各指輪＆耐酸アミュなど多種多様な耐性装備がありながら電撃耐性だけなかったので追加してみました
酸だけアミュレットなのもなんだかなと思って電撃もアミュレットにしてみました
r電のためだけにアミュレットを付けるのは序盤だけだと思われるので大したバランス崩壊にはならないと思われます
ご確認下さい