### PR TITLE
[Refactor] QuestType::reward_fa_id をカプセル化

### DIFF
--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -57,33 +57,63 @@ bool QuestType::is_fixed(QuestId quest_id)
 
 bool QuestType::has_reward() const
 {
-    return this->reward_fa_id != FixedArtifactId::NONE;
+    return this->reward_fa_id.has_value();
+}
+
+tl::optional<FixedArtifactId> QuestType::get_reward() const
+{
+    return this->reward_fa_id;
 }
 
 short QuestType::get_reward_bi_id() const
 {
-    const auto &artifact = ArtifactList::get_instance().get_artifact(this->reward_fa_id);
+    if (!this->has_reward()) {
+        return 0;
+    }
+
+    const auto &artifact = ArtifactList::get_instance().get_artifact(*this->reward_fa_id);
     return BaseitemList::get_instance().lookup_baseitem_id(artifact.bi_key);
 }
 
 bool QuestType::is_reward_instant_artifact() const
 {
-    return ArtifactList::get_instance().get_artifact(this->reward_fa_id).is_instant_artifact();
+    if (!this->has_reward()) {
+        return false;
+    }
+
+    return ArtifactList::get_instance().get_artifact(*this->reward_fa_id).is_instant_artifact();
 }
 
 bool QuestType::is_reward_target(const BaseitemKey &key) const
 {
-    return ArtifactList::get_instance().get_artifact(this->reward_fa_id).bi_key == key;
+    if (!this->has_reward()) {
+        return false;
+    }
+
+    return ArtifactList::get_instance().get_artifact(*this->reward_fa_id).bi_key == key;
 }
 
-void QuestType::set_reward() const
+void QuestType::set_reward(FixedArtifactId fa_id)
 {
-    ArtifactRecords::get_instance().set_quest_reward(this->reward_fa_id, true);
+    if (fa_id == FixedArtifactId::NONE) {
+        this->reset_reward();
+        return;
+    }
+
+    if (this->reward_fa_id && (*this->reward_fa_id != fa_id)) {
+        ArtifactRecords::get_instance().set_quest_reward(*this->reward_fa_id, false);
+    }
+
+    this->reward_fa_id = fa_id;
+    ArtifactRecords::get_instance().set_quest_reward(fa_id, true);
 }
 
-void QuestType::reset_reward() const
+void QuestType::reset_reward()
 {
-    ArtifactRecords::get_instance().set_quest_reward(this->reward_fa_id, false);
+    if (this->reward_fa_id) {
+        ArtifactRecords::get_instance().set_quest_reward(*this->reward_fa_id, false);
+        this->reward_fa_id.reset();
+    }
 }
 
 /*!
@@ -243,7 +273,7 @@ void check_find_art_quest_completion(PlayerType *player_ptr, ItemEntity *o_ptr)
     for (const auto &[quest_id, quest] : quests) {
         auto found_artifact = (quest.type == QuestKindType::FIND_ARTIFACT);
         found_artifact &= (quest.status == QuestStatusType::TAKEN);
-        found_artifact &= (o_ptr->is_specific_artifact(quest.reward_fa_id));
+        found_artifact &= quest.get_reward().map_or([o_ptr](FixedArtifactId fa_id) { return o_ptr->is_specific_artifact(fa_id); }, false);
         if (found_artifact) {
             complete_quest(player_ptr, quest_id);
         }

--- a/src/dungeon/quest.h
+++ b/src/dungeon/quest.h
@@ -6,6 +6,7 @@
 #include "util/enum-range.h"
 #include <map>
 #include <string>
+#include <tl/optional.hpp>
 #include <vector>
 
 // clang-format off
@@ -118,7 +119,6 @@ public:
     MONSTER_NUMBER cur_num = 0; /*!< 撃破したモンスターの数 / Number killed */
     MONSTER_NUMBER max_num = 0; /*!< 求められるモンスターの撃破数 / Number required */
 
-    FixedArtifactId reward_fa_id{}; /*!< クエスト対象のアイテムID / object index */
     MONSTER_NUMBER num_mon = 0; /*!< QuestKindTypeがKILL_NUMBER時の目標撃破数 number of monsters on level */
 
     BIT_FLAGS flags = 0; /*!< クエストに関するフラグビット / quest flags */
@@ -129,13 +129,17 @@ public:
 
     static bool is_fixed(QuestId quest_idx);
     bool has_reward() const;
+    tl::optional<FixedArtifactId> get_reward() const;
     short get_reward_bi_id() const;
     bool is_reward_instant_artifact() const;
     bool is_reward_target(const BaseitemKey &key) const;
-    void set_reward() const;
-    void reset_reward() const;
+    void set_reward(FixedArtifactId fa_id);
+    void reset_reward();
     MonraceDefinition &get_bounty();
     const MonraceDefinition &get_bounty() const;
+
+private:
+    tl::optional<FixedArtifactId> reward_fa_id{}; /*!< クエスト対象のアイテムID / object index */
 };
 
 class QuestList final : public util::AbstractMapWrapper<QuestId, QuestType> {

--- a/src/floor/fixed-map-generator.cpp
+++ b/src/floor/fixed-map-generator.cpp
@@ -201,7 +201,6 @@ static bool parse_qtw_QQ(QuestType *q_ptr, const std::vector<std::string> &token
     q_ptr->level = std::stoi(tokens[6]);
     q_ptr->r_idx = i2enum<MonraceId>(std::stoi(tokens[7]));
     const auto fa_id = i2enum<FixedArtifactId>(std::stoi(tokens[8]));
-    q_ptr->reward_fa_id = fa_id;
     q_ptr->dungeon = i2enum<DungeonId>(std::stoi(tokens[9]));
 
     if (num > 10) {
@@ -217,7 +216,7 @@ static bool parse_qtw_QQ(QuestType *q_ptr, const std::vector<std::string> &token
         return true;
     }
 
-    q_ptr->set_reward();
+    q_ptr->set_reward(fa_id);
     return true;
 }
 
@@ -254,8 +253,7 @@ static bool parse_qtw_QR(QuestType *q_ptr, const std::vector<std::string> &token
     }
 
     if (reward_idx != FixedArtifactId::NONE) {
-        q_ptr->reward_fa_id = reward_idx;
-        q_ptr->set_reward();
+        q_ptr->set_reward(reward_idx);
     } else {
         q_ptr->type = QuestKindType::KILL_ALL;
     }

--- a/src/info-reader/general-parser.cpp
+++ b/src/info-reader/general-parser.cpp
@@ -143,8 +143,8 @@ parse_error_type parse_line_feature(const FloorType &floor, std::string_view buf
             }
         } else if (token.starts_with('!')) {
             if (floor.is_in_quest()) {
-                const auto &quests = QuestList::get_instance();
-                one_letter.artifact = quests.get_quest(floor.quest_number).reward_fa_id;
+                const auto &quest = QuestList::get_instance().get_quest(floor.quest_number);
+                one_letter.artifact = quest.get_reward().value_or(FixedArtifactId::NONE);
             }
         } else {
             one_letter.artifact = i2enum<FixedArtifactId>(std::stoi(token));

--- a/src/knowledge/knowledge-quests.cpp
+++ b/src/knowledge/knowledge-quests.cpp
@@ -102,7 +102,7 @@ static void do_cmd_knowledge_quests_current(PlayerType *player_ptr, FILE *fff)
                     std::string item_name("");
                     if (quest.has_reward()) {
                         ItemEntity item(quest.get_reward_bi_id());
-                        item.fa_id = quest.reward_fa_id;
+                        item.fa_id = quest.get_reward().value_or(FixedArtifactId::NONE);
                         item.ident = IDENT_STORE;
                         item_name = describe_flavor(player_ptr, item, OD_NAME_ONLY);
                     }

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -68,9 +68,11 @@ static void load_quest_details(PlayerType *player_ptr, QuestType *q_ptr, const Q
         auto &quests = QuestList::get_instance();
         determine_random_questor(player_ptr, quests.get_quest(loading_quest_id));
     }
-    q_ptr->reward_fa_id = i2enum<FixedArtifactId>(rd_s16b());
-    if (q_ptr->has_reward()) {
-        q_ptr->set_reward();
+
+    q_ptr->reset_reward();
+    const auto reward_fa_id = i2enum<FixedArtifactId>(rd_s16b());
+    if (reward_fa_id != FixedArtifactId::NONE) {
+        q_ptr->set_reward(reward_fa_id);
     }
 
     q_ptr->flags = rd_byte();

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "save/save.h"
+#include "artifact/fixed-art-types.h"
 #include "core/object-compressor.h"
 #include "dungeon/quest.h"
 #include "inventory/inventory-slot-types.h"
@@ -142,7 +143,7 @@ static bool wr_savefile_new(PlayerType *player_ptr)
         wr_s16b((int16_t)quest.max_num);
         wr_s16b(enum2i(quest.type));
         wr_s16b(enum2i(quest.r_idx));
-        wr_s16b(enum2i(quest.reward_fa_id));
+        wr_s16b(enum2i(quest.get_reward().value_or(FixedArtifactId::NONE)));
         wr_byte((byte)quest.flags);
         wr_byte((byte)quest.dungeon);
     }


### PR DESCRIPTION
QuestType::reward_fa_id に関連する操作するメンバ関数群があるにも関わらず、QuestType::reward_fa_id がパブリックメンバで露出しており操作が完全にカプセル化されておらず中途半端な状態となっている。
QuestType::reward_fa_Id をプライベートメンバに変更し、関連する操作はすべてメンバ関数で行うよう変更する。

Issueはなし。#5382 のレビュー中に気になったので対応しました。
