### PR TITLE
[Fix] 地形定義ファイルのJSON化に伴うエンバグの修正

### DIFF
--- a/lib/edit/TerrainDefinitions.jsonc
+++ b/lib/edit/TerrainDefinitions.jsonc
@@ -2165,7 +2165,7 @@
       },
       "symbol": {
         "character": "*",
-        "color": "Black",
+        "color": "Dark Gray",
         "lit": false,
       },
       "mimic": null,
@@ -2360,7 +2360,7 @@
       },
       "symbol": {
         "character": "7",
-        "color": "Black",
+        "color": "Dark Gray",
         "lit": false,
       },
       "mimic": null,
@@ -2558,7 +2558,7 @@
       },
       "symbol": {
         "character": "#",
-        "color": "Black",
+        "color": "Dark Gray",
         "lit": false,
       },
       "mimic": null,
@@ -2619,7 +2619,7 @@
       },
       "symbol": {
         "character": "^",
-        "color": "Black",
+        "color": "Dark Gray",
         "lit": true,
       },
       "mimic": null,
@@ -4051,7 +4051,7 @@
       },
       "symbol": {
         "character": "x",
-        "color": "Black",
+        "color": "Dark Gray",
         "lit": false,
       },
       "mimic": null,

--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -77,6 +77,7 @@ static errr set_terrain_symbol(const nlohmann::json &symbol_obj, TerrainType &te
     const bool lit = lit_obj.get<bool>();
     if (lit) {
         terrain.reset_lighting(false);
+        return PARSE_ERROR_NONE;
     }
 
     for (int j = F_LIT_NS_BEGIN; j < F_LIT_MAX; j++) {


### PR DESCRIPTION
修正点は2つ。

・"Dark Gray"であるべき地形が"Black"であった
・"LIT"フラグを持つ地形の色補正が無効になっていた