### PR TITLE
[Fix] 鉄人オプションを複数同時に有効化すると無限ループに陥る問題を解決した

### DIFF
--- a/lib/edit/DungeonDefinitions.jsonc
+++ b/lib/edit/DungeonDefinitions.jsonc
@@ -291,6 +291,7 @@
       },
       "flags": [
         "MAZE",
+        "NO_VAULT",
         "SMALLEST",
         "FORGET",
         "MONSTER_DIV_64",
@@ -998,6 +999,7 @@
         "CAVE",
         "CAVERN",
         "SMALLEST",
+        "NO_VAULT",
         "LAVA_RIVER",
         "DESTROY",
         "LAKE_ACID",

--- a/lib/edit/DungeonDefinitions.jsonc
+++ b/lib/edit/DungeonDefinitions.jsonc
@@ -291,7 +291,6 @@
       },
       "flags": [
         "MAZE",
-        "NO_VAULT",
         "SMALLEST",
         "FORGET",
         "MONSTER_DIV_64",
@@ -999,7 +998,6 @@
         "CAVE",
         "CAVERN",
         "SMALLEST",
-        "NO_VAULT",
         "LAVA_RIVER",
         "DESTROY",
         "LAKE_ACID",

--- a/src/system/dungeon/dungeon-definition.cpp
+++ b/src/system/dungeon/dungeon-definition.cpp
@@ -211,6 +211,16 @@ void DungeonDefinition::set_guardian_flag()
     }
 }
 
+/*!
+ * @brief 最小面積が保証されるダンジョンにはVAULTを生成しないフラグをセットする.
+ */
+void DungeonDefinition::set_no_vault_flag_if_smallest()
+{
+    if (this->flags.has(DungeonFeatureType::SMALLEST)) {
+        this->flags.set(DungeonFeatureType::NO_VAULT);
+    }
+}
+
 MonraceDefinition &DungeonDefinition::get_guardian()
 {
     return MonraceList::get_instance().get_monrace(this->final_guardian);

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -108,6 +108,7 @@ public:
 
     //!< @details ここから下は、地形など全ての定義ファイルを読み込んだ後に呼び出される初期化処理.
     void set_guardian_flag();
+    void set_no_vault_flag_if_smallest();
 
 private:
     Pos2D pos = { 0, 0 };

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -36,5 +36,6 @@ void DungeonList::retouch()
 {
     for (auto &[_, dungeon] : this->dungeons) {
         dungeon->set_guardian_flag();
+        dungeon->set_no_vault_flag_if_smallest();
     }
 }

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -992,7 +992,8 @@ void FloorType::place_trap_at(const Pos2D &pos)
 /*!
  * @brief フロアサイズを生成する
  *
- * 鉄人フラグ「常に非常に小さいフロアを生成」は、DungeonFeatureTypeを全て無視して小さなフロアだけを生成する.
+ * 鉄人フラグ「常に非常に小さいフロアを生成」は、DungeonFeatureTypeを全て無視して1x1ブロックのフロアだけを生成する.
+ * 但し、鉄人フラグ「常に普通でない部屋を生成」も同時にONならば、NO_VAULTフラグのないダンジョンでは2×1ブロックのフロアだけを生成する.
  * 初心者フラグのついているダンジョンは、2～4ブロックのフロアを生成する.
  * SMALLESTとLARGESTの両方がついているダンジョンは、1/2の確率でSMALLEST、1/2の確率でLARGESTとみなす.
  * SMALLとLARGEの両方がついているダンジョンは、1/2の確率でSMALL、1/2の確率でLARGEとみなす.
@@ -1005,12 +1006,16 @@ void FloorType::decide_floor_size()
         this->width = dungeon_block.second * SCREEN_WID;
     });
 
+    const auto &dungeon = this->get_dungeon_definition();
     if (ironman_smallest_floor) {
         dungeon_block = *dungeon_blocks.cbegin();
+        if (ironman_rooms && dungeon.flags.has_not(DungeonFeatureType::NO_VAULT)) {
+            dungeon_block = { 2, 1 };
+        }
+
         return;
     }
 
-    const auto &dungeon = this->get_dungeon_definition();
     if (dungeon.flags.has(DungeonFeatureType::BEGINNER)) {
         dungeon_block = this->select_floor_size_beginner();
         return;


### PR DESCRIPTION
「常に非常に小さいフロアを生成」「常に普通でない部屋を生成」を両方ONにすると、金鉱1x1ブロックの空間にVaultを生成しようとしてスタックしてしまいます
広さ的に無理があるので、Vaultの出現可能性があるならば縦2x横1ブロックを保証するようにしました

迷宮と金鉱はVault生成可能性的にふさわしくないのでNO\_VAULTフラグを追加しました
この修正で、上記フラグが同時にONでも正常にフロアが生成されることを確認しました