### PR TITLE
[Fix] 耐電のアミュレットがsubtype番号を飛ばしてしまっていたので31→30へ修正した

### DIFF
--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -22099,7 +22099,7 @@
       },
       "itemkind": {
         "type_value": 40,
-        "subtype_value": 31,
+        "subtype_value": 30,
       },
       "parameter_value": 0,
       "level": 12,


### PR DESCRIPTION
GitHubでコメントがあったものの修正です
ご確認下さい