### PR TITLE
[Refactor] town-records.cpp/h を定義してPlayerType::visit を廃止した

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -310,6 +310,7 @@
     <ClCompile Include="..\..\src\io\macro-configurations-store.cpp" />
     <ClCompile Include="..\..\src\monster-floor\monster-movement-direction-list.cpp" />
     <ClCompile Include="..\..\src\player-info\bluemage-data.cpp" />
+    <ClCompile Include="..\..\src\system\floor\town-records.cpp" />
     <ClCompile Include="..\..\src\system\floor\wilderness-grid.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
@@ -1038,6 +1039,7 @@
     <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h" />
     <ClInclude Include="..\..\src\system\enums\terrain\terrain-kind.h" />
     <ClInclude Include="..\..\src\system\enums\terrain\wilderness-terrain.h" />
+    <ClInclude Include="..\..\src\system\floor\town-records.h" />
     <ClInclude Include="..\..\src\system\floor\wilderness-grid.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-service.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2568,6 +2568,9 @@
     <ClCompile Include="..\..\src\player-info\bluemage-data.cpp">
       <Filter>player-info</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\floor\town-records.cpp">
+      <Filter>system\floor</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5564,6 +5567,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\io\macro-configurations-store.h">
       <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\floor\town-records.h">
+      <Filter>system\floor</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1294,6 +1294,7 @@ hengband_SOURCES = \
 	system/floor/floor-list.cpp system/floor/floor-list.h \
 	system/floor/town-info.cpp system/floor/town-info.h \
 	system/floor/town-list.cpp system/floor/town-list.h \
+	system/floor/town-records.cpp system/floor/town-records.h \
 	system/floor/wilderness-grid.cpp system/floor/wilderness-grid.h \
 	\
 	system/monrace/monrace-allocation.cpp system/monrace/monrace-allocation.h \

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -22,6 +22,7 @@
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/floor-info.h"
 #include "system/floor/floor-list.h"
+#include "system/floor/town-records.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/inner-game-data.h"
 #include "system/item-entity.h"
@@ -114,7 +115,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     player_ptr->pet_follow_distance = PET_FOLLOW_DIST;
     player_ptr->pet_extra_flags = (PF_TELEPORT | PF_ATTACK_SPELL | PF_SUMMON_SPELL);
     DungeonRecords::get_instance().reset_all();
-    player_ptr->visit = 1;
+    TownRecords::get_instance().initialize();
     world.set_wild_mode(false);
     WildernessGrids::get_instance().initialize_position();
 

--- a/src/floor/wild.cpp
+++ b/src/floor/wild.cpp
@@ -35,6 +35,7 @@
 #include "system/floor/floor-info.h"
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
+#include "system/floor/town-records.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
 #include "system/monster-entity.h"
@@ -287,7 +288,7 @@ static void generate_area(PlayerType *player_ptr, const Pos2D &pos, bool is_bord
 
         parse_fixed_map(player_ptr, TOWN_DEFINITION_LIST, 0, 0, MAX_HGT, MAX_WID);
         if (!is_corner && !is_border) {
-            player_ptr->visit |= (1UL << (player_ptr->town_num - 1));
+            TownRecords::get_instance().set_visited(i2enum<TownId>(player_ptr->town_num - 1));
         }
     } else {
         generate_wilderness_area(floor, wg, is_corner);

--- a/src/load/extra-loader.cpp
+++ b/src/load/extra-loader.cpp
@@ -39,7 +39,7 @@ void rd_extra(PlayerType *player_ptr)
         world.play_time = ElapsedTime(rd_u32b());
     }
 
-    rd_visited_towns(player_ptr);
+    rd_visited_towns();
     if (!h_older_than(1, 0, 5)) {
         player_ptr->count = rd_u32b();
     }

--- a/src/load/load-zangband.cpp
+++ b/src/load/load-zangband.cpp
@@ -23,6 +23,7 @@
 #include "system/dungeon/dungeon-record.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/floor-info.h"
+#include "system/floor/town-records.h"
 #include "system/inner-game-data.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
@@ -194,10 +195,10 @@ void set_zangband_action(PlayerType *player_ptr)
     }
 }
 
-void set_zangband_visited_towns(PlayerType *player_ptr)
+void set_zangband_visited_towns()
 {
     strip_bytes(4);
-    player_ptr->visit = 1L;
+    TownRecords::get_instance().initialize();
 }
 
 void set_zangband_quest(PlayerType *player_ptr, QuestType *const q_ptr, const QuestId loading_quest_index, const QuestId old_inside_quest)

--- a/src/load/load-zangband.h
+++ b/src/load/load-zangband.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "dungeon/quest.h"
-#include "system/angband.h"
 
+enum class QuestId : short;
 class PlayerType;
 class QuestType;
 void load_zangband_options();
@@ -19,7 +19,7 @@ void set_zangband_game_turns(PlayerType *player_ptr);
 void set_zangband_special_attack(PlayerType *player_ptr);
 void set_zangband_special_defense(PlayerType *player_ptr);
 void set_zangband_action(PlayerType *player_ptr);
-void set_zangband_visited_towns(PlayerType *player_ptr);
+void set_zangband_visited_towns();
 void set_zangband_quest(PlayerType *player_ptr, QuestType *const q_ptr, const QuestId loading_quest_index, const QuestId old_inside_quest);
 void set_zangband_class(PlayerType *player_ptr);
 void set_zangband_learnt_spells(PlayerType *player_ptr);

--- a/src/load/world-loader.cpp
+++ b/src/load/world-loader.cpp
@@ -11,6 +11,7 @@
 #include "system/dungeon/dungeon-record.h"
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/floor-info.h"
+#include "system/floor/town-records.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/inner-game-data.h"
 #include "system/player-type-definition.h"
@@ -137,19 +138,30 @@ static void rd_world_info(PlayerType *player_ptr)
     }
 }
 
-void rd_visited_towns(PlayerType *player_ptr)
+void rd_visited_towns()
 {
+    auto &town_records = TownRecords::get_instance();
     if (h_older_than(0, 3, 9)) {
-        player_ptr->visit = 1L;
+        town_records.set_visited(TownId::OUTPOST);
         return;
     }
 
     if (h_older_than(0, 3, 10)) {
-        set_zangband_visited_towns(player_ptr);
+        set_zangband_visited_towns();
         return;
     }
 
-    player_ptr->visit = rd_u32b();
+    if (loading_savefile_version_is_older_than(24)) {
+        const auto tmp32u = rd_u32b();
+        EnumClassFlagGroup<TownId> visited_towns;
+        migrate_bitflag_to_flaggroup(visited_towns, tmp32u);
+        town_records.set_ids(visited_towns);
+        return;
+    }
+
+    EnumClassFlagGroup<TownId> visited_towns;
+    rd_FlagGroup(visited_towns, rd_byte);
+    town_records.set_ids(visited_towns);
 }
 
 void rd_global_configurations(PlayerType *player_ptr)

--- a/src/load/world-loader.h
+++ b/src/load/world-loader.h
@@ -7,7 +7,7 @@ void rd_dungeons(PlayerType *player_ptr);
 void rd_alter_reality(PlayerType *player_ptr);
 void set_gambling_monsters();
 void rd_autopick(PlayerType *player_ptr);
-void rd_visited_towns(PlayerType *player_ptr);
+void rd_visited_towns();
 void rd_global_configurations(PlayerType *player_ptr);
 void load_wilderness_info(PlayerType *player_ptr);
 errr analyze_wilderness();

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -15,9 +15,11 @@
 #include "system/dungeon/dungeon-list.h"
 #include "system/dungeon/dungeon-record.h"
 #include "system/floor/floor-info.h"
+#include "system/floor/town-records.h"
 #include "system/inner-game-data.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/timed-effects.h"
+#include "util/flag-group.h"
 #include "world/world.h"
 #include <variant>
 
@@ -280,6 +282,6 @@ void wr_player(PlayerType *player_ptr)
     /* Save temporary preserved pets (obsolated) */
     wr_s16b(0);
     wr_u32b(world.play_time.elapsed_sec());
-    wr_s32b(player_ptr->visit);
+    wr_FlagGroup(TownRecords::get_instance().get_ids(), wr_byte);
     wr_u32b(player_ptr->count);
 }

--- a/src/spell-kind/spells-world.cpp
+++ b/src/spell-kind/spells-world.cpp
@@ -29,6 +29,7 @@
 #include "system/floor/floor-info.h"
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
+#include "system/floor/town-records.h"
 #include "system/floor/wilderness-grid.h"
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
@@ -277,8 +278,9 @@ bool tele_town(PlayerType *player_ptr)
 
     auto num = 0;
     const int towns_size = towns_info.size();
+    const auto &town_records = TownRecords::get_instance();
     for (auto i = 1; i < towns_size; i++) {
-        if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == player_ptr->town_num) || !(player_ptr->visit & (1UL << (i - 1)))) {
+        if ((i == VALID_TOWNS) || (i == SECRET_TOWN) || (i == player_ptr->town_num) || !town_records.has_visited(i2enum<TownId>(i - 1))) {
             continue;
         }
 
@@ -309,7 +311,7 @@ bool tele_town(PlayerType *player_ptr)
         }
 
         const auto town_num = key - 'a' + 1;
-        if ((town_num == player_ptr->town_num) || (town_num == VALID_TOWNS) || (town_num == SECRET_TOWN) || !(player_ptr->visit & (1UL << (key - 'a')))) {
+        if ((town_num == player_ptr->town_num) || (town_num == VALID_TOWNS) || (town_num == SECRET_TOWN) || !town_records.has_visited(i2enum<TownId>(key - 'a'))) {
             continue;
         }
 

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -14,6 +14,7 @@
 #include "system/enums/dungeon/dungeon-id.h"
 #include "system/floor/town-info.h"
 #include "system/floor/town-list.h"
+#include "system/floor/town-records.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
 #include "system/player-type-definition.h"
@@ -195,9 +196,10 @@ public:
         const auto &town_name = towns_info[town_rumor.t_idx].name;
         this->print_rumor(town_name);
 
-        const uint32_t visit = (1U << (town_rumor.t_idx - 1));
-        if ((town_rumor.t_idx != SECRET_TOWN) && !(player_ptr->visit & visit)) {
-            player_ptr->visit |= visit;
+        const auto town_id = i2enum<TownId>(town_rumor.t_idx - 1);
+        auto &town_records = TownRecords::get_instance();
+        if ((town_rumor.t_idx != SECRET_TOWN) && !town_records.has_visited(town_id)) {
+            town_records.set_visited(town_id);
             msg_erase();
             msg_print(_("{}に行ったことがある気がする。", "You feel you have been to {}."), town_name);
         }

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -29,7 +29,7 @@ constexpr std::string_view ROOT_VARIANT_NAME("Hengband");
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)
  */
-constexpr uint32_t SAVEFILE_VERSION = 23;
+constexpr uint32_t SAVEFILE_VERSION = 24;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)

--- a/src/system/floor/town-list.h
+++ b/src/system/floor/town-list.h
@@ -3,7 +3,6 @@
 #include <vector>
 
 constexpr short VALID_TOWNS = 6; // @details 旧海底都市クエストのマップを除外する. 有効な町に差し替え完了したら不要になるので注意.
-constexpr auto SECRET_TOWN = 5; // @details ズルの町番号.
 
 class TownInfo;
 extern std::vector<TownInfo> towns_info;

--- a/src/system/floor/town-records.cpp
+++ b/src/system/floor/town-records.cpp
@@ -1,0 +1,44 @@
+#include "system/floor/town-records.h"
+#include "system/floor/town-list.h"
+#include "util/enum-converter.h"
+
+TownRecords TownRecords::instance{};
+
+TownRecords &TownRecords::get_instance()
+{
+    return instance;
+}
+
+bool TownRecords::has_visited(TownId id) const
+{
+    if (enum2i(id) == SECRET_TOWN) {
+        return false;
+    }
+
+    return this->visited_ids.has(id);
+}
+
+void TownRecords::set_visited(TownId id)
+{
+    if (enum2i(id) == SECRET_TOWN) {
+        return;
+    }
+
+    this->visited_ids.set(id);
+}
+
+void TownRecords::initialize()
+{
+    this->visited_ids.clear();
+    this->visited_ids.set(TownId::OUTPOST);
+}
+
+void TownRecords::set_ids(const EnumClassFlagGroup<TownId> &loaded_data)
+{
+    this->visited_ids = loaded_data;
+}
+
+EnumClassFlagGroup<TownId> TownRecords::get_ids() const
+{
+    return this->visited_ids;
+}

--- a/src/system/floor/town-records.h
+++ b/src/system/floor/town-records.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "util/flag-group.h"
+
+constexpr auto SECRET_TOWN = 5; // @details ズルの町番号.
+
+enum class TownId {
+    OUTPOST = 0,
+    TELMORA = 1,
+    MORIVANT = 2,
+    ANGWIL = 3,
+    ZUL = 4,
+    RLYEH = 5,
+    MAX,
+};
+
+class TownRecords {
+public:
+    TownRecords(TownRecords &&) = delete;
+    TownRecords(const TownRecords &) = delete;
+    TownRecords &operator=(const TownRecords &) = delete;
+    TownRecords &operator=(TownRecords &&) = delete;
+
+    static TownRecords &get_instance();
+
+    bool has_visited(TownId id) const;
+    void set_visited(TownId id);
+    void initialize();
+
+    void set_ids(const EnumClassFlagGroup<TownId> &loaded_data); //!< for load only.
+    EnumClassFlagGroup<TownId> get_ids() const; //!< for save only.
+
+private:
+    TownRecords() = default;
+
+    static TownRecords instance;
+
+    EnumClassFlagGroup<TownId> visited_ids;
+};

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -203,7 +203,6 @@ public:
 #define KNOW_STAT 0x01
 #define KNOW_HPRATE 0x02
     BIT_FLAGS8 knowledge{}; /* Knowledge about yourself */
-    BIT_FLAGS visit{}; /* Visited towns */
 
     BIT_FLAGS old_race1{}; /* Record of race changes */
     BIT_FLAGS old_race2{}; /* Record of race changes */


### PR DESCRIPTION
PlayerTypeの枷を1つ外しました
セーブ/ロード/宿屋での街移動について特に問題ないことを確認しました