### PR TITLE
[Feature] 地形生成時の派生と財宝ドロップ数を定義化

### DIFF
--- a/lib/edit/TerrainDefinitions.jsonc
+++ b/lib/edit/TerrainDefinitions.jsonc
@@ -1678,6 +1678,18 @@
         "DROP_GOLD": "1d1",
         "SECRET": "QUARTZ_TREASURE",
       },
+      "generation": {
+        "changes": [
+          {
+            "terrain": "QUARTZ_HIDDEN_2",
+            "probability": 4,
+          },
+          {
+            "terrain": "QUARTZ_HIDDEN_3",
+            "probability": 1,
+          },
+        ],
+      },
     },
     {
       "id": 54,
@@ -1725,6 +1737,18 @@
         "DESTROYED": "*FLOOR*",
         "DROP_GOLD": "1d1",
         "ENSECRET": "QUARTZ_HIDDEN",
+      },
+      "generation": {
+        "changes": [
+          {
+            "terrain": "QUARTZ_TREASURE_2",
+            "probability": 4,
+          },
+          {
+            "terrain": "QUARTZ_TREASURE_3",
+            "probability": 1,
+          },
+        ],
       },
     },
     {
@@ -5155,6 +5179,102 @@
       },
       "interactions": {
         "DESTROYED": "DEEP_WATER",
+      },
+    },
+    {
+      "id": 240,
+      "key": "QUARTZ_TREASURE_2",
+      "name": {
+        "ja": "財宝を含有した石英の鉱脈",
+        "en": "quartz vein with treasure",
+      },
+      "symbol": {
+        "character": "*",
+        "color": "Orange",
+        "lit": true,
+      },
+      "mimic": null,
+      "map_priority": 2,
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "tunnel": {
+        "power": 30,
+      },
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "2d2",
+        "ENSECRET": "QUARTZ_HIDDEN_2",
+      },
+    },
+    {
+      "id": 241,
+      "key": "QUARTZ_TREASURE_3",
+      "name": {
+        "ja": "財宝を含有した石英の鉱脈",
+        "en": "quartz vein with treasure",
+      },
+      "symbol": {
+        "character": "*",
+        "color": "Orange",
+        "lit": true,
+      },
+      "mimic": null,
+      "map_priority": 2,
+      "flags": ["REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "tunnel": {
+        "power": 30,
+      },
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "3d3",
+        "ENSECRET": "QUARTZ_HIDDEN_3",
+      },
+    },
+    {
+      "id": 242,
+      "key": "QUARTZ_HIDDEN_2",
+      "name": {
+        "ja": "石英の鉱脈(隠された財宝を含有)",
+        "en": "quartz vein hidden treasure",
+      },
+      "symbol": {
+        "character": "%",
+        "color": "White",
+        "lit": true,
+      },
+      "mimic": "QUARTZ_VEIN",
+      "map_priority": 2,
+      "flags": ["SECRET", "REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "tunnel": {
+        "power": 30,
+      },
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "2d2",
+        "SECRET": "QUARTZ_TREASURE_2",
+      },
+    },
+    {
+      "id": 243,
+      "key": "QUARTZ_HIDDEN_3",
+      "name": {
+        "ja": "石英の鉱脈(隠された財宝を含有)",
+        "en": "quartz vein hidden treasure",
+      },
+      "symbol": {
+        "character": "%",
+        "color": "White",
+        "lit": true,
+      },
+      "mimic": "QUARTZ_VEIN",
+      "map_priority": 2,
+      "flags": ["SECRET", "REMEMBER", "WALL", "STONE", "CAN_PASS", "CAN_DISINTEGRATE"],
+      "tunnel": {
+        "power": 30,
+      },
+      "interactions": {
+        "DESTROYED": "*FLOOR*",
+        "DROP_GOLD": "3d3",
+        "SECRET": "QUARTZ_TREASURE_3",
       },
     },
   ],

--- a/schema/TerrainDefinitions.schema.json
+++ b/schema/TerrainDefinitions.schema.json
@@ -291,6 +291,32 @@
             },
             "additionalProperties": false
           },
+          "generation": {
+            "type": ["object", "null"],
+            "required": ["changes"],
+            "properties": {
+              "changes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["terrain", "probability"],
+                  "properties": {
+                    "terrain": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "probability": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 100
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
           "interactions": {
             "type": "object",
             "description": "特定行動後の地形変化定義",
@@ -309,7 +335,7 @@
               },
               "DROP_GOLD": {
                 "type": "string",
-                "pattern": "^1d1$"
+                "pattern": "^[1-9][0-9]*d[1-9][0-9]*$"
               },
               "ENSECRET": {
                 "type": "string"

--- a/src/floor/cave-generator.cpp
+++ b/src/floor/cave-generator.cpp
@@ -3,6 +3,7 @@
 #include "dungeon/quest-monster-placer.h"
 #include "floor/dungeon-tunnel-util.h"
 #include "floor/floor-allocation-types.h"
+#include "floor/floor-generator.h"
 #include "floor/floor-streams.h"
 #include "floor/geometry.h"
 #include "floor/object-allocator.h"
@@ -385,6 +386,7 @@ tl::optional<std::string> cave_gen(PlayerType *player_ptr)
 
     make_aqua_streams(player_ptr, &dd, dungeon);
     make_perm_walls(player_ptr);
+    apply_terrain_generation_changes(floor);
     if (!check_place_necessary_objects(player_ptr, &dd)) {
         return dd.why;
     }

--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -37,6 +37,7 @@
 #include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
 #include "system/terrain/terrain-list.h"
+#include "term/z-rand.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
 #include "window/main-window-util.h"
@@ -300,6 +301,33 @@ void wipe_generate_random_floor_flags(FloorType &floor)
     }
 }
 
+static short select_terrain_generation_change(short terrain_id)
+{
+    const auto &terrain = TerrainList::get_instance().get_terrain(terrain_id);
+    if (terrain.generation_changes.empty()) {
+        return terrain_id;
+    }
+
+    const auto chance = randint1(100);
+    auto cumulative_probability = 0;
+    for (const auto &change : terrain.generation_changes) {
+        cumulative_probability += change.probability;
+        if (chance <= cumulative_probability) {
+            return change.result;
+        }
+    }
+
+    return terrain_id;
+}
+
+void apply_terrain_generation_changes(FloorType &floor)
+{
+    for (const auto &pos : floor.get_area()) {
+        auto &grid = floor.get_grid(pos);
+        grid.feat = select_terrain_generation_change(grid.feat);
+    }
+}
+
 /*!
  * @brief フロアの全情報を初期化する / Clear and empty floor.
  * @parama player_ptr プレイヤーへの参照ポインタ
@@ -440,6 +468,7 @@ void generate_floor(PlayerType *player_ptr)
     const auto is_wild_mode = AngbandWorld::get_instance().is_wild_mode();
     for (int num = 0; true; num++) {
         tl::optional<std::string> why;
+        auto should_apply_terrain_generation_changes = true;
         clear_cave(player_ptr);
         player_ptr->x = player_ptr->y = 0;
         if (floor.inside_arena) {
@@ -459,6 +488,11 @@ void generate_floor(PlayerType *player_ptr)
             panel_row_min = floor.height;
             panel_col_min = floor.width;
             why = cave_gen(player_ptr);
+            should_apply_terrain_generation_changes = false;
+        }
+
+        if (!why && should_apply_terrain_generation_changes) {
+            apply_terrain_generation_changes(floor);
         }
 
         if (floor.o_list.size() >= MAX_FLOOR_ITEMS) {

--- a/src/floor/floor-generator.h
+++ b/src/floor/floor-generator.h
@@ -3,5 +3,6 @@
 class FloorType;
 class PlayerType;
 void wipe_generate_random_floor_flags(FloorType &floor);
+void apply_terrain_generation_changes(FloorType &floor);
 void clear_cave(PlayerType *player_ptr);
 void generate_floor(PlayerType *player_ptr);

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -801,7 +801,8 @@ void cave_alter_feat(PlayerType *player_ptr, POSITION y, POSITION x, TerrainChar
         /* Handle gold */
         if (old_terrain.flags.has(TerrainCharacteristics::HAS_GOLD) && new_terrain.flags.has_not(TerrainCharacteristics::HAS_GOLD)) {
             /* Place some gold */
-            place_gold(player_ptr, pos);
+            const auto drop_count = old_terrain.gold_drop.is_valid() ? old_terrain.gold_drop.roll() : 1;
+            place_gold(player_ptr, pos, drop_count);
             found = true;
         }
 

--- a/src/grid/object-placer.cpp
+++ b/src/grid/object-placer.cpp
@@ -41,6 +41,19 @@ void place_gold(PlayerType *player_ptr, const Pos2D &pos)
     lite_spot(player_ptr, pos);
 }
 
+void place_gold(PlayerType *player_ptr, const Pos2D &pos, int drop_count)
+{
+    if (drop_count <= 0) {
+        return;
+    }
+
+    auto &floor = *player_ptr->current_floor_ptr;
+    for (auto i = 0; i < drop_count; i++) {
+        auto item = floor.make_gold();
+        (void)drop_near(player_ptr, item, pos, false);
+    }
+}
+
 /*!
  * @brief フロアの指定位置に生成階に応じたベースアイテムの生成を行う
  * @param player_ptr プレイヤーへの参照ポインタ

--- a/src/grid/object-placer.h
+++ b/src/grid/object-placer.h
@@ -6,4 +6,5 @@
 
 class PlayerType;
 void place_gold(PlayerType *player_ptr, const Pos2D &pos);
+void place_gold(PlayerType *player_ptr, const Pos2D &pos, int drop_count);
 void place_object(PlayerType *player_ptr, const Pos2D &pos, uint32_t mode, BaseitemRestrict restrict = nullptr);

--- a/src/info-reader/terrain-reader.cpp
+++ b/src/info-reader/terrain-reader.cpp
@@ -130,6 +130,52 @@ static errr set_terrain_conversion(const nlohmann::json &convert_obj, TerrainTyp
     return terrain.init_conversion_type(it->second, stream_index) ? PARSE_ERROR_NONE : PARSE_ERROR_INVALID_VALUE;
 }
 
+static errr set_terrain_generation(const nlohmann::json &generation_obj, TerrainType &terrain)
+{
+    if (generation_obj.is_null()) {
+        return PARSE_ERROR_NONE;
+    }
+    if (!generation_obj.is_object()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    const auto &changes_obj = generation_obj["changes"];
+    if (!changes_obj.is_array()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    auto probability_sum = 0;
+    for (const auto &change_obj : changes_obj) {
+        if (!change_obj.is_object()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        const auto &terrain_obj = change_obj["terrain"];
+        if (!terrain_obj.is_string()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        auto change = TerrainGenerationChange{};
+        change.result_tag = terrain_obj.get<std::string>();
+        if (change.result_tag.empty()) {
+            return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+        }
+
+        if (auto err = info_set_integer(change_obj["probability"], change.probability, true, Range(1, 100))) {
+            return err;
+        }
+
+        probability_sum += change.probability;
+        if (probability_sum > 100) {
+            return PARSE_ERROR_INVALID_FLAG;
+        }
+
+        terrain.generation_changes.push_back(change);
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
 /*!
  * @brief 地形の用途別強度をJSON定義から設定する
  * @param power_obj 強度値を表すJSON値
@@ -391,6 +437,7 @@ static errr set_terrain_interactions(const nlohmann::json &interactions_obj, Ter
                 return err;
             }
             if (dice.is_valid()) {
+                terrain.gold_drop = dice;
                 terrain.flags.set(TerrainCharacteristics::HAS_GOLD);
             }
             continue;
@@ -464,6 +511,8 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
 
     terrain.mimic = s;
     terrain.destroyed = s;
+    terrain.gold_drop = Dice{};
+    terrain.generation_changes.clear();
     for (auto j = 0; j < MAX_FEAT_STATES; j++) {
         terrain.state[j].action = TerrainCharacteristics::MAX;
         terrain.state[j].result_tag.clear();
@@ -530,6 +579,9 @@ errr parse_terrains_json_info(nlohmann::json &element, angband_header *)
         return err;
     }
     if (auto err = set_terrain_conversion(element["convert"], terrain)) {
+        return err;
+    }
+    if (auto err = set_terrain_generation(element["generation"], terrain)) {
         return err;
     }
     if (auto err = set_terrain_interactions(element["interactions"], terrain)) {

--- a/src/system/terrain/terrain-definition.h
+++ b/src/system/terrain/terrain-definition.h
@@ -7,10 +7,13 @@
 #include "system/enums/terrain/terrain-characteristics.h"
 #include "system/enums/terrain/terrain-conversion-type.h"
 #include "system/enums/terrain/trap.h"
+#include "util/dice.h"
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
 #include <cstdint>
 #include <map>
+#include <string>
+#include <vector>
 
 /* Number of feats we change to (Excluding default). Used in TerrainDefinitions.jsonc. */
 constexpr auto MAX_FEAT_STATES = 8;
@@ -29,6 +32,14 @@ enum class TerrainAction {
     NO_DROP = 2,
     CRASH_GLASS = 3,
     MAX,
+};
+
+class TerrainGenerationChange {
+public:
+    TerrainGenerationChange() = default;
+    std::string result_tag{}; /*!< 生成時の変化先地形タグ */
+    FEAT_IDX result{}; /*!< 生成時の変化先地形ID */
+    int probability{}; /*!< 変化確率(%) */
 };
 
 /*!
@@ -75,6 +86,8 @@ public:
     uint8_t door_power{}; /*!< 扉の強度 */
     uint8_t trap_power{}; /*!< 罠の解除難易度 */
     uint8_t tunnel_power{}; /*!< トンネル掘削難易度 */
+    Dice gold_drop{}; /*!< 財宝地形から生成する財宝数 */
+    std::vector<TerrainGenerationChange> generation_changes; /*!< 生成時の変化候補 */
     std::map<int, DisplaySymbol> symbol_definitions; //!< デフォルトの地形シンボル (色/文字).
     std::map<int, DisplaySymbol> symbol_configs; //!< 設定変更後の地形シンボル (色/文字).
 

--- a/src/system/terrain/terrain-list.cpp
+++ b/src/system/terrain/terrain-list.cpp
@@ -101,6 +101,9 @@ void TerrainList::retouch()
         for (auto &ts : terrain.state) {
             ts.result = this->search_real_terrain(ts.result_tag).value_or(ts.result);
         }
+        for (auto &change : terrain.generation_changes) {
+            change.result = this->search_real_terrain(change.result_tag).value_or(change.result);
+        }
     }
 }
 


### PR DESCRIPTION
- TerrainDefinitions に generation.changes を追加し、通常地形生成後に派生地形へ変化させる

- QUARTZ_TREASURE / QUARTZ_HIDDEN の派生地形を追加し、財宝ドロップ数を DROP_GOLD のダイス定義から反映する
-- 派生地形は財宝ドロップ数が多く、少し硬い。見た目からは分からない。低確率で石英鉱脈の代わりに生成される。

- TerrainDefinitions schema と reader を generation / 複数 DROP_GOLD に対応させる