### PR TITLE
[Refactor] tokenizer() の引数からchar** を除外し、戻り値をint からvector<string> に変えた

### DIFF
--- a/src/cmd-io/cmd-dump.cpp
+++ b/src/cmd-io/cmd-dump.cpp
@@ -56,8 +56,7 @@ void do_cmd_pref(PlayerType *player_ptr)
         return;
     }
 
-    auto buf(*input_str);
-    (void)interpret_pref_file(player_ptr, buf.data());
+    (void)interpret_pref_file(player_ptr, *input_str);
 }
 
 /*

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -179,9 +179,9 @@ static void parse_qtw_D(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char *s)
     }
 }
 
-static bool parse_qtw_QQ(QuestType *q_ptr, char **zz, int num)
+static bool parse_qtw_QQ(QuestType *q_ptr, const std::vector<std::string> &tokens, int num)
 {
-    if (zz[1][0] != 'Q') {
+    if (tokens[1][0] != 'Q') {
         return false;
     }
 
@@ -193,18 +193,18 @@ static bool parse_qtw_QQ(QuestType *q_ptr, char **zz, int num)
         return true;
     }
 
-    q_ptr->type = i2enum<QuestKindType>(atoi(zz[2]));
-    q_ptr->num_mon = (MONSTER_NUMBER)atoi(zz[3]);
-    q_ptr->cur_num = (MONSTER_NUMBER)atoi(zz[4]);
-    q_ptr->max_num = (MONSTER_NUMBER)atoi(zz[5]);
-    q_ptr->level = (DEPTH)atoi(zz[6]);
-    q_ptr->r_idx = i2enum<MonraceId>(atoi(zz[7]));
-    const auto fa_id = i2enum<FixedArtifactId>(atoi(zz[8]));
+    q_ptr->type = i2enum<QuestKindType>(std::stoi(tokens[2]));
+    q_ptr->num_mon = std::stoi(tokens[3]);
+    q_ptr->cur_num = std::stoi(tokens[4]);
+    q_ptr->max_num = std::stoi(tokens[5]);
+    q_ptr->level = std::stoi(tokens[6]);
+    q_ptr->r_idx = i2enum<MonraceId>(std::stoi(tokens[7]));
+    const auto fa_id = i2enum<FixedArtifactId>(std::stoi(tokens[8]));
     q_ptr->reward_fa_id = fa_id;
-    q_ptr->dungeon = i2enum<DungeonId>(std::atoi(zz[9]));
+    q_ptr->dungeon = i2enum<DungeonId>(std::stoi(tokens[9]));
 
     if (num > 10) {
-        q_ptr->flags = atoi(zz[10]);
+        q_ptr->flags = std::stoi(tokens[10]);
     }
 
     auto &monrace = q_ptr->get_bounty();
@@ -224,9 +224,9 @@ static bool parse_qtw_QQ(QuestType *q_ptr, char **zz, int num)
 /*!
  * @todo 処理がどうなっているのかいずれチェックする
  */
-static bool parse_qtw_QR(QuestType *q_ptr, char **zz, int num)
+static bool parse_qtw_QR(QuestType *q_ptr, const std::vector<std::string> &tokens, int num)
 {
-    if (zz[1][0] != 'R') {
+    if (tokens[1][0] != 'R') {
         return false;
     }
 
@@ -238,7 +238,7 @@ static bool parse_qtw_QR(QuestType *q_ptr, char **zz, int num)
     auto reward_idx = FixedArtifactId::NONE;
     auto &artifacts = ArtifactList::get_instance();
     for (auto idx = 2; idx < num; idx++) {
-        const auto fa_id = i2enum<FixedArtifactId>(atoi(zz[idx]));
+        const auto fa_id = i2enum<FixedArtifactId>(std::stoi(tokens[idx]));
         if (fa_id == FixedArtifactId::NONE) {
             continue;
         }
@@ -266,10 +266,10 @@ static bool parse_qtw_QR(QuestType *q_ptr, char **zz, int num)
 /*!
  * @brief t_info、q_info、w_infoにおけるQトークンをパースする
  * @param qtwg_ptr トークンパース構造体への参照ポインタ
- * @param zz トークン保管文字列
+ * @param tokens トークン保管文字列
  * @return エラーコード、但しPARSE_CONTINUEの時は処理続行
  */
-static int parse_qtw_Q(qtwg_type *qtwg_ptr, char **zz)
+static int parse_qtw_Q(qtwg_type *qtwg_ptr)
 {
     if (qtwg_ptr->buf[0] != 'Q') {
         return PARSE_CONTINUE;
@@ -285,32 +285,33 @@ static int parse_qtw_Q(qtwg_type *qtwg_ptr, char **zz)
     }
 #endif
 
-    int num = tokenize(qtwg_ptr->buf + _(2, 3), 33, zz);
-    if (num < 3) {
+    const auto tokens = tokenize(qtwg_ptr->buf + _(2, 3), 33);
+    const auto size = tokens.size();
+    if (size < 3) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
     auto &quests = QuestList::get_instance();
-    auto &quest = quests.get_quest(i2enum<QuestId>(atoi(zz[0])));
-    if (parse_qtw_QQ(&quest, zz, num)) {
+    auto &quest = quests.get_quest(i2enum<QuestId>(std::stoi(tokens[0])));
+    if (parse_qtw_QQ(&quest, tokens, size)) {
         return PARSE_ERROR_NONE;
     }
 
-    if (parse_qtw_QR(&quest, zz, num)) {
+    if (parse_qtw_QR(&quest, tokens, size)) {
         return PARSE_ERROR_NONE;
     }
 
-    if (zz[1][0] == 'N') {
+    if (tokens[1][0] == 'N') {
         if (init_flags & (INIT_ASSIGN | INIT_SHOW_TEXT | INIT_NAME_ONLY)) {
-            quest.name = zz[2];
+            quest.name = tokens[2];
         }
 
         return PARSE_ERROR_NONE;
     }
 
-    if (zz[1][0] == 'T') {
+    if (tokens[1][0] == 'T') {
         if ((init_flags & INIT_SHOW_TEXT) && (std::ssize(quest_text_lines) < QUEST_TEST_LINES_MAX)) {
-            quest_text_lines.emplace_back(zz[2]);
+            quest_text_lines.emplace_back(tokens[2]);
         }
 
         return PARSE_ERROR_NONE;
@@ -319,7 +320,7 @@ static int parse_qtw_Q(qtwg_type *qtwg_ptr, char **zz)
     return PARSE_ERROR_GENERIC;
 }
 
-static bool parse_qtw_P(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char **zz)
+static bool parse_qtw_P(PlayerType *player_ptr, qtwg_type *qtwg_ptr)
 {
     if (qtwg_ptr->buf[0] != 'P') {
         return false;
@@ -329,7 +330,8 @@ static bool parse_qtw_P(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char **zz)
         return true;
     }
 
-    if (tokenize(qtwg_ptr->buf + 2, 2, zz) != 2) {
+    const auto tokens = tokenize(qtwg_ptr->buf + 2, 2);
+    if (tokens.size() != 2) {
         return true;
     }
 
@@ -349,17 +351,15 @@ static bool parse_qtw_P(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char **zz)
     panel_row_min = floor.height;
     panel_col_min = floor.width;
     if (floor.is_in_quest()) {
-        POSITION py = atoi(zz[0]);
-        POSITION px = atoi(zz[1]);
-        player_ptr->y = py;
-        player_ptr->x = px;
+        Pos2D p_pos(std::stoi(tokens[0]), std::stoi(tokens[1]));
+        player_ptr->set_position(p_pos);
         delete_monster(player_ptr, player_ptr->get_position());
         return true;
     }
 
     if (!player_ptr->oldpx && !player_ptr->oldpy) {
-        player_ptr->oldpy = atoi(zz[0]);
-        player_ptr->oldpx = atoi(zz[1]);
+        player_ptr->oldpy = std::stoi(tokens[0]);
+        player_ptr->oldpx = std::stoi(tokens[1]);
     }
 
     return true;
@@ -381,7 +381,6 @@ static bool parse_qtw_P(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char **zz)
  */
 parse_error_type generate_fixed_map_floor(PlayerType *player_ptr, qtwg_type *qtwg_ptr, process_dungeon_file_pf parse_fixed_map)
 {
-    char *zz[33];
     if (!qtwg_ptr->buf[0]) {
         return PARSE_ERROR_NONE;
     }
@@ -418,7 +417,7 @@ parse_error_type generate_fixed_map_floor(PlayerType *player_ptr, qtwg_type *qtw
         return PARSE_ERROR_NONE;
     }
 
-    parse_error_type parse_result_Q = i2enum<parse_error_type>(parse_qtw_Q(qtwg_ptr, zz));
+    parse_error_type parse_result_Q = i2enum<parse_error_type>(parse_qtw_Q(qtwg_ptr));
     if (parse_result_Q != PARSE_CONTINUE) {
         return parse_result_Q;
     }
@@ -434,7 +433,7 @@ parse_error_type generate_fixed_map_floor(PlayerType *player_ptr, qtwg_type *qtw
         return pos.error_or(PARSE_ERROR_NONE);
     }
 
-    if (parse_qtw_P(player_ptr, qtwg_ptr, zz)) {
+    if (parse_qtw_P(player_ptr, qtwg_ptr)) {
         return PARSE_ERROR_NONE;
     }
 

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -285,7 +285,7 @@ static int parse_qtw_Q(qtwg_type *qtwg_ptr, char **zz)
     }
 #endif
 
-    int num = tokenize(qtwg_ptr->buf + _(2, 3), 33, zz, 0);
+    int num = tokenize(qtwg_ptr->buf + _(2, 3), 33, zz);
     if (num < 3) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -329,7 +329,7 @@ static bool parse_qtw_P(PlayerType *player_ptr, qtwg_type *qtwg_ptr, char **zz)
         return true;
     }
 
-    if (tokenize(qtwg_ptr->buf + 2, 2, zz, 0) != 2) {
+    if (tokenize(qtwg_ptr->buf + 2, 2, zz) != 2) {
         return true;
     }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -642,7 +642,7 @@ tl::expected<Pos2D, parse_error_type> parse_line_wilderness(char *line, int xmin
 #endif
     {
         char *zz[33];
-        const auto num = tokenize(line + 4, 6, zz, 0);
+        const auto num = tokenize(line + 4, 6, zz);
         if (num <= 1) {
             return tl::unexpected(PARSE_ERROR_TOO_FEW_ARGUMENTS);
         }
@@ -696,7 +696,7 @@ tl::expected<Pos2D, parse_error_type> parse_line_wilderness(char *line, int xmin
         }
 
         char *zz[33];
-        if (tokenize(line + 4, 2, zz, 0) != 2) {
+        if (tokenize(line + 4, 2, zz) != 2) {
             return tl::unexpected(PARSE_ERROR_TOO_FEW_ARGUMENTS);
         }
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -641,32 +641,31 @@ tl::expected<Pos2D, parse_error_type> parse_line_wilderness(char *line, int xmin
     case 'E':
 #endif
     {
-        char *zz[33];
-        const auto num = tokenize(line + 4, 6, zz);
-        if (num <= 1) {
+        const auto tokens = tokenize(line + 4, 6);
+        if (tokens.size() <= 1) {
             return tl::unexpected(PARSE_ERROR_TOO_FEW_ARGUMENTS);
         }
 
-        const int index = zz[0][0];
+        const auto index = tokens.at(0).at(0);
         auto &letter = letters.get_grid(index);
-        if (num > 1) {
-            letter.set_terrain(i2enum<WildernessTerrain>(std::stoi(zz[1])));
+        if (tokens.size() > 1) {
+            letter.set_terrain(i2enum<WildernessTerrain>(std::stoi(tokens.at(1))));
         }
 
-        if (num > 2) {
-            letter.set_level(std::stoi(zz[2]));
+        if (tokens.size() > 2) {
+            letter.set_level(std::stoi(tokens.at(2)));
         }
 
-        if (num > 3) {
-            letter.set_town(static_cast<short>(std::stoi(zz[3])));
+        if (tokens.size() > 3) {
+            letter.set_town(static_cast<short>(std::stoi(tokens.at(3))));
         }
 
-        if (num > 4) {
-            letter.set_road(std::stoi(zz[4]));
+        if (tokens.size() > 4) {
+            letter.set_road(std::stoi(tokens.at(4)));
         }
 
-        if (num > 5) {
-            letter.set_name(zz[5]);
+        if (tokens.size() > 5) {
+            letter.set_name(tokens.at(5));
         }
 
         break;
@@ -695,12 +694,12 @@ tl::expected<Pos2D, parse_error_type> parse_line_wilderness(char *line, int xmin
             break;
         }
 
-        char *zz[33];
-        if (tokenize(line + 4, 2, zz) != 2) {
+        const auto tokens = tokenize(line + 4, 2);
+        if (tokens.size() != 2) {
             return tl::unexpected(PARSE_ERROR_TOO_FEW_ARGUMENTS);
         }
 
-        wilderness.set_starting_player_position({ std::stoi(zz[0]), std::stoi(zz[1]) });
+        wilderness.set_starting_player_position({ std::stoi(tokens.at(0)), std::stoi(tokens.at(1)) });
         wilderness.initialize_position();
         if (!wilderness.is_player_in_bounds()) {
             return tl::unexpected(PARSE_ERROR_OUT_OF_BOUNDS);

--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -103,7 +103,7 @@ parse_error_type parse_line_feature(const FloorType &floor, char *buf)
     }
 
     char *zz[9];
-    int num = tokenize(buf + 2, 9, zz, 0);
+    int num = tokenize(buf + 2, 9, zz);
     if (num <= 1) {
         return PARSE_ERROR_GENERIC;
     }
@@ -251,7 +251,7 @@ parse_error_type parse_line_building(char *buf)
 
     switch (s[0]) {
     case 'N': {
-        if (tokenize(s + 2, 3, zz, 0) == 3) {
+        if (tokenize(s + 2, 3, zz) == 3) {
             strcpy(buildings[index].name, zz[0]);
             strcpy(buildings[index].owner_name, zz[1]);
             strcpy(buildings[index].owner_race, zz[2]);
@@ -261,7 +261,7 @@ parse_error_type parse_line_building(char *buf)
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
     case 'A': {
-        if (tokenize(s + 2, 8, zz, 0) >= 7) {
+        if (tokenize(s + 2, 8, zz) >= 7) {
             int action_index = atoi(zz[0]);
             strcpy(buildings[index].act_names[action_index], zz[1]);
             buildings[index].member_costs[action_index] = (PRICE)atoi(zz[2]);
@@ -276,7 +276,7 @@ parse_error_type parse_line_building(char *buf)
     }
     case 'C': {
         auto pct_max = PLAYER_CLASS_TYPE_MAX;
-        auto n = tokenize(s + 2, pct_max, zz, 0);
+        auto n = tokenize(s + 2, pct_max, zz);
         for (auto i = 0; i < pct_max; i++) {
             buildings[index].member_class[i] = (i < n) ? atoi(zz[i]) : 1;
         }
@@ -284,7 +284,7 @@ parse_error_type parse_line_building(char *buf)
         break;
     }
     case 'R': {
-        auto n = tokenize(s + 2, MAX_RACES, zz, 0);
+        auto n = tokenize(s + 2, MAX_RACES, zz);
         for (int i = 0; i < MAX_RACES; i++) {
             buildings[index].member_race[i] = (i < n) ? atoi(zz[i]) : 1;
         }
@@ -293,7 +293,7 @@ parse_error_type parse_line_building(char *buf)
     }
     case 'M': {
         int n;
-        n = tokenize(s + 2, MAX_MAGIC, zz, 0);
+        n = tokenize(s + 2, MAX_MAGIC, zz);
         for (int i = 0; i < MAX_MAGIC; i++) {
             buildings[index].member_realm[i + 1] = ((i < n) ? static_cast<int16_t>(atoi(zz[i])) : 1);
         }

--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -39,12 +39,11 @@ void dungeon_grid::set_trap_id(TerrainTag tag)
  * @brief パース関数に基づいてデータファイルからデータを読み取る /
  * Initialize an "*_info" array, by parsing an ascii "template" file
  * @param fp 読み取りに使うファイルポインタ
- * @param buf 読み取りに使うバッファ領域
  * @param head ヘッダ構造体
  * @param parse_info_txt_line パース関数
- * @return エラーコード, エラー行番号
+ * @return エラーコード, エラー行番号, エラーが起きた行の内容
  */
-std::tuple<errr, int> init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_txt_line)
+std::tuple<errr, int, std::string> init_info_txt(FILE *fp, angband_header *head, Parser parse_info_txt_line)
 {
     error_idx = -1;
     auto error_line = 0;
@@ -52,41 +51,38 @@ std::tuple<errr, int> init_info_txt(FILE *fp, char *buf, angband_header *head, P
     util::SHA256 sha256;
 
     while (true) {
-        // init_info_txtの呼び出し側のbufは1024バイト
-        const auto line_str = angband_fgets(fp, 1024);
-        if (!line_str) {
+        const auto line_opt = angband_fgets(fp);
+        if (!line_opt) {
             break;
         }
+
+        const std::string_view line = *line_opt;
         error_line++;
-        const auto len = line_str->copy(buf, 1024 - 1);
-        buf[len] = '\0';
-        const std::string_view line = buf;
+
         if (line.empty() || line.starts_with('#')) {
             continue;
         }
 
         if (!line.substr(1).starts_with(':')) {
-            return { PARSE_ERROR_GENERIC, error_line };
+            return { PARSE_ERROR_GENERIC, error_line, std::string(line) };
         }
 
         if (line.starts_with('V')) {
             continue;
         }
 
-        // 文字コードの差異を吸収するため、日本語が含まれる可能性のある
-        // 「N:」「D:」「J:」はハッシュ計算から除外する
+        // N/D/J行はハッシュから除外（日本語対応）
         if (!line.starts_with('N') && !line.starts_with('D') && !line.starts_with('J')) {
             sha256.update(line);
         }
 
         if (auto err = parse_info_txt_line(line, head); err != 0) {
-            return { err, error_line };
+            return { err, error_line, std::string(line) };
         }
     }
 
     head->digest = sha256.digest();
-
-    return { PARSE_ERROR_NONE, error_line };
+    return { PARSE_ERROR_NONE, error_line, "" };
 }
 
 /*!
@@ -96,121 +92,136 @@ std::tuple<errr, int> init_info_txt(FILE *fp, char *buf, angband_header *head, P
  * @param buf 解析文字列
  * @return エラーコード
  */
-parse_error_type parse_line_feature(const FloorType &floor, char *buf)
+parse_error_type parse_line_feature(const FloorType &floor, std::string_view buf)
 {
     if (init_flags & INIT_ONLY_BUILDINGS) {
         return PARSE_ERROR_NONE;
     }
 
-    char *zz[9];
-    int num = tokenize(buf + 2, 9, zz);
-    if (num <= 1) {
+    const auto tokens = tokenize(buf.substr(2), 9);
+    const auto tokens_size = tokens.size();
+    if (tokens_size <= 1) {
         return PARSE_ERROR_GENERIC;
     }
 
     const auto &terrains = TerrainList::get_instance();
-    int index = zz[0][0];
-    letter[index].set_terrain_id(TerrainTag::NONE);
-    letter[index].monster = 0;
-    letter[index].object = 0;
-    letter[index].ego = EgoType::NONE;
-    letter[index].artifact = FixedArtifactId::NONE;
-    letter[index].set_trap_id(TerrainTag::NONE);
-    letter[index].cave_info = 0;
-    letter[index].special = 0;
-    letter[index].random = RANDOM_NONE;
+    const int index = tokens.at(0).at(0);
+    auto &one_letter = letter[index];
+    one_letter.set_terrain_id(TerrainTag::NONE);
+    one_letter.monster = 0;
+    one_letter.object = 0;
+    one_letter.ego = EgoType::NONE;
+    one_letter.artifact = FixedArtifactId::NONE;
+    one_letter.set_trap_id(TerrainTag::NONE);
+    one_letter.cave_info = 0;
+    one_letter.special = 0;
+    one_letter.random = RANDOM_NONE;
 
-    switch (num) {
+    switch (tokens_size) {
     case 9:
-        letter[index].special = (int16_t)atoi(zz[8]);
+        one_letter.special = static_cast<short>(std::stoi(tokens.at(8)));
         [[fallthrough]];
-    case 8:
-        if ((zz[7][0] == '*') && !zz[7][1]) {
-            letter[index].random |= RANDOM_TRAP;
+    case 8: {
+        const auto &token = tokens.at(7);
+        if (token == "*") {
+            one_letter.random |= RANDOM_TRAP;
         } else {
             try {
-                letter[index].trap = terrains.get_terrain_id(zz[7]);
+                one_letter.trap = terrains.get_terrain_id(token);
             } catch (const std::exception &) {
                 return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
             }
         }
+    }
         [[fallthrough]];
-    case 7:
-        if (zz[6][0] == '*') {
-            letter[index].random |= RANDOM_ARTIFACT;
-            if (zz[6][1]) {
-                letter[index].artifact = i2enum<FixedArtifactId>(atoi(zz[6] + 1));
+    case 7: {
+        const auto &token = tokens.at(6);
+        if (token.starts_with('*')) {
+            one_letter.random |= RANDOM_ARTIFACT;
+            if (token.length() > 1) {
+                one_letter.artifact = i2enum<FixedArtifactId>(std::stoi(token.substr(1)));
             }
-        } else if (zz[6][0] == '!') {
+        } else if (token.starts_with('!')) {
             if (floor.is_in_quest()) {
                 const auto &quests = QuestList::get_instance();
-                letter[index].artifact = quests.get_quest(floor.quest_number).reward_fa_id;
+                one_letter.artifact = quests.get_quest(floor.quest_number).reward_fa_id;
             }
         } else {
-            letter[index].artifact = i2enum<FixedArtifactId>(atoi(zz[6]));
+            one_letter.artifact = i2enum<FixedArtifactId>(std::stoi(token));
         }
+    }
         [[fallthrough]];
-    case 6:
-        if (zz[5][0] == '*') {
-            letter[index].random |= RANDOM_EGO;
-            if (zz[5][1]) {
-                letter[index].ego = i2enum<EgoType>(atoi(zz[5] + 1));
+    case 6: {
+        const auto &token = tokens.at(5);
+        if (token.starts_with('*')) {
+            one_letter.random |= RANDOM_EGO;
+            if (token.length() > 1) {
+                one_letter.ego = i2enum<EgoType>(std::stoi(token.substr(1)));
             }
         } else {
-            letter[index].ego = i2enum<EgoType>(atoi(zz[5]));
+            one_letter.ego = i2enum<EgoType>(std::stoi(token));
         }
+    }
         [[fallthrough]];
-    case 5:
-        if (zz[4][0] == '*') {
-            letter[index].random |= RANDOM_OBJECT;
-            if (zz[4][1]) {
-                letter[index].object = (OBJECT_IDX)atoi(zz[4] + 1);
+    case 5: {
+        const auto &token = tokens.at(4);
+        if (token.starts_with('*')) {
+            one_letter.random |= RANDOM_OBJECT;
+            if (token.length() > 1) {
+                one_letter.object = static_cast<short>(std::stoi(token.substr(1)));
             }
-        } else if (zz[4][0] == '!') {
+        } else if (token.starts_with('!')) {
             if (floor.is_in_quest()) {
                 const auto &quests = QuestList::get_instance();
                 const auto &quest = quests.get_quest(floor.quest_number);
                 if (quest.has_reward()) {
                     const auto &artifact = quest.get_reward();
                     if (artifact.gen_flags.has_not(ItemGenerationTraitType::INSTA_ART)) {
-                        letter[index].object = BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key);
+                        one_letter.object = BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key);
                     }
                 }
             }
         } else {
-            letter[index].object = (OBJECT_IDX)atoi(zz[4]);
+            one_letter.object = static_cast<short>(std::stoi(token));
         }
+    }
         [[fallthrough]];
-    case 4:
-        if (zz[3][0] == '*') {
-            letter[index].random |= RANDOM_MONSTER;
-            if (zz[3][1]) {
-                letter[index].monster = (MONSTER_IDX)atoi(zz[3] + 1);
+    case 4: {
+        const auto &token = tokens.at(3);
+        if (token.starts_with('*')) {
+            one_letter.random |= RANDOM_MONSTER;
+            if (token.length() > 1) {
+                one_letter.monster = static_cast<short>(std::stoi(token.substr(1)));
             }
-        } else if (zz[3][0] == 'c') {
-            if (!zz[3][1]) {
+        } else if (token.starts_with('c')) {
+            if (token.length() < 2) {
                 return PARSE_ERROR_GENERIC;
             }
-            letter[index].monster = -atoi(zz[3] + 1);
+            one_letter.monster = -std::stoi(token.substr(1));
         } else {
-            letter[index].monster = (MONSTER_IDX)atoi(zz[3]);
+            one_letter.monster = static_cast<short>(std::stoi(token));
         }
+    }
         [[fallthrough]];
-    case 3:
-        letter[index].cave_info = atoi(zz[2]);
+    case 3: {
+        const auto &token = tokens.at(2);
+        one_letter.cave_info = static_cast<uint32_t>(std::stoi(token));
+    }
         [[fallthrough]];
-    case 2:
-        if ((zz[1][0] == '*') && !zz[1][1]) {
-            letter[index].random |= RANDOM_FEATURE;
-        } else {
-            try {
-                letter[index].feature = terrains.get_terrain_id(zz[1]);
-            } catch (const std::exception &) {
-                return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
-            }
+    case 2: {
+        const auto &token = tokens.at(1);
+        if (token == "*") {
+            one_letter.random |= RANDOM_FEATURE;
+            break;
         }
 
-        break;
+        try {
+            one_letter.feature = terrains.get_terrain_id(token);
+            break;
+        } catch (const std::exception &) {
+            return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
+        }
+    }
     }
 
     return PARSE_ERROR_NONE;
@@ -222,80 +233,77 @@ parse_error_type parse_line_feature(const FloorType &floor, char *buf)
  * @param buf 解析文字列
  * @return エラーコード
  */
-parse_error_type parse_line_building(char *buf)
+parse_error_type parse_line_building(std::string_view buf)
 {
-    char *zz[1000];
-    char *s;
-
 #ifdef JP
     if (buf[2] == '$') {
         return PARSE_ERROR_NONE;
     }
-    s = buf + 2;
+    auto s = buf.substr(2);
 #else
     if (buf[2] != '$') {
         return PARSE_ERROR_NONE;
     }
-    s = buf + 3;
+    auto s = buf.substr(3);
 #endif
-    int index = atoi(s);
-    s = angband_strchr(s, ':');
-    if (!s) {
+    const auto index = std::stoi(std::string(s));
+    const auto colon_pos = s.find(':');
+    if (colon_pos == std::string_view::npos) {
         return PARSE_ERROR_GENERIC;
     }
-
-    *s++ = '\0';
-    if (!*s) {
+    s.remove_prefix(colon_pos + 1);
+    if (s.empty()) {
         return PARSE_ERROR_GENERIC;
     }
-
     switch (s[0]) {
     case 'N': {
-        if (tokenize(s + 2, 3, zz) == 3) {
-            strcpy(buildings[index].name, zz[0]);
-            strcpy(buildings[index].owner_name, zz[1]);
-            strcpy(buildings[index].owner_race, zz[2]);
+        const auto tokens = tokenize(s.substr(2), 3);
+        if (tokens.size() == 3) {
+            auto &building = buildings[index];
+            angband_strcpy(building.name, tokens[0], sizeof(building.name));
+            angband_strcpy(building.owner_name, tokens[1], sizeof(building.owner_name));
+            angband_strcpy(building.owner_race, tokens[2], sizeof(building.owner_race));
             break;
         }
 
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
     case 'A': {
-        if (tokenize(s + 2, 8, zz) >= 7) {
-            int action_index = atoi(zz[0]);
-            strcpy(buildings[index].act_names[action_index], zz[1]);
-            buildings[index].member_costs[action_index] = (PRICE)atoi(zz[2]);
-            buildings[index].other_costs[action_index] = (PRICE)atoi(zz[3]);
-            buildings[index].letters[action_index] = zz[4][0];
-            buildings[index].actions[action_index] = static_cast<int16_t>(atoi(zz[5]));
-            buildings[index].action_restr[action_index] = static_cast<int16_t>(atoi(zz[6]));
+        const auto tokens = tokenize(s.substr(2), 7);
+        if (tokens.size() >= 7) {
+            const auto action_index = std::stoi(tokens[0]);
+            auto &building = buildings[index];
+            angband_strcpy(building.act_names[action_index], tokens[1], sizeof(building.act_names[action_index]));
+            building.member_costs[action_index] = std::stoi(tokens[2]);
+            building.other_costs[action_index] = std::stoi(tokens[3]);
+            building.letters[action_index] = tokens[4][0];
+            building.actions[action_index] = static_cast<int16_t>(std::stoi(tokens[5]));
+            building.action_restr[action_index] = static_cast<int16_t>(std::stoi(tokens[6]));
             break;
         }
 
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
     case 'C': {
-        auto pct_max = PLAYER_CLASS_TYPE_MAX;
-        auto n = tokenize(s + 2, pct_max, zz);
-        for (auto i = 0; i < pct_max; i++) {
-            buildings[index].member_class[i] = (i < n) ? atoi(zz[i]) : 1;
+        const auto tokens = tokenize(s.substr(2), PLAYER_CLASS_TYPE_MAX);
+        for (size_t i = 0; i < PLAYER_CLASS_TYPE_MAX; i++) {
+            buildings[index].member_class[i] = (i < tokens.size()) ? std::stoi(tokens[i]) : 1;
         }
 
         break;
     }
     case 'R': {
-        auto n = tokenize(s + 2, MAX_RACES, zz);
-        for (int i = 0; i < MAX_RACES; i++) {
-            buildings[index].member_race[i] = (i < n) ? atoi(zz[i]) : 1;
+        const auto tokens = tokenize(s.substr(2), MAX_RACES);
+        for (size_t i = 0; i < MAX_RACES; i++) {
+            buildings[index].member_race[i] = (i < tokens.size()) ? std::stoi(tokens[i]) : 1;
         }
 
         break;
     }
     case 'M': {
-        int n;
-        n = tokenize(s + 2, MAX_MAGIC, zz);
-        for (int i = 0; i < MAX_MAGIC; i++) {
-            buildings[index].member_realm[i + 1] = ((i < n) ? static_cast<int16_t>(atoi(zz[i])) : 1);
+        const auto tokens = tokenize(s.substr(2), MAX_MAGIC);
+        for (size_t i = 0; i < MAX_MAGIC; i++) {
+            buildings[index].member_realm[i + 1] = ((i < tokens.size()) ? static_cast<int16_t>(std::stoi(tokens[i])) : 1);
         }
 
         break;

--- a/src/info-reader/general-parser.h
+++ b/src/info-reader/general-parser.h
@@ -4,6 +4,7 @@
 #include "object-enchant/object-ego.h"
 #include "system/angband.h"
 #include <functional>
+#include <string>
 #include <string_view>
 #include <tuple>
 
@@ -32,6 +33,6 @@ class FloorType;
 
 using Parser = std::function<errr(std::string_view, angband_header *)>;
 using JSONParser = std::function<errr(nlohmann::json &, angband_header *)>;
-std::tuple<errr, int> init_info_txt(FILE *fp, char *buf, angband_header *head, Parser parse_info_txt_line);
-parse_error_type parse_line_feature(const FloorType &floor, char *buf);
-parse_error_type parse_line_building(char *buf);
+std::tuple<errr, int, std::string> init_info_txt(FILE *fp, angband_header *head, Parser parse_info_txt_line);
+parse_error_type parse_line_feature(const FloorType &floor, std::string_view buf);
+parse_error_type parse_line_building(std::string_view buf);

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -48,7 +48,7 @@ static void add_history_from_pref_line(std::string_view t)
 static bool interpret_r_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -81,7 +81,7 @@ static bool interpret_r_token(char *buf)
 static bool interpret_k_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -177,7 +177,7 @@ static void decide_feature_type(int i, int num, char **zz)
 static bool interpret_f_token(char *buf)
 {
     char *zz[16];
-    int num = tokenize(buf + 2, F_LIT_MAX * 2 + 1, zz, TOKENIZE_CHECKQUOTE);
+    int num = tokenize(buf + 2, F_LIT_MAX * 2 + 1, zz);
 
     if ((num != 3) && (num != 4) && (num != F_LIT_MAX * 2 + 1)) {
         return false;
@@ -204,7 +204,7 @@ static bool interpret_f_token(char *buf)
 static bool interpret_s_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -223,7 +223,7 @@ static bool interpret_s_token(char *buf)
 static bool interpret_u_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 3, zz, TOKENIZE_CHECKQUOTE) != 3) {
+    if (tokenize(buf + 2, 3, zz) != 3) {
         return false;
     }
 
@@ -253,7 +253,7 @@ static bool interpret_u_token(char *buf)
 static bool interpret_e_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) {
+    if (tokenize(buf + 2, 2, zz) != 2) {
         return false;
     }
 
@@ -285,7 +285,7 @@ static int interpret_p_token(char *buf)
 static bool interpret_c_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 2, zz, TOKENIZE_CHECKQUOTE) != 2) {
+    if (tokenize(buf + 2, 2, zz) != 2) {
         return false;
     }
 
@@ -313,7 +313,7 @@ static bool interpret_c_token(char *buf)
 static bool interpret_v_token(char *buf)
 {
     char *zz[16];
-    if (tokenize(buf + 2, 5, zz, TOKENIZE_CHECKQUOTE) != 5) {
+    if (tokenize(buf + 2, 5, zz) != 5) {
         return false;
     }
 
@@ -480,7 +480,7 @@ static bool interpret_macro_keycodes(int tok, char **zz)
 static bool interpret_t_token(char *buf)
 {
     char *zz[16];
-    int tok = tokenize(buf + 2, 2 + MAX_MACRO_MOD, zz, 0);
+    int tok = tokenize(buf + 2, 2 + MAX_MACRO_MOD, zz);
     if (tok >= 4) {
         return decide_template_modifier(tok, zz);
     }

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -14,6 +14,7 @@
 #include "io/input-key-requester.h"
 #include "io/macro-configurations-store.h"
 #include "io/tokenizer.h"
+#include "locale/language-switcher.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/monrace/monrace-definition.h"
@@ -45,16 +46,16 @@ static void add_history_from_pref_line(std::string_view t)
  * @param buf バッファ
  * @return 解釈に成功したか否か
  */
-static bool interpret_r_token(char *buf)
+static bool interpret_r_token(std::string_view buf)
 {
-    char *zz[16];
-    if (tokenize(buf + 2, 3, zz) != 3) {
+    const auto tokens = tokenize(buf.substr(2), 3);
+    if (tokens.size() != 3) {
         return false;
     }
 
-    const auto i = std::stoi(zz[0], nullptr, 0);
-    const auto n1 = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
-    const auto n2 = static_cast<char>(std::stoi(zz[2], nullptr, 0));
+    const auto i = std::stoi(tokens[0], nullptr, 0);
+    const auto n1 = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
+    const auto n2 = static_cast<char>(std::stoi(tokens[2], nullptr, 0));
     auto &monraces = MonraceList::get_instance();
     if (i >= std::ssize(monraces)) {
         return false;
@@ -78,16 +79,16 @@ static bool interpret_r_token(char *buf)
  * @param buf バッファ
  * @return 解釈に成功したか否か
  */
-static bool interpret_k_token(char *buf)
+static bool interpret_k_token(std::string_view buf)
 {
-    char *zz[16];
-    if (tokenize(buf + 2, 3, zz) != 3) {
+    const auto tokens = tokenize(buf.substr(2), 3);
+    if (tokens.size() != 3) {
         return false;
     }
 
-    const auto i = static_cast<short>(std::stoi(zz[0], nullptr, 0));
-    const auto color = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
-    const auto character = static_cast<char>(std::stoi(zz[2], nullptr, 0));
+    const auto i = static_cast<short>(std::stoi(tokens[0], nullptr, 0));
+    const auto color = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
+    const auto character = static_cast<char>(std::stoi(tokens[2], nullptr, 0));
     auto &baseitems = BaseitemList::get_instance();
     if (i >= static_cast<int>(baseitems.size())) {
         return false;
@@ -110,13 +111,13 @@ static bool interpret_k_token(char *buf)
  * @brief トークン数によって地形の文字形と色を決定する
  * @param i 地形種別
  * @param num トークン数
- * @param zz トークン内容
+ * @param tokens トークン内容
  */
-static void decide_feature_type(int i, int num, char **zz)
+static void decide_feature_type(int i, int num, const std::vector<std::string> &tokens)
 {
     auto &terrain = TerrainList::get_instance().get_terrain(static_cast<short>(i));
-    const auto color_token = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
-    const auto character_token = static_cast<char>(std::stoi(zz[2], nullptr, 0));
+    const auto color_token = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
+    const auto character_token = static_cast<char>(std::stoi(tokens[2], nullptr, 0));
     const auto has_character_token = character_token != '\0';
 
     /* Allow TERM_DARK text */
@@ -144,8 +145,8 @@ static void decide_feature_type(int i, int num, char **zz)
     case F_LIT_MAX * 2 + 1:
         /* Use desired lighting */
         for (auto j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++) {
-            const auto color = static_cast<uint8_t>(std::stoi(zz[j * 2 + 1], nullptr, 0));
-            const auto character = static_cast<char>(std::stoi(zz[j * 2 + 2], nullptr, 0));
+            const auto color = static_cast<uint8_t>(std::stoi(tokens[j * 2 + 1], nullptr, 0));
+            const auto character = static_cast<char>(std::stoi(tokens[j * 2 + 2], nullptr, 0));
             const auto has_character = character != '\0';
             auto &symbol = terrain.symbol_configs[j];
 
@@ -174,25 +175,24 @@ static void decide_feature_type(int i, int num, char **zz)
  * "F:<num>:<a>/<c>:LIT"
  * "F:<num>:<a>/<c>:<la>/<lc>:<da>/<dc>"
  */
-static bool interpret_f_token(char *buf)
+static bool interpret_f_token(std::string_view buf)
 {
-    char *zz[16];
-    int num = tokenize(buf + 2, F_LIT_MAX * 2 + 1, zz);
-
+    const auto tokens = tokenize(buf.substr(2), F_LIT_MAX * 2 + 1);
+    const auto num = tokens.size();
     if ((num != 3) && (num != 4) && (num != F_LIT_MAX * 2 + 1)) {
         return false;
     }
 
-    if ((num == 4) && !streq(zz[3], "LIT")) {
+    if ((num == 4) && tokens[3] != "LIT") {
         return false;
     }
 
-    int i = (int)strtol(zz[0], nullptr, 0);
+    const auto i = std::stoi(tokens[0], nullptr, 0);
     if (i >= static_cast<int>(TerrainList::get_instance().size())) {
         return false;
     }
 
-    decide_feature_type(i, num, zz);
+    decide_feature_type(i, num, tokens);
     return true;
 }
 
@@ -201,16 +201,16 @@ static bool interpret_f_token(char *buf)
  * @param buf バッファ
  * @return 解釈に成功したか否か
  */
-static bool interpret_s_token(char *buf)
+static bool interpret_s_token(std::string_view buf)
 {
-    char *zz[16];
-    if (tokenize(buf + 2, 3, zz) != 3) {
+    const auto tokens = tokenize(buf.substr(2), 3);
+    if (tokens.size() != 3) {
         return false;
     }
 
-    const auto num = std::stoi(zz[0], nullptr, 0);
-    const auto color = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
-    const auto character = static_cast<char>(std::stoi(zz[2], nullptr, 0));
+    const auto num = std::stoi(tokens[0], nullptr, 0);
+    const auto color = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
+    const auto character = static_cast<char>(std::stoi(tokens[2], nullptr, 0));
     ds_bolt[num] = DisplaySymbol(color, character);
     return true;
 }
@@ -220,24 +220,24 @@ static bool interpret_s_token(char *buf)
  * @param buf バッファ
  * @return 解釈に成功したか否か
  */
-static bool interpret_u_token(char *buf)
+static bool interpret_u_token(std::string_view buf)
 {
-    char *zz[16];
-    if (tokenize(buf + 2, 3, zz) != 3) {
+    const auto tokens = tokenize(buf.substr(2), 3);
+    if (tokens.size() != 3) {
         return false;
     }
 
-    const auto tval = i2enum<ItemKindType>(std::stoi(zz[0], nullptr, 0));
-    const auto n1 = static_cast<uint8_t>(std::stoi(zz[1], nullptr, 0));
-    const auto n2 = static_cast<char>(strtol(zz[2], nullptr, 0));
+    const auto tval = i2enum<ItemKindType>(std::stoi(tokens[0], nullptr, 0));
+    const auto color = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
+    const auto character = static_cast<char>(std::stoi(tokens[2], nullptr, 0));
     for (auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.is_valid() && (baseitem.bi_key.tval() == tval)) {
-            if (n1) {
-                baseitem.symbol_definition.color = n1;
+            if (color) {
+                baseitem.symbol_definition.color = color;
             }
 
-            if (n2) {
-                baseitem.symbol_definition.character = n2;
+            if (character) {
+                baseitem.symbol_definition.character = character;
             }
         }
     }
@@ -250,17 +250,17 @@ static bool interpret_u_token(char *buf)
  * @param buf バッファ
  * @return 解釈に成功したか否か
  */
-static bool interpret_e_token(char *buf)
+static bool interpret_e_token(std::string_view buf)
 {
-    char *zz[16];
-    if (tokenize(buf + 2, 2, zz) != 2) {
+    const auto tokens = tokenize(buf.substr(2), 2);
+    if (tokens.size() != 2) {
         return false;
     }
 
-    int j = (byte)strtol(zz[0], nullptr, 0) % 128;
-    TERM_COLOR n1 = (TERM_COLOR)strtol(zz[1], nullptr, 0);
-    if (n1) {
-        tval_to_attr[j] = n1;
+    const auto num = std::stoi(tokens[0], nullptr, 0) % 128;
+    const auto color = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
+    if (color > 0) {
+        tval_to_attr[num] = color;
     }
     return true;
 }
@@ -270,10 +270,10 @@ static bool interpret_e_token(char *buf)
  * @param buf バッファ
  * @return エラーコード
  */
-static int interpret_p_token(char *buf)
+static int interpret_p_token(std::string_view buf)
 {
     char tmp[1024];
-    text_to_ascii(tmp, buf + 2, sizeof(tmp));
+    text_to_ascii(tmp, buf.substr(2), sizeof(tmp));
     return macro_add(tmp, macro_buffers.data());
 }
 
@@ -282,20 +282,20 @@ static int interpret_p_token(char *buf)
  * @param buf バッファ
  * @return 解釈に成功したか否か
  */
-static bool interpret_c_token(char *buf)
+static bool interpret_c_token(std::string_view buf)
 {
-    char *zz[16];
-    if (tokenize(buf + 2, 2, zz) != 2) {
+    const auto tokens = tokenize(buf.substr(2), 2);
+    if (tokens.size() != 2) {
         return false;
     }
 
-    const auto mode = i2enum<KeymapMode>(std::stoi(zz[0], nullptr, 0));
+    const auto mode = i2enum<KeymapMode>(std::stoi(tokens[0], nullptr, 0));
     if ((mode < KeymapMode::ORIGINAL) || (mode > KeymapMode::ROGUE)) {
         return false;
     }
 
     char tmp[1024];
-    text_to_ascii(tmp, zz[1], sizeof(tmp));
+    text_to_ascii(tmp, tokens[1], sizeof(tmp));
     if (!tmp[0] || tmp[1]) {
         return false;
     }
@@ -310,18 +310,18 @@ static bool interpret_c_token(char *buf)
  * @param buf バッファ
  * @return 解釈に成功したか否か
  */
-static bool interpret_v_token(char *buf)
+static bool interpret_v_token(std::string_view buf)
 {
-    char *zz[16];
-    if (tokenize(buf + 2, 5, zz) != 5) {
+    const auto tokens = tokenize(buf.substr(2), 5);
+    if (tokens.size() != 5) {
         return false;
     }
 
-    int i = (byte)strtol(zz[0], nullptr, 0);
-    angband_color_table[i][0] = (byte)strtol(zz[1], nullptr, 0);
-    angband_color_table[i][1] = (byte)strtol(zz[2], nullptr, 0);
-    angband_color_table[i][2] = (byte)strtol(zz[3], nullptr, 0);
-    angband_color_table[i][3] = (byte)strtol(zz[4], nullptr, 0);
+    const auto num = std::stoi(tokens[0], nullptr, 0);
+    angband_color_table[num][0] = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
+    angband_color_table[num][1] = static_cast<uint8_t>(std::stoi(tokens[2], nullptr, 0));
+    angband_color_table[num][2] = static_cast<uint8_t>(std::stoi(tokens[3], nullptr, 0));
+    angband_color_table[num][3] = static_cast<uint8_t>(std::stoi(tokens[4], nullptr, 0));
     return true;
 }
 
@@ -334,18 +334,18 @@ static bool interpret_v_token(char *buf)
  * Process "Y:<str>" -- turn option on
  * オプションの名前が正しくない時も、パース自体は続行する (V2以前からの仕様)
  */
-static void interpret_xy_token(PlayerType *player_ptr, char *buf)
+static void interpret_xy_token(PlayerType *player_ptr, std::string_view buf)
 {
     const auto &world = AngbandWorld::get_instance();
     for (auto &option : option_info) {
-        if (option.text != buf + 2) {
+        if (option.text != buf.substr(2)) {
             continue;
         }
 
         int os = option.flag_position;
         int ob = option.offset;
         if ((player_ptr->playing || world.character_xtra) && (GameOptionPage::BIRTH == option.page) && !world.wizard) {
-            msg_format(_("初期オプションは変更できません! '%s'", "Birth options can not be changed! '%s'"), buf);
+            msg_print(_("初期オプションは変更できません! '{}'", "Birth options can not be changed! '{}'"), buf);
             msg_erase();
             return;
         }
@@ -361,14 +361,14 @@ static void interpret_xy_token(PlayerType *player_ptr, char *buf)
         return;
     }
 
-    msg_format(_("オプションの名前が正しくありません： %s", "Ignored invalid option: %s"), buf);
+    msg_print(_("オプションの名前が正しくありません： {}", "Ignored invalid option: {}"), buf);
     msg_erase();
 }
 
 /*!
  * @brief Zトークンの解釈 / Process "Z:<type>:<str>" -- set spell color
  * @param line トークン1行
- * @param zz トークン保管文字列
+ * @param tokens トークン保管文字列
  * @return 解釈に成功したか
  */
 static bool interpret_z_token(std::string_view line)
@@ -394,10 +394,10 @@ static bool interpret_z_token(std::string_view line)
 /*!
  * @brief Tトークンの解釈 / Process "T:<template>:<modifier chr>:<modifier name>:..." for 4 tokens
  * @param num_tokens トークン数
- * @param zz トークン保管文字列
+ * @param tokens トークン保管文字列
  * @return 解釈に成功したか否か
  */
-static bool decide_template_modifier(size_t num_tokens, char **zz)
+static bool decide_template_modifier(size_t num_tokens, const std::vector<std::string> &tokens)
 {
     if (macro_template) {
         const size_t macro_modifier_length = macro_modifier_chr ? macro_modifier_chr->length() : 0;
@@ -416,20 +416,20 @@ static bool decide_template_modifier(size_t num_tokens, char **zz)
         max_macrotrigger = 0;
     }
 
-    if (*zz[0] == '\0') {
+    if (tokens[0].empty()) {
         return true;
     }
 
-    size_t zz_length = strlen(zz[1]);
+    auto zz_length = tokens[1].length();
     zz_length = std::min(MAX_MACRO_MOD, zz_length);
     if (2 + zz_length != num_tokens) {
         return false;
     }
 
-    macro_template = zz[0];
-    macro_modifier_chr = zz[1];
+    macro_template = tokens[0];
+    macro_modifier_chr = tokens[1];
     for (size_t i = 0; i < zz_length; i++) {
-        macro_modifier_names[i] = zz[2 + i];
+        macro_modifier_names[i] = tokens[2 + i];
     }
 
     return true;
@@ -438,10 +438,10 @@ static bool decide_template_modifier(size_t num_tokens, char **zz)
 /*!
  * @brief Tトークンの解釈 / Process "T:<trigger>:<keycode>:<shift-keycode>" for 2 or 3 tokens
  * @param tok トークン数
- * @param zz トークン保管文字列
+ * @param tokens トークン保管文字列
  * @return 解釈に成功したか否か
  */
-static bool interpret_macro_keycodes(int tok, char **zz)
+static bool interpret_macro_keycodes(int tok, const std::vector<std::string> &tokens)
 {
     if (max_macrotrigger >= MAX_MACRO_TRIG) {
         msg_print(_("マクロトリガーの設定が多すぎます!", "Too many macro triggers!"));
@@ -451,23 +451,28 @@ static bool interpret_macro_keycodes(int tok, char **zz)
     auto m = max_macrotrigger;
     max_macrotrigger++;
     std::string t;
-    const auto *s = zz[0];
-    while (*s != '\0') {
-        if ('\\' == *s) {
-            s++;
+    t.reserve(tokens[0].size());
+    std::string_view s = tokens[0];
+    while (!s.empty()) {
+        if (s.starts_with('\\')) {
+            s.remove_prefix(1);
+            if (s.empty()) {
+                break;
+            }
         }
 
-        t.push_back(*s++);
+        t.push_back(s[0]);
+        s.remove_prefix(1);
     }
 
     macro_trigger_names[m] = std::move(t);
-    macro_trigger_keycodes.at(ShiftStatus::OFF).at(m) = zz[1];
+    macro_trigger_keycodes.at(ShiftStatus::OFF).at(m) = tokens[1];
     if (tok == 3) {
-        macro_trigger_keycodes.at(ShiftStatus::ON).at(m) = zz[2];
+        macro_trigger_keycodes.at(ShiftStatus::ON).at(m) = tokens[2];
         return true;
     }
 
-    macro_trigger_keycodes.at(ShiftStatus::ON).at(m) = zz[1];
+    macro_trigger_keycodes.at(ShiftStatus::ON).at(m) = tokens[1];
     return true;
 }
 
@@ -477,18 +482,19 @@ static bool interpret_macro_keycodes(int tok, char **zz)
  * @return 解釈に成功したか否か
  * @todo 2.2.1r時点のコードからトークン数0～1の場合もエラーコード0だが、1であるべきでは？
  */
-static bool interpret_t_token(char *buf)
+static bool interpret_t_token(std::string_view buf)
 {
-    char *zz[16];
-    int tok = tokenize(buf + 2, 2 + MAX_MACRO_MOD, zz);
-    if (tok >= 4) {
-        return decide_template_modifier(tok, zz);
+    const auto tokens = tokenize(buf.substr(2), 2 + MAX_MACRO_MOD);
+    const auto size = tokens.size();
+    if (size >= 4) {
+        return decide_template_modifier(size, tokens);
     }
-    if (tok < 2) {
+
+    if (size < 2) {
         return true;
     }
 
-    return interpret_macro_keycodes(tok, zz);
+    return interpret_macro_keycodes(size, tokens);
 }
 
 /*!
@@ -513,7 +519,7 @@ static bool interpret_t_token(char *buf)
  * used for the "nothing" attr/char.
  * </pre>
  */
-int interpret_pref_file(PlayerType *player_ptr, char *buf)
+int interpret_pref_file(PlayerType *player_ptr, std::string_view buf)
 {
     if (buf[1] != ':') {
         return 1;
@@ -522,7 +528,7 @@ int interpret_pref_file(PlayerType *player_ptr, char *buf)
     switch (buf[0]) {
     case 'H':
         /* Process "H:<history>" */
-        add_history_from_pref_line(buf + 2);
+        add_history_from_pref_line(buf.substr(2));
         return 0;
     case 'R':
         return interpret_r_token(buf) ? 0 : 1;
@@ -538,7 +544,7 @@ int interpret_pref_file(PlayerType *player_ptr, char *buf)
         return interpret_e_token(buf) ? 0 : 1;
     case 'A':
         /* Process "A:<str>" -- save an "action" for later */
-        text_to_ascii(macro_buffers.data(), buf + 2, macro_buffers.size());
+        text_to_ascii(macro_buffers.data(), buf.substr(2), macro_buffers.size());
         return 0;
     case 'P':
         return interpret_p_token(buf);

--- a/src/io/interpret-pref-file.h
+++ b/src/io/interpret-pref-file.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <tl/optional.hpp>
 
 extern tl::optional<std::string> histpref_buf;
 
 class PlayerType;
-int interpret_pref_file(PlayerType *player_ptr, char *buf);
+int interpret_pref_file(PlayerType *player_ptr, std::string_view buf);

--- a/src/io/read-pref-file.cpp
+++ b/src/io/read-pref-file.cpp
@@ -122,7 +122,7 @@ static errr process_pref_file_aux(PlayerType *player_ptr, const std::filesystem:
             continue;
         }
 
-        err = interpret_pref_file(player_ptr, line_str->data());
+        err = interpret_pref_file(player_ptr, *line_str);
         if (err != 0) {
             if (preftype != PREF_TYPE_AUTOPICK) {
                 break;

--- a/src/io/tokenizer.cpp
+++ b/src/io/tokenizer.cpp
@@ -1,48 +1,41 @@
 #include "io/tokenizer.h"
 
 /*!
- * @brief 各種データテキストをトークン単位に分解する / Extract the first few "tokens" from a buffer
- * @param buf データテキストの参照ポインタ
- * @param num トークンの数
- * @param tokens トークンを保管する文字列参照ポインタ配列
- * @param mode オプション
- * @return 解釈した文字列数
- * @details
- * <pre>
- * This function uses "colon" and "slash" as the delimeter characters.
- * We never extract more than "num" tokens.  The "last" token may include
- * "delimeter" characters, allowing the buffer to include a "string" token.
- * We save pointers to the tokens in "tokens", and return the number found.
- * Hack -- Attempt to handle the 'c' character formalism
- * Hack -- An empty buffer, or a final delimeter, yields an "empty" token.
- * Hack -- We will always extract at least one token
- * </pre>
+ * @brief 各種データテキストをトークン単位に分解する
+ * @param buf データテキスト
+ * @param num 最大トークン数
+ * @return トークン文字列の配列
  */
-int16_t tokenize(char *buf, int16_t num, char **tokens)
+std::vector<std::string> tokenize(std::string_view buf, size_t num)
 {
-    int16_t i = 0;
-    char *s = buf;
-    while (i < num - 1) {
-        char *t;
-        for (t = s; *t; t++) {
-            if ((*t == ':') || (*t == '/')) {
+    std::vector<std::string> tokens;
+    if (num == 0) {
+        return tokens;
+    }
+
+    tokens.reserve(num);
+    auto remaining = buf;
+    while ((tokens.size() < num - 1) && !remaining.empty()) {
+        size_t token_end = 0;
+        for (; token_end < remaining.length(); token_end++) {
+            const auto c = remaining.at(token_end);
+            if ((c == ':') || (c == '/')) {
                 break;
             }
 
-            if (*t == '\\') {
-                t++;
+            if (c == '\\') {
+                token_end++;
             }
         }
 
-        if (!*t) {
-            break;
+        tokens.emplace_back(remaining.substr(0, token_end));
+        if (token_end >= remaining.length()) {
+            return tokens;
         }
 
-        *t++ = '\0';
-        tokens[i++] = s;
-        s = t;
+        remaining = remaining.substr(token_end + 1);
     }
 
-    tokens[i++] = s;
-    return i;
+    tokens.emplace_back(remaining);
+    return tokens;
 }

--- a/src/io/tokenizer.cpp
+++ b/src/io/tokenizer.cpp
@@ -18,7 +18,7 @@
  * Hack -- We will always extract at least one token
  * </pre>
  */
-int16_t tokenize(char *buf, int16_t num, char **tokens, BIT_FLAGS mode)
+int16_t tokenize(char *buf, int16_t num, char **tokens)
 {
     int16_t i = 0;
     char *s = buf;
@@ -27,21 +27,6 @@ int16_t tokenize(char *buf, int16_t num, char **tokens, BIT_FLAGS mode)
         for (t = s; *t; t++) {
             if ((*t == ':') || (*t == '/')) {
                 break;
-            }
-
-            if ((mode & TOKENIZE_CHECKQUOTE) && (*t == '\'')) {
-                t++;
-                if (*t == '\\') {
-                    t++;
-                }
-                if (!*t) {
-                    break;
-                }
-
-                t++;
-                if (*t != '\'') {
-                    *t = '\'';
-                }
             }
 
             if (*t == '\\') {

--- a/src/io/tokenizer.h
+++ b/src/io/tokenizer.h
@@ -2,6 +2,4 @@
 
 #include "system/angband.h"
 
-#define TOKENIZE_CHECKQUOTE 0x01 /* Special handling of single quotes */
-
-int16_t tokenize(char *buf, int16_t num, char **tokens, BIT_FLAGS mode);
+int16_t tokenize(char *buf, int16_t num, char **tokens);

--- a/src/io/tokenizer.h
+++ b/src/io/tokenizer.h
@@ -1,5 +1,8 @@
 #pragma once
 
-#include "system/angband.h"
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
 
-int16_t tokenize(char *buf, int16_t num, char **tokens);
+std::vector<std::string> tokenize(std::string_view buf, size_t num);

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -44,6 +44,7 @@
 #include "util/angband-files.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
+#include <fmt/format.h>
 #include <fstream>
 #include <functional>
 #include <string>
@@ -91,23 +92,22 @@ static void init_info(std::string_view filename, angband_header &head, InfoType 
     const auto path = path_build(ANGBAND_DIR_EDIT, filename);
     auto *fp = angband_fopen(path, FileOpenMode::READ);
     if (!fp) {
-        quit_fmt(_("'%s'ファイルをオープンできません。", "Cannot open '%s' file."), filename.data());
+        quit(fmt::format(_("'{}'ファイルをオープンできません。", "Cannot open '{}' file."), filename));
     }
 
-    char buf[1024]{};
-    const auto &[error_code, error_line] = init_info_txt(fp, buf, &head, parser);
+    const auto &[error_code, error_line, line] = init_info_txt(fp, &head, parser);
     angband_fclose(fp);
     if (error_code != PARSE_ERROR_NONE) {
         const auto oops = (((error_code > 0) && (error_code < PARSE_ERROR_MAX)) ? err_str[error_code] : _("未知の", "unknown"));
 #ifdef JP
-        msg_format("'%s'ファイルの %d 行目にエラー。", filename.data(), error_line);
+        msg_print("'{}'ファイルの {} 行目にエラー。", filename, error_line);
 #else
-        msg_format("Error %d at line %d of '%s'.", error_code, error_line, filename.data());
+        msg_print("Error {} at line {} of '{}'.", error_code, error_line, filename);
 #endif
-        msg_format(_("レコード %d は '%s' エラーがあります。", "Record %d contains a '%s' error."), error_idx, oops);
-        msg_format(_("構文 '%s'。", "Parsing '%s'."), buf);
+        msg_print(_("レコード {} は '{}' エラーがあります。", "Record {} contains a '{}' error."), error_idx, oops);
+        msg_print(_("構文 '{}'。", "Parsing '{}'."), line);
         msg_erase();
-        quit_fmt(_("'%s'ファイルにエラー", "Error in '%s' file."), filename.data());
+        quit(fmt::format(_("'{}'ファイルにエラー", "Error in '{}' file."), filename));
     }
 
     if constexpr (HasShrinkToFit<InfoType>) {

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -3,6 +3,7 @@
 #include "flavor/object-flavor-types.h"
 #include "io/files-util.h"
 #include "io/tokenizer.h"
+#include "locale/language-switcher.h"
 #include "object-enchant/special-object-flags.h"
 #include "system/angband-exceptions.h"
 #include "system/artifact-type-definition.h"
@@ -57,7 +58,7 @@ tl::optional<std::vector<std::string>> get_rumor_tokens(std::string rumor)
 {
     constexpr auto num_tokens = 3;
     char *tmp_tokens[num_tokens];
-    if (tokenize(rumor.data() + 2, num_tokens, tmp_tokens, TOKENIZE_CHECKQUOTE) != num_tokens) {
+    if (tokenize(rumor.data() + 2, num_tokens, tmp_tokens) != num_tokens) {
         msg_print(_("この情報は間違っている。", "This information is wrong."));
         return tl::nullopt;
     }

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -54,16 +54,15 @@ T get_rumor_num(std::string_view zz, U max_idx)
  * @return トークン群の配列を返す。フィールドの数が合わない場合はtl::nulloptを返す。
  * @todo tmp_tokensを使わず単なるsplitにすればもっと簡略化できそう
  */
-tl::optional<std::vector<std::string>> get_rumor_tokens(std::string rumor)
+tl::optional<std::vector<std::string>> get_rumor_tokens(std::string_view rumor)
 {
     constexpr auto num_tokens = 3;
-    char *tmp_tokens[num_tokens];
-    if (tokenize(rumor.data() + 2, num_tokens, tmp_tokens) != num_tokens) {
+    const auto tokens = tokenize(rumor.substr(2), num_tokens);
+    if (tokens.size() != num_tokens) {
         msg_print(_("この情報は間違っている。", "This information is wrong."));
         return tl::nullopt;
     }
 
-    std::vector<std::string> tokens(std::begin(tmp_tokens), std::end(tmp_tokens));
     return tokens;
 }
 }


### PR DESCRIPTION
文字列操作の箇所はAIに聞きながら実施しましたがイマイチ自信はないです
起動＆セーブデータ読み込みが正常に成功してdevelopと同じマップが描画されるところまでは確認しました

/gemini review

ロジックが維持されているかを確認して
但し、atoi() をstd::stoi() に変更したのは意図的であって例外設計はmain関数で担保する