### PR TITLE
[Refactor] 地形定義の財宝ドロップ定義の修正

### DIFF
--- a/lib/edit/TerrainDefinitions.jsonc
+++ b/lib/edit/TerrainDefinitions.jsonc
@@ -1599,7 +1599,7 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "MAY_HAVE_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 10,
       },
@@ -1622,7 +1622,7 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "MAY_HAVE_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 20,
       },
@@ -4744,7 +4744,7 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "MAY_HAVE_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 10,
       },
@@ -4767,7 +4767,7 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "MAY_HAVE_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 20,
       },
@@ -5077,7 +5077,7 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "MAY_HAVE_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 10,
       },
@@ -5100,7 +5100,7 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "MAY_HAVE_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 20,
       },

--- a/lib/edit/TerrainDefinitions.jsonc
+++ b/lib/edit/TerrainDefinitions.jsonc
@@ -1645,12 +1645,13 @@
       },
       "mimic": "MAGMA_VEIN",
       "map_priority": 2,
-      "flags": ["SECRET", "REMEMBER", "HAS_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["SECRET", "REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 10,
       },
       "interactions": {
         "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "1d1",
         "SECRET": "MAGMA_TREASURE",
       },
     },
@@ -1668,12 +1669,13 @@
       },
       "mimic": "QUARTZ_VEIN",
       "map_priority": 2,
-      "flags": ["SECRET", "REMEMBER", "HAS_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["SECRET", "REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 20,
       },
       "interactions": {
         "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "1d1",
         "SECRET": "QUARTZ_TREASURE",
       },
     },
@@ -1691,12 +1693,13 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "HAS_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 20,
       },
       "interactions": {
         "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "1d1",
         "ENSECRET": "MAGMA_HIDDEN",
       },
     },
@@ -1714,12 +1717,13 @@
       },
       "mimic": null,
       "map_priority": 2,
-      "flags": ["REMEMBER", "HAS_GOLD", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
       "tunnel": {
         "power": 20,
       },
       "interactions": {
         "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "1d1",
         "ENSECRET": "QUARTZ_HIDDEN",
       },
     },

--- a/schema/TerrainDefinitions.schema.json
+++ b/schema/TerrainDefinitions.schema.json
@@ -94,7 +94,6 @@
                 "LAVA",
                 "UP_STAIRS",
                 "LOS",
-                "MAY_HAVE_GOLD",
                 "MIRROR",
                 "DOWN_STAIRS",
                 "MOUNTAIN",

--- a/schema/TerrainDefinitions.schema.json
+++ b/schema/TerrainDefinitions.schema.json
@@ -86,7 +86,6 @@
                 "FLOOR",
                 "GLASS",
                 "GLOW",
-                "HAS_GOLD",
                 "HAS_ITEM",
                 "HIT_TRAP",
                 "CAN_DISINTEGRATE",
@@ -134,7 +133,29 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["TRAPDOOR", "PIT", "SPIKED_PIT", "POISON_PIT", "TY_CURSE", "TELEPORT", "FIRE", "ACID", "SLOW", "LOSE_STR", "LOSE_DEX", "LOSE_CON", "BLIND", "CONFUSE", "POISON", "SLEEP", "TRAPS", "ALARM", "OPEN", "ARMAGEDDON", "PIRANHA"]
+                "enum": [
+                  "TRAPDOOR",
+                  "PIT",
+                  "SPIKED_PIT",
+                  "POISON_PIT",
+                  "TY_CURSE",
+                  "TELEPORT",
+                  "FIRE",
+                  "ACID",
+                  "SLOW",
+                  "LOSE_STR",
+                  "LOSE_DEX",
+                  "LOSE_CON",
+                  "BLIND",
+                  "CONFUSE",
+                  "POISON",
+                  "SLEEP",
+                  "TRAPS",
+                  "ALARM",
+                  "OPEN",
+                  "ARMAGEDDON",
+                  "PIRANHA"
+                ]
               },
               "power": {
                 "type": "integer",
@@ -174,7 +195,17 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["START", "TILE_1", "TILE_2", "TILE_3", "TILE_4", "END", "OLD", "TELEPORT", "WRECKED"]
+                "enum": [
+                  "START",
+                  "TILE_1",
+                  "TILE_2",
+                  "TILE_3",
+                  "TILE_4",
+                  "END",
+                  "OLD",
+                  "TELEPORT",
+                  "WRECKED"
+                ]
               }
             },
             "additionalProperties": false
@@ -185,7 +216,18 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["GENERAL", "ARMOURY", "WEAPON", "TEMPLE", "ALCHEMIST", "MAGIC", "BLACK", "HOME", "BOOK", "MUSEUM"]
+                "enum": [
+                  "GENERAL",
+                  "ARMOURY",
+                  "WEAPON",
+                  "TEMPLE",
+                  "ALCHEMIST",
+                  "MAGIC",
+                  "BLACK",
+                  "HOME",
+                  "BOOK",
+                  "MUSEUM"
+                ]
               }
             },
             "additionalProperties": false
@@ -196,7 +238,40 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["BUILDING_00", "BUILDING_01", "BUILDING_02", "BUILDING_03", "BUILDING_04", "BUILDING_05", "BUILDING_06", "BUILDING_07", "BUILDING_08", "BUILDING_09", "BUILDING_10", "BUILDING_11", "BUILDING_12", "BUILDING_13", "BUILDING_14", "BUILDING_15", "BUILDING_16", "BUILDING_17", "BUILDING_18", "BUILDING_19", "BUILDING_20", "BUILDING_21", "BUILDING_22", "BUILDING_23", "BUILDING_24", "BUILDING_25", "BUILDING_26", "BUILDING_27", "BUILDING_28", "BUILDING_29", "BUILDING_30", "BUILDING_31"]
+                "enum": [
+                  "BUILDING_00",
+                  "BUILDING_01",
+                  "BUILDING_02",
+                  "BUILDING_03",
+                  "BUILDING_04",
+                  "BUILDING_05",
+                  "BUILDING_06",
+                  "BUILDING_07",
+                  "BUILDING_08",
+                  "BUILDING_09",
+                  "BUILDING_10",
+                  "BUILDING_11",
+                  "BUILDING_12",
+                  "BUILDING_13",
+                  "BUILDING_14",
+                  "BUILDING_15",
+                  "BUILDING_16",
+                  "BUILDING_17",
+                  "BUILDING_18",
+                  "BUILDING_19",
+                  "BUILDING_20",
+                  "BUILDING_21",
+                  "BUILDING_22",
+                  "BUILDING_23",
+                  "BUILDING_24",
+                  "BUILDING_25",
+                  "BUILDING_26",
+                  "BUILDING_27",
+                  "BUILDING_28",
+                  "BUILDING_29",
+                  "BUILDING_30",
+                  "BUILDING_31"
+                ]
               }
             },
             "additionalProperties": false
@@ -219,9 +294,49 @@
           "interactions": {
             "type": "object",
             "description": "特定行動後の地形変化定義",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "properties": {
+              "BASH": {
+                "type": "string"
+              },
+              "CLOSE": {
+                "type": "string"
+              },
+              "DESTROYED": {
+                "type": "string"
+              },
+              "DISARM": {
+                "type": "string"
+              },
+              "DROP_GOLD": {
+                "type": "string",
+                "pattern": "^1d1$"
+              },
+              "ENSECRET": {
+                "type": "string"
+              },
+              "HIT_TRAP": {
+                "type": "string"
+              },
+              "MAY_HAVE_GOLD": {
+                "type": "string"
+              },
+              "OPEN": {
+                "type": "string"
+              },
+              "SECRET": {
+                "type": "string"
+              },
+              "SHAFT": {
+                "type": "string"
+              },
+              "SPIKE": {
+                "type": "string"
+              },
+              "UNPERM": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
           }
         },
         "additionalProperties": false

--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -6,6 +6,7 @@
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
 #include "term/gameterm.h"
+#include "util/dice.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 #include <algorithm>
@@ -382,6 +383,17 @@ static errr set_terrain_interactions(const nlohmann::json &interactions_obj, Ter
         const auto result_tag = value_obj.get<std::string>();
         if (result_tag.empty()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        if (action == "DROP_GOLD") {
+            Dice dice;
+            if (auto err = info_set_dice(value_obj, dice, true)) {
+                return err;
+            }
+            if (dice.is_valid()) {
+                terrain.flags.set(TerrainCharacteristics::HAS_GOLD);
+            }
+            continue;
         }
 
         if (action == "DESTROYED") {

--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -358,6 +358,60 @@ static errr set_terrain_building(const nlohmann::json &building_obj, TerrainType
     return terrain.init_building_type(it->second) ? PARSE_ERROR_NONE : PARSE_ERROR_INVALID_VALUE;
 }
 
+/*!
+ * @brief 地形変化定義を地形情報へ反映する
+ * @param interactions_obj 地形変化定義を表すJSONオブジェクト
+ * @param terrain 設定先の地形情報
+ * @return パース結果
+ */
+static errr set_terrain_interactions(const nlohmann::json &interactions_obj, TerrainType &terrain)
+{
+    if (interactions_obj.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!interactions_obj.is_object()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    for (auto it = interactions_obj.begin(); it != interactions_obj.end(); ++it) {
+        const auto action = it.key();
+        const auto &value_obj = it.value();
+        if (!value_obj.is_string()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+        const auto result_tag = value_obj.get<std::string>();
+        if (result_tag.empty()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        if (action == "DESTROYED") {
+            terrain.destroyed_tag = result_tag;
+            continue;
+        }
+
+        const auto state_it = std::find_if(std::begin(terrain.state), std::end(terrain.state),
+            [](const auto &s) { return s.action == TerrainCharacteristics::MAX; });
+        if (state_it == std::end(terrain.state)) {
+            return PARSE_ERROR_GENERIC;
+        }
+
+        const auto idx_state = static_cast<int>(std::distance(std::begin(terrain.state), state_it));
+
+        if (auto val = parse_terrain_action(action)) {
+            terrain.state[idx_state].action = *val;
+            if (*val == TerrainCharacteristics::MAY_HAVE_GOLD) {
+                terrain.flags.set(TerrainCharacteristics::MAY_HAVE_GOLD);
+            }
+        } else {
+            msg_format(_("未知の地形アクション '%s'。", "Unknown feature action '%s'."), action.data());
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+        terrain.state[idx_state].result_tag = result_tag;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
 errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
 {
     if (element.is_null() || !element.is_object()) {
@@ -466,45 +520,8 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
     if (auto err = set_terrain_conversion(element["convert"], terrain)) {
         return err;
     }
-
-    const auto &inter_obj = element["interactions"];
-    if (!inter_obj.is_null()) {
-        if (!inter_obj.is_object()) {
-            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-        }
-
-        for (auto it = inter_obj.begin(); it != inter_obj.end(); ++it) {
-            const auto action = it.key();
-            const auto &value_obj = it.value();
-            if (!value_obj.is_string()) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-            const auto result_tag = value_obj.get<std::string>();
-            if (result_tag.empty()) {
-                return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-            }
-
-            if (action == "DESTROYED") {
-                terrain.destroyed_tag = result_tag;
-                continue;
-            }
-
-            const auto state_it = std::find_if(std::begin(terrain.state), std::end(terrain.state),
-                [](const auto &s) { return s.action == TerrainCharacteristics::MAX; });
-            if (state_it == std::end(terrain.state)) {
-                return PARSE_ERROR_GENERIC;
-            }
-
-            const auto idx_state = static_cast<int>(std::distance(std::begin(terrain.state), state_it));
-
-            if (auto val = parse_terrain_action(action)) {
-                terrain.state[idx_state].action = *val;
-            } else {
-                msg_format(_("未知の地形アクション '%s'。", "Unknown feature action '%s'."), action.data());
-                return PARSE_ERROR_INVALID_FLAG;
-            }
-            terrain.state[idx_state].result_tag = result_tag;
-        }
+    if (auto err = set_terrain_interactions(element["interactions"], terrain)) {
+        return err;
     }
 
     return PARSE_ERROR_NONE;


### PR DESCRIPTION
flags.MAY_HAVE_GOLD flags.HAS_GOLDの廃止

定義ファイル読込時に
interactions.MAY_HAVE_GOLDが定義されていればTerrainCharacteristics::MAY_HAVE_GOLDをセット
interactions.DROP_GOLDが有効値であればTerrainCharacteristics::HAS_GOLDをセット

interactions.DROP_GOLDは現状1d1のみ有効とする。
ゲームの挙動はこのPRでは変更しない。