### PR TITLE
[Refactor] misc_to_attr/misc_to_char をまとめてmisc_to_display_symbol に変えた

### DIFF
--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -315,7 +315,7 @@ void print_rel(PlayerType *player_ptr, const DisplaySymbol &symbol, const Pos2D 
 
 void print_bolt_pict(PlayerType *player_ptr, const Pos2D &pos_src, const Pos2D &pos_dst, AttributeType typ)
 {
-    const auto symbol = bolt_pict(pos_src, pos_dst, typ);
+    const auto &symbol = bolt_pict(pos_src, pos_dst, typ);
     print_rel(player_ptr, symbol, pos_dst);
 }
 

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -208,11 +208,10 @@ static bool interpret_s_token(char *buf)
         return false;
     }
 
-    int j = (byte)strtol(zz[0], nullptr, 0);
-    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-    auto n2 = static_cast<char>(strtol(zz[2], nullptr, 0));
-    misc_to_attr[j] = n1;
-    misc_to_char[j] = n2;
+    const auto j = std::stoi(zz[0], nullptr, 0);
+    const auto n1 = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
+    const auto n2 = static_cast<char>(std::stoi(zz[2], nullptr, 0));
+    misc_to_display_symbol[j] = DisplaySymbol(n1, n2);
     return true;
 }
 

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -208,10 +208,10 @@ static bool interpret_s_token(char *buf)
         return false;
     }
 
-    const auto j = std::stoi(zz[0], nullptr, 0);
-    const auto n1 = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
-    const auto n2 = static_cast<char>(std::stoi(zz[2], nullptr, 0));
-    misc_to_display_symbol[j] = DisplaySymbol(n1, n2);
+    const auto num = std::stoi(zz[0], nullptr, 0);
+    const auto color = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
+    const auto character = static_cast<char>(std::stoi(zz[2], nullptr, 0));
+    ds_bolt[num] = DisplaySymbol(color, character);
     return true;
 }
 

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -355,11 +355,10 @@ std::array<term_type *, 8> angband_terms;
  */
 static const concptr color_char = "dwsorgbuDWvyRGBU";
 
-/*
- * Specify attr/char pairs for visual special effects
- * Be sure to use "index & 0x7F" to avoid illegal access
+/*!
+ * @brief ボルト射出の軌跡を表す色付きシンボルテーブル
  */
-std::array<DisplaySymbol, 256> misc_to_display_symbol{};
+std::array<DisplaySymbol, 256> ds_bolt{};
 
 /*
  * Specify attr/char pairs for inventory items (by tval)
@@ -571,7 +570,7 @@ const DisplaySymbol &bolt_pict(const Pos2D &pos_src, const Pos2D &pos_dst, Attri
     }
 
     const auto k = spell_color(typ);
-    return misc_to_display_symbol[base + k];
+    return ds_bolt[base + k];
 }
 
 /*!

--- a/src/term/gameterm.cpp
+++ b/src/term/gameterm.cpp
@@ -359,8 +359,7 @@ static const concptr color_char = "dwsorgbuDWvyRGBU";
  * Specify attr/char pairs for visual special effects
  * Be sure to use "index & 0x7F" to avoid illegal access
  */
-TERM_COLOR misc_to_attr[256];
-char misc_to_char[256];
+std::array<DisplaySymbol, 256> misc_to_display_symbol{};
 
 /*
  * Specify attr/char pairs for inventory items (by tval)
@@ -554,7 +553,7 @@ static TERM_COLOR spell_color(AttributeType type)
  * @param typ 魔法の効果属性
  * @return 方向キャラID
  */
-DisplaySymbol bolt_pict(const Pos2D &pos_src, const Pos2D &pos_dst, AttributeType typ)
+const DisplaySymbol &bolt_pict(const Pos2D &pos_src, const Pos2D &pos_dst, AttributeType typ)
 {
     int base;
     if (pos_dst == pos_src) {
@@ -572,9 +571,7 @@ DisplaySymbol bolt_pict(const Pos2D &pos_src, const Pos2D &pos_dst, AttributeTyp
     }
 
     const auto k = spell_color(typ);
-    const auto a = misc_to_attr[base + k];
-    const auto c = misc_to_char[base + k];
-    return { a, c };
+    return misc_to_display_symbol[base + k];
 }
 
 /*!

--- a/src/term/gameterm.h
+++ b/src/term/gameterm.h
@@ -21,7 +21,7 @@ extern const concptr ident_info[];
 extern std::array<term_type *, 8> angband_terms;
 #define term_screen (angband_terms[0])
 
-extern std::array<DisplaySymbol, 256> misc_to_display_symbol;
+extern std::array<DisplaySymbol, 256> ds_bolt;
 extern TERM_COLOR tval_to_attr[128];
 extern const char angband_term_name[8][16];
 extern byte angband_color_table[256][4];

--- a/src/term/gameterm.h
+++ b/src/term/gameterm.h
@@ -21,8 +21,7 @@ extern const concptr ident_info[];
 extern std::array<term_type *, 8> angband_terms;
 #define term_screen (angband_terms[0])
 
-extern TERM_COLOR misc_to_attr[256];
-extern char misc_to_char[256];
+extern std::array<DisplaySymbol, 256> misc_to_display_symbol;
 extern TERM_COLOR tval_to_attr[128];
 extern const char angband_term_name[8][16];
 extern byte angband_color_table[256][4];
@@ -34,4 +33,4 @@ extern TERM_COLOR color_char_to_attr(char c);
 extern const std::unordered_map<std::string_view, TERM_COLOR> color_list;
 
 class DisplaySymbol;
-DisplaySymbol bolt_pict(const Pos2D &pos_src, const Pos2D &pos_dst, AttributeType typ);
+const DisplaySymbol &bolt_pict(const Pos2D &pos_src, const Pos2D &pos_dst, AttributeType typ);


### PR DESCRIPTION
生配列×2より構造体arrayの方が分かりやすくなったはずです
ご確認下さい
(変数名がmiscなのは元からですが、何か良いアイディアがあればそちらに差し替えます)