### PR TITLE
[Refactor] MonraceDefinition::r_sights をMonraceRecord::seen_count に移した

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -319,6 +319,7 @@
     <ClCompile Include="..\..\src\system\floor\wilderness-grid.cpp" />
     <ClCompile Include="..\..\src\system\monrace\monrace-record.cpp" />
     <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
     <ClCompile Include="..\..\src\system\floor\floor-list.cpp" />
@@ -1058,6 +1059,7 @@
     <ClInclude Include="..\..\src\system\item\identification-flags.h" />
     <ClInclude Include="..\..\src\system\monrace\monrace-record.h" />
     <ClInclude Include="..\..\src\system\monrace\monrace-records.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-service.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-service.h" />
     <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -317,6 +317,8 @@
     <ClCompile Include="..\..\src\system\artifact\artifact-service.cpp" />
     <ClCompile Include="..\..\src\system\floor\town-records.cpp" />
     <ClCompile Include="..\..\src\system\floor\wilderness-grid.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-record.cpp" />
+    <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-monrace-service.cpp" />
     <ClCompile Include="..\..\src\system\services\dungeon-service.cpp" />
     <ClCompile Include="..\..\src\system\floor\floor-list.cpp" />
@@ -1054,6 +1056,8 @@
     <ClInclude Include="..\..\src\system\floor\town-records.h" />
     <ClInclude Include="..\..\src\system\floor\wilderness-grid.h" />
     <ClInclude Include="..\..\src\system\item\identification-flags.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-record.h" />
+    <ClInclude Include="..\..\src\system\monrace\monrace-records.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-monrace-service.h" />
     <ClInclude Include="..\..\src\system\services\dungeon-service.h" />
     <ClInclude Include="..\..\src\system\enums\dungeon\dungeon-id.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2586,6 +2586,9 @@
     <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp">
       <Filter>system\monrace</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-service.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5608,6 +5611,9 @@
       <Filter>system\monrace</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\monrace\monrace-records.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-service.h">
       <Filter>system\monrace</Filter>
     </ClInclude>
   </ItemGroup>

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2580,6 +2580,12 @@
     <ClCompile Include="..\..\src\info-reader\definition-hash-data.cpp">
       <Filter>info-reader</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-record.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\monrace\monrace-records.cpp">
+      <Filter>system\monrace</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5597,6 +5603,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\info-reader\definition-hash-data.h">
       <Filter>info-reader</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-record.h">
+      <Filter>system\monrace</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\monrace\monrace-records.h">
+      <Filter>system\monrace</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1310,6 +1310,8 @@ hengband_SOURCES = \
 	system/monrace/monrace-definition.cpp system/monrace/monrace-definition.h \
 	system/monrace/monrace-list.cpp system/monrace/monrace-list.h \
 	system/monrace/monrace-message.cpp system/monrace/monrace-message.h \
+	system/monrace/monrace-record.cpp system/monrace/monrace-record.h \
+	system/monrace/monrace-records.cpp system/monrace/monrace-records.h \
 	\
 	system/services/baseitem-monrace-service.cpp system/services/baseitem-monrace-service.h \
 	system/services/dungeon-service.cpp system/services/dungeon-service.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1312,6 +1312,7 @@ hengband_SOURCES = \
 	system/monrace/monrace-message.cpp system/monrace/monrace-message.h \
 	system/monrace/monrace-record.cpp system/monrace/monrace-record.h \
 	system/monrace/monrace-records.cpp system/monrace/monrace-records.h \
+	system/monrace/monrace-service.cpp system/monrace/monrace-service.h \
 	\
 	system/services/baseitem-monrace-service.cpp system/services/baseitem-monrace-service.h \
 	system/services/dungeon-service.cpp system/services/dungeon-service.h \

--- a/src/cmd-io/cmd-lore.cpp
+++ b/src/cmd-io/cmd-lore.cpp
@@ -7,6 +7,7 @@
 #include "lore/lore-util.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
@@ -16,33 +17,32 @@
 #include "util/int-char-converter.h"
 #include "util/string-processor.h"
 #include "view/display-lore.h"
+#include <fmt/format.h>
 
 namespace {
 std::pair<std::string, std::vector<MonraceId>> collect_monraces(char symbol)
 {
-    const auto &monraces = MonraceList::get_instance();
     const auto is_known_only = !cheat_know;
-
     switch (symbol) {
     case KTRL('A'): {
         constexpr auto msg = _("全モンスターのリスト", "Full monster list.");
         auto filter = [](const MonraceDefinition &) { return true; };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('U'): {
         constexpr auto msg = _("ユニーク・モンスターのリスト", "Unique monster list.");
         auto filter = [](const MonraceDefinition &monrace) { return monrace.kind_flags.has(MonsterKindType::UNIQUE); };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('N'): {
         constexpr auto msg = _("ユニーク外モンスターのリスト", "Non-unique monster list.");
         auto filter = [](const MonraceDefinition &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('R'): {
         constexpr auto msg = _("乗馬可能モンスターのリスト", "Ridable monster list.");
         auto filter = [](const MonraceDefinition &monrace) { return monrace.misc_flags.has(MonsterMiscType::RIDING); };
-        return std::make_pair(msg, monraces.search(std::move(filter), is_known_only));
+        return std::make_pair(msg, MonraceService::search(std::move(filter), is_known_only));
     }
     case KTRL('M'): {
         const auto monster_name = input_string(_("名前(英語の場合小文字で可)", "Enter name:"), MAX_MONSTER_NAME);
@@ -50,8 +50,8 @@ std::pair<std::string, std::vector<MonraceId>> collect_monraces(char symbol)
             return { "", {} };
         }
 
-        auto msg = format(_("名前:%sにマッチ", "Monsters' names with \"%s\""), monster_name->data());
-        return std::make_pair(msg, monraces.search_by_name(*monster_name, is_known_only));
+        const auto msg = fmt::format(_("名前:{}にマッチ", "Monsters' names with \"{}\""), monster_name->data());
+        return std::make_pair(msg, MonraceService::search_by_name(*monster_name, is_known_only));
     }
     default: {
         int ident_i;
@@ -62,8 +62,8 @@ std::pair<std::string, std::vector<MonraceId>> collect_monraces(char symbol)
         }
 
         if (ident_info[ident_i]) {
-            auto msg = format("%c - %s.", symbol, ident_info[ident_i] + 2);
-            return std::make_pair(msg, monraces.search_by_symbol(symbol, is_known_only));
+            const auto msg = fmt::format("{} - {}.", symbol, ident_info[ident_i] + 2);
+            return std::make_pair(msg, MonraceService::search_by_symbol(symbol, is_known_only));
         }
 
         return std::make_pair(_("無効な文字", "Unknown Symbol"), std::vector<MonraceId>{});

--- a/src/knowledge/knowledge-monsters.cpp
+++ b/src/knowledge/knowledge-monsters.cpp
@@ -21,6 +21,7 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
@@ -53,9 +54,10 @@ static std::vector<MonraceId> collect_monsters(short grp_cur, monster_lore_mode 
     const auto grp_amberite = (MONRACE_CHARACTERS_GROUP[grp_cur] == "Amberites");
 
     const auto &monraces = MonraceList::get_instance();
+    const auto &monrace_records = MonraceRecords::get_instance();
     std::vector<MonraceId> monrace_ids;
     for (const auto &[monrace_id, monrace] : monraces) {
-        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !monrace->r_sights) {
+        if (((mode != MONSTER_LORE_DEBUG) && (mode != MONSTER_LORE_RESEARCH)) && !cheat_know && !monrace_records.has_been_seen(monrace_id)) {
             continue;
         }
 

--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -6,9 +6,11 @@
 
 #include "knowledge/knowledge-uniques.h"
 #include "core/show-file.h"
+#include "game-option/cheat-options.h"
 #include "io-dump/dump-util.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/player-type-definition.h"
 #include "term/z-form.h"
 #include "util/angband-files.h"
@@ -35,8 +37,13 @@ UniqueList::UniqueList(bool is_alive)
 
 void UniqueList::sweep()
 {
-    auto &monraces = MonraceList::get_instance();
+    const auto &monraces = MonraceList::get_instance();
+    const auto &records = MonraceRecords::get_instance();
     for (auto &[monrace_id, monrace] : monraces) {
+        if (!cheat_know && !records.has_been_seen(monrace_id)) {
+            continue;
+        }
+
         if (!monrace->is_valid() || !monrace->should_display(this->is_alive)) {
             continue;
         }

--- a/src/load/lore-loader.cpp
+++ b/src/load/lore-loader.cpp
@@ -7,6 +7,8 @@
 #include "system/angband.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-record.h"
+#include "system/monrace/monrace-records.h"
 #include "system/system-variables.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
@@ -331,7 +333,8 @@ static void migrate_old_behavior_flags(MonraceDefinition &monrace, BIT_FLAGS old
  */
 static void rd_lore(MonraceDefinition &monrace, const MonraceId r_idx)
 {
-    monrace.r_sights = rd_s16b();
+    auto &records = MonraceRecords::get_instance();
+    records.set_seen_count(r_idx, rd_s16b());
     monrace.r_deaths = rd_s16b();
     monrace.r_pkills = rd_s16b();
 

--- a/src/lore/lore-util.cpp
+++ b/src/lore/lore-util.cpp
@@ -5,6 +5,7 @@
 #include "monster-race/race-sex.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 
@@ -45,6 +46,7 @@ lore_type::lore_type(MonraceId monrace_id, monster_lore_mode mode)
 {
     this->nightmare = ironman_nightmare && (mode != MONSTER_LORE_DEBUG);
     this->monrace = MonraceList::get_instance().get_monrace_shared(monrace_id);
+    this->record = MonraceRecords::get_instance().get_record(monrace_id);
     this->speed = this->nightmare ? this->monrace->speed + 5 : this->monrace->speed;
     this->drop_gold = this->monrace->r_drop_gold;
     this->drop_item = this->monrace->r_drop_item;

--- a/src/lore/lore-util.h
+++ b/src/lore/lore-util.h
@@ -34,6 +34,7 @@ enum monster_lore_mode {
 };
 
 class MonraceDefinition;
+class MonraceRecord;
 struct lore_msg {
     lore_msg(std::string_view msg, byte color = TERM_WHITE);
     std::string msg;
@@ -68,7 +69,8 @@ struct lore_type {
     RaceBlowMethodType method;
 
     bool nightmare;
-    std::shared_ptr<MonraceDefinition> monrace;
+    std::shared_ptr<const MonraceDefinition> monrace;
+    std::shared_ptr<const MonraceRecord> record;
     byte speed;
     ITEM_NUMBER drop_gold;
     ITEM_NUMBER drop_item;

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -24,7 +24,8 @@
 #include "market/building-initializer.h"
 #include "system/angband-system.h"
 #include "system/dungeon/dungeon-definition.h"
-#include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/services/baseitem-monrace-service.h"
 #include "system/system-variables.h"
 #include "term/gameterm.h"
@@ -189,6 +190,8 @@ void init_angband(PlayerType *player_ptr, bool no_term)
 
     init_note(_("[データの初期化中... (モンスター)]", "[Initializing arrays... (monsters)]"));
     init_monrace_definitions();
+    const auto monraces_size = MonraceList::get_instance().size();
+    MonraceRecords::get_instance().initialize(monraces_size);
     const auto error = BaseitemMonraceService::check_specific_drop_gold_flags_duplication();
     if (error) {
         quit(*error);

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -30,6 +30,7 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
@@ -164,19 +165,15 @@ void MonsterDamageProcessor::death_special_flag_monster()
     auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
     auto monrace_id = monster.r_idx;
     auto &monrace = monster.get_monrace();
+    auto &monrace_records = MonraceRecords::get_instance();
     if (monrace.misc_flags.has(MonsterMiscType::TANUKI)) {
         monster.ap_r_idx = monrace_id;
-        if (monrace.r_sights < MAX_SHORT) {
-            monrace.r_sights++;
-        }
+        monrace_records.increment_seen_count(monrace_id);
     }
 
     if (monster.mflag2.has(MonsterConstantFlagType::CHAMELEON)) {
-        auto &real_monrace = monster.get_real_monrace();
         monrace_id = monster.get_real_monrace_id();
-        if (real_monrace.r_sights < MAX_SHORT) {
-            real_monrace.r_sights++;
-        }
+        monrace_records.increment_seen_count(monrace_id);
     }
 
     if (monster.mflag2.has(MonsterConstantFlagType::CLONED)) {

--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -8,6 +8,7 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "timed-effect/timed-effects.h"
@@ -138,9 +139,8 @@ static std::string get_describing_monster_name(const MonsterEntity &monster, con
         }
     }
 
-    const auto &monraces = MonraceList::get_instance();
-    const auto ids = monraces.search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
-    return monraces.get_monrace(rand_choice(ids)).name.string();
+    const auto ids = MonraceService::search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
+    return MonraceList::get_instance().get_monrace(rand_choice(ids)).name.string();
 }
 
 #ifdef JP

--- a/src/monster/monster-status.cpp
+++ b/src/monster/monster-status.cpp
@@ -17,6 +17,7 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
@@ -424,7 +425,7 @@ void monster_gain_exp(PlayerType *player_ptr, MONSTER_IDX m_idx, MonraceId monra
         const auto is_hallucinated = player_ptr->effects()->hallucination().is_hallucinated();
         if (!ignore_unview || player_can_see_bold(player_ptr, monster.fy, monster.fx)) {
             if (is_hallucinated) {
-                const auto ids = monraces.search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
+                const auto ids = MonraceService::search([](const auto &monrace) { return monrace.kind_flags.has_not(MonsterKindType::UNIQUE); });
                 const auto &monrace_hallucinated = monraces.get_monrace(rand_choice(ids));
                 auto mes_evolution = _("%sは%sに進化した。", "%s^ evolved into %s.");
                 auto mes_degeneration = _("%sは%sに退化した。", "%s^ degenerated into %s.");

--- a/src/monster/monster-update.cpp
+++ b/src/monster/monster-update.cpp
@@ -34,6 +34,7 @@
 #include "system/grid-type-definition.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
@@ -495,12 +496,10 @@ static void update_invisible_monster(PlayerType *player_ptr, um_type *um_ptr, MO
     }
 
     if (!player_ptr->effects()->hallucination().is_hallucinated()) {
-        auto &monrace = monster.get_monrace();
-        auto &shadower = MonraceList::get_instance().get_monrace(MonraceId::KAGE);
-        if ((monster.ap_r_idx == MonraceId::KAGE) && (shadower.r_sights < MAX_SHORT)) {
-            shadower.r_sights++;
-        } else if (monster.is_original_ap() && (monrace.r_sights < MAX_SHORT)) {
-            monrace.r_sights++;
+        if (monster.ap_r_idx == MonraceId::KAGE) {
+            MonraceRecords::get_instance().increment_seen_count(MonraceId::KAGE);
+        } else if (monster.is_original_ap()) {
+            monster.increment_seen_count();
         }
     }
 

--- a/src/save/lore-writer.cpp
+++ b/src/save/lore-writer.cpp
@@ -3,6 +3,7 @@
 #include "save/save-util.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "util/bit-flags-calculator.h"
 
 /*!
@@ -12,7 +13,8 @@
 void wr_lore(MonraceId monrace_id)
 {
     const auto &monrace = MonraceList::get_instance().get_monrace(monrace_id);
-    wr_s16b(static_cast<short>(monrace.r_sights));
+    const auto &monrace_records = MonraceRecords::get_instance();
+    wr_s16b(monrace_records.get_seen_count(monrace_id));
     wr_s16b(static_cast<short>(monrace.r_deaths));
     wr_s16b(static_cast<short>(monrace.r_pkills));
     wr_s16b(static_cast<short>(monrace.r_akills));

--- a/src/store/rumor.cpp
+++ b/src/store/rumor.cpp
@@ -18,6 +18,7 @@
 #include "system/floor/town-records.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/player-type-definition.h"
 #include "util/string-processor.h"
 #include "view/display-messages.h"
@@ -170,9 +171,9 @@ public:
         auto &monraces = MonraceList::get_instance();
         auto &monrace = monraces.get_monrace(monster_rumor.monrace_id);
         this->print_rumor(monrace.name);
-
-        if (monrace.r_sights == 0) {
-            monrace.r_sights = 1;
+        auto &monrace_records = MonraceRecords::get_instance();
+        if (!monrace_records.has_been_seen(monster_rumor.monrace_id)) {
+            monrace_records.increment_seen_count(monster_rumor.monrace_id);
         }
     }
 

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -1,5 +1,4 @@
 #include "system/monrace/monrace-definition.h"
-#include "game-option/cheat-options.h"
 #include "monster-attack/monster-attack-table.h"
 #include "monster-race/race-ability-mask.h"
 #include "monster-race/race-resistance-mask.h"
@@ -839,15 +838,11 @@ bool MonraceDefinition::has_entity() const
  * @brief モンスターリストを走査し、生きているか死んでいるユニークだけを抽出する
  * @param is_alive 生きているユニークのリストならばTRUE、撃破したユニークのリストならばFALSE
  * @return is_aliveの条件に見合うユニークがいたらTRUE、それ以外はFALSE
- * @details 闘技場のモンスターとは再戦できないので、生きているなら表示から外す
+ * @details 闘技場のモンスターとは再戦できないので、生きているなら表示から外す.
  */
 bool MonraceDefinition::should_display(bool is_alive) const
 {
     if (this->kind_flags.has_not(MonsterKindType::UNIQUE)) {
-        return false;
-    }
-
-    if (!cheat_know && !this->r_sights) {
         return false;
     }
 

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -128,7 +128,6 @@ public:
     MONSTER_NUMBER max_num{}; //!< 階に最大存在できる数 / Maximum population allowed per level
     MONSTER_NUMBER cur_num{}; //!< 階に現在いる数 / Monster population on current level
     FLOOR_IDX floor_id{}; //!< 存在している保存階ID /  Location of unique monster
-    MONSTER_NUMBER r_sights{}; //!< 見えている数 / Count sightings of this monster
     MONSTER_NUMBER r_deaths{}; //!< このモンスターに殺された人数 / Count deaths from this monster
     MONSTER_NUMBER r_pkills{}; //!< このゲームで倒すのを見た数 / Count visible monsters killed in this life
     MONSTER_NUMBER r_akills{}; //!< このゲームで倒した数 / Count all monsters killed in this life

--- a/src/system/monrace/monrace-list.cpp
+++ b/src/system/monrace/monrace-list.cpp
@@ -10,7 +10,6 @@
 #include "system/redrawing-flags-updater.h"
 #include "tracking/lore-tracker.h"
 #include "util/probability-table.h"
-#include "util/string-processor.h"
 #include <algorithm>
 
 namespace {
@@ -43,7 +42,7 @@ const std::set<MonraceId> CHAPEL_RACES = {
     MonraceId::TOPAZ_MONK,
 };
 
-//!< @details 「Aシンボルだが天使ではない」モンスターのリスト.
+//! 「Aシンボルだが天使ではない」モンスターのリスト.
 const std::set<MonraceId> NON_ANGEL_RACES = {
     MonraceId::A_GOLD,
     MonraceId::A_SILVER,
@@ -145,77 +144,6 @@ const std::vector<MonraceId> &MonraceList::get_valid_monrace_ids() const
 
     std::transform(++this->monraces.begin(), this->monraces.end(), std::back_inserter(valid_monraces), [](auto &x) { return x.first; });
     return valid_monraces;
-}
-
-/*!
- * @brief モンスターを引数で与えたフィルタ関数で検索する
- *
- * @param filter このフィルタ関数がtrueを返すモンスターを検索する
- * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
- * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
- */
-std::vector<MonraceId> MonraceList::search(std::function<bool(const MonraceDefinition &)> filter, bool is_known_only) const
-{
-    std::vector<MonraceId> result_ids;
-
-    for (const auto &[id, monrace] : this->monraces) {
-        if (!monrace->is_valid()) {
-            continue;
-        }
-
-        if (is_known_only && (monrace->r_sights == 0)) {
-            continue;
-        }
-
-        if (filter(*monrace)) {
-            result_ids.push_back(id);
-        }
-    }
-
-    return result_ids;
-}
-
-/*!
- * @brief モンスターを名前で検索する
- *
- * 引数で与えた名前を含む(部分一致)モンスターを検索する。
- *
- * @param name 検索するモンスターの名前
- * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
- * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
- */
-std::vector<MonraceId> MonraceList::search_by_name(std::string_view name, bool is_known_only) const
-{
-    std::vector<MonraceId> result_ids;
-    const auto lowered_search_name = str_tolower(name);
-
-    auto filter = [&](const MonraceDefinition &monrace) {
-        const auto lowered_en_name = str_tolower(monrace.name.en_string());
-
-#ifdef JP
-        return str_find(lowered_en_name, lowered_search_name) || str_find(monrace.name.string(), lowered_search_name);
-#else
-        return str_find(lowered_en_name, lowered_search_name);
-#endif
-    };
-
-    return this->search(std::move(filter), is_known_only);
-}
-
-/*!
- * @brief モンスターのシンボルで検索する
- *
- * @param symbol 検索するモンスターのシンボル
- * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
- * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
- */
-std::vector<MonraceId> MonraceList::search_by_symbol(char symbol, bool is_known_only) const
-{
-    auto filter = [&](const MonraceDefinition &monrace) {
-        return monrace.symbol_char_is_any_of(std::string(1, symbol));
-    };
-
-    return this->search(std::move(filter), is_known_only);
 }
 
 bool MonraceList::is_angel(MonraceId monrace_id) const

--- a/src/system/monrace/monrace-list.h
+++ b/src/system/monrace/monrace-list.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "util/abstract-map-wrapper.h"
-#include <functional>
 #include <map>
 #include <memory>
 #include <set>
@@ -38,9 +37,6 @@ public:
     std::shared_ptr<MonraceDefinition> get_monrace_shared(MonraceId monrace_id);
     std::shared_ptr<const MonraceDefinition> get_monrace_shared(MonraceId monrace_id) const;
     const std::vector<MonraceId> &get_valid_monrace_ids() const;
-    std::vector<MonraceId> search(std::function<bool(const MonraceDefinition &)> filter, bool is_known_only = false) const;
-    std::vector<MonraceId> search_by_name(std::string_view name, bool is_known_only = false) const;
-    std::vector<MonraceId> search_by_symbol(char symbol, bool is_known_only) const;
     bool is_angel(MonraceId monrace_id) const;
     bool can_unify_separate(MonraceId monrace_id) const;
     void kill_unified_unique(MonraceId monrace_id);

--- a/src/system/monrace/monrace-record.cpp
+++ b/src/system/monrace/monrace-record.cpp
@@ -1,0 +1,29 @@
+#include "system/monrace/monrace-record.h"
+#include <limits>
+
+void MonraceRecord::reset_all()
+{
+    this->seen_count = 0;
+}
+
+bool MonraceRecord::has_been_seen() const
+{
+    return this->seen_count > 0;
+}
+
+void MonraceRecord::increment_seen_count()
+{
+    if (this->seen_count < std::numeric_limits<short>::max()) {
+        this->seen_count++;
+    }
+}
+
+short MonraceRecord::get_seen_count() const
+{
+    return this->seen_count;
+}
+
+void MonraceRecord::set_seen_count(short count)
+{
+    this->seen_count = count;
+}

--- a/src/system/monrace/monrace-record.h
+++ b/src/system/monrace/monrace-record.h
@@ -1,0 +1,27 @@
+#pragma once
+
+/*!
+ * @brief モンスター種族に関するプレイ中の動的な記録を管理するクラス
+ * @author Hourier
+ * @date 2026/05/26
+ */
+
+class MonraceRecord {
+public:
+    MonraceRecord() = default;
+    MonraceRecord(const MonraceRecord &other) = delete;
+    MonraceRecord(MonraceRecord &&other) noexcept = delete;
+    MonraceRecord &operator=(const MonraceRecord &other) = delete;
+    MonraceRecord &operator=(MonraceRecord &&other) noexcept = delete;
+    ~MonraceRecord() = default;
+
+    void reset_all();
+
+    bool has_been_seen() const;
+    void increment_seen_count();
+    short get_seen_count() const; //!< セーブ用.
+    void set_seen_count(short count); //!< ロード用.
+
+private:
+    short seen_count = 0; //!< これまでにプレイヤーが目撃した数.
+};

--- a/src/system/monrace/monrace-records.cpp
+++ b/src/system/monrace/monrace-records.cpp
@@ -1,5 +1,8 @@
 #include "system/monrace/monrace-records.h"
+#include "system/angband-exceptions.h"
 #include "system/monrace/monrace-record.h"
+#include "util/enum-converter.h"
+#include <fmt/format.h>
 
 MonraceRecords MonraceRecords::instance{};
 
@@ -31,11 +34,13 @@ MonraceRecords &MonraceRecords::get_instance()
 
 std::shared_ptr<const MonraceRecord> MonraceRecords::get_record(MonraceId monrace_id) const
 {
+    this->check_monrace_id(monrace_id);
     return this->records.at(monrace_id);
 }
 
 bool MonraceRecords::has_been_seen(MonraceId monrace_id) const
 {
+    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return false;
     }
@@ -45,6 +50,7 @@ bool MonraceRecords::has_been_seen(MonraceId monrace_id) const
 
 void MonraceRecords::increment_seen_count(MonraceId monrace_id)
 {
+    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return;
     }
@@ -54,6 +60,7 @@ void MonraceRecords::increment_seen_count(MonraceId monrace_id)
 
 short MonraceRecords::get_seen_count(MonraceId monrace_id) const
 {
+    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return 0;
     }
@@ -63,9 +70,17 @@ short MonraceRecords::get_seen_count(MonraceId monrace_id) const
 
 void MonraceRecords::set_seen_count(MonraceId monrace_id, short count)
 {
+    this->check_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return;
     }
 
     this->records.at(monrace_id)->set_seen_count(count);
+}
+
+void MonraceRecords::check_monrace_id(MonraceId monrace_id) const
+{
+    if ((monrace_id < MonraceId::PLAYER) || (enum2i(monrace_id) >= static_cast<short>(this->records.size()))) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid monrace_id: {}", enum2i(monrace_id)));
+    }
 }

--- a/src/system/monrace/monrace-records.cpp
+++ b/src/system/monrace/monrace-records.cpp
@@ -1,0 +1,55 @@
+#include "system/monrace/monrace-records.h"
+#include "system/monrace/monrace-record.h"
+
+MonraceRecords MonraceRecords::instance{};
+
+/*!
+ * @brief レコードのmapを初期化する
+ *
+ * 起動時に一度だけ実行されるが、ドメイン仕様とは無関係に初期化処理は冪等性を担保すべきである.
+ * そのため、呼ばれる度に全てをリセットする設計とする.
+ */
+void MonraceRecords::initialize(size_t size)
+{
+    if (!this->records.empty()) {
+        for (auto &[_, record] : this->records) {
+            record->reset_all();
+        }
+
+        return;
+    }
+
+    for (size_t i = 0; i < size; i++) {
+        this->records.emplace(static_cast<MonraceId>(i), std::make_shared<MonraceRecord>());
+    }
+}
+
+MonraceRecords &MonraceRecords::get_instance()
+{
+    return instance;
+}
+
+std::shared_ptr<const MonraceRecord> MonraceRecords::get_record(MonraceId monrace_id) const
+{
+    return this->records.at(monrace_id);
+}
+
+bool MonraceRecords::has_been_seen(MonraceId monrace_id) const
+{
+    return this->records.at(monrace_id)->has_been_seen();
+}
+
+void MonraceRecords::increment_seen_count(MonraceId monrace_id)
+{
+    this->records.at(monrace_id)->increment_seen_count();
+}
+
+short MonraceRecords::get_seen_count(MonraceId monrace_id) const
+{
+    return this->records.at(monrace_id)->get_seen_count();
+}
+
+void MonraceRecords::set_seen_count(MonraceId monrace_id, short count)
+{
+    this->records.at(monrace_id)->set_seen_count(count);
+}

--- a/src/system/monrace/monrace-records.cpp
+++ b/src/system/monrace/monrace-records.cpp
@@ -36,20 +36,36 @@ std::shared_ptr<const MonraceRecord> MonraceRecords::get_record(MonraceId monrac
 
 bool MonraceRecords::has_been_seen(MonraceId monrace_id) const
 {
+    if (monrace_id == MonraceId::PLAYER) {
+        return false;
+    }
+
     return this->records.at(monrace_id)->has_been_seen();
 }
 
 void MonraceRecords::increment_seen_count(MonraceId monrace_id)
 {
+    if (monrace_id == MonraceId::PLAYER) {
+        return;
+    }
+
     this->records.at(monrace_id)->increment_seen_count();
 }
 
 short MonraceRecords::get_seen_count(MonraceId monrace_id) const
 {
+    if (monrace_id == MonraceId::PLAYER) {
+        return 0;
+    }
+
     return this->records.at(monrace_id)->get_seen_count();
 }
 
 void MonraceRecords::set_seen_count(MonraceId monrace_id, short count)
 {
+    if (monrace_id == MonraceId::PLAYER) {
+        return;
+    }
+
     this->records.at(monrace_id)->set_seen_count(count);
 }

--- a/src/system/monrace/monrace-records.h
+++ b/src/system/monrace/monrace-records.h
@@ -31,10 +31,12 @@ private:
     MonraceRecords() = default;
 
     static MonraceRecords instance;
-    std::map<MonraceId, std::shared_ptr<MonraceRecord>> records;
 
+    std::map<MonraceId, std::shared_ptr<MonraceRecord>> records;
     std::map<MonraceId, std::shared_ptr<MonraceRecord>> &get_inner_container() override
     {
         return this->records;
     }
+
+    void check_monrace_id(MonraceId monrace_id) const;
 };

--- a/src/system/monrace/monrace-records.h
+++ b/src/system/monrace/monrace-records.h
@@ -1,0 +1,40 @@
+#pragma once
+
+/*!
+ * @brief モンスター種族に関するプレイ中の動的な記録を集合論的に取り扱うクラス
+ * @author Hourier
+ * @date 2026/05/26
+ */
+
+#include "system/enums/monrace/monrace-id.h"
+#include "util/abstract-map-wrapper.h"
+#include <memory>
+
+class MonraceRecord;
+class MonraceRecords : public util::AbstractMapWrapper<MonraceId, std::shared_ptr<MonraceRecord>> {
+public:
+    MonraceRecords(MonraceRecords &&) = delete;
+    MonraceRecords(const MonraceRecords &) = delete;
+    MonraceRecords &operator=(const MonraceRecords &) = delete;
+    MonraceRecords &operator=(MonraceRecords &&) = delete;
+    static MonraceRecords &get_instance();
+
+    void initialize(size_t size);
+    std::shared_ptr<const MonraceRecord> get_record(MonraceId monrace_id) const;
+
+    bool has_been_seen(MonraceId monrace_id) const;
+    void increment_seen_count(MonraceId monrace_id);
+    short get_seen_count(MonraceId monrace_id) const; //!< セーブ用.
+    void set_seen_count(MonraceId monrace_id, short count); //!< ロード用.
+
+private:
+    MonraceRecords() = default;
+
+    static MonraceRecords instance;
+    std::map<MonraceId, std::shared_ptr<MonraceRecord>> records;
+
+    std::map<MonraceId, std::shared_ptr<MonraceRecord>> &get_inner_container() override
+    {
+        return this->records;
+    }
+};

--- a/src/system/monrace/monrace-service.cpp
+++ b/src/system/monrace/monrace-service.cpp
@@ -2,6 +2,7 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "util/string-processor.h"
 
 /*!
@@ -14,12 +15,13 @@
 std::vector<MonraceId> MonraceService::search(const std::function<bool(const MonraceDefinition &)> &filter, bool is_known_only)
 {
     std::vector<MonraceId> result_ids;
+    const auto &records = MonraceRecords::get_instance();
     for (const auto &[id, monrace] : MonraceList::get_instance()) {
         if (!monrace->is_valid()) {
             continue;
         }
 
-        if (is_known_only && (monrace->r_sights == 0)) {
+        if (is_known_only && !records.has_been_seen(id)) {
             continue;
         }
 

--- a/src/system/monrace/monrace-service.cpp
+++ b/src/system/monrace/monrace-service.cpp
@@ -1,0 +1,75 @@
+#include "system/monrace/monrace-service.h"
+#include "system/enums/monrace/monrace-id.h"
+#include "system/monrace/monrace-definition.h"
+#include "system/monrace/monrace-list.h"
+#include "util/string-processor.h"
+
+/*!
+ * @brief モンスターを引数で与えたフィルタ関数で検索する
+ *
+ * @param filter このフィルタ関数がtrueを返すモンスターを検索する
+ * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
+ * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
+ */
+std::vector<MonraceId> MonraceService::search(const std::function<bool(const MonraceDefinition &)> &filter, bool is_known_only)
+{
+    std::vector<MonraceId> result_ids;
+    for (const auto &[id, monrace] : MonraceList::get_instance()) {
+        if (!monrace->is_valid()) {
+            continue;
+        }
+
+        if (is_known_only && (monrace->r_sights == 0)) {
+            continue;
+        }
+
+        if (filter(*monrace)) {
+            result_ids.push_back(id);
+        }
+    }
+
+    return result_ids;
+}
+
+/*!
+ * @brief モンスターを名前で検索する
+ *
+ * 引数で与えた名前を含む(部分一致)モンスターを検索する。
+ *
+ * @param name 検索するモンスターの名前
+ * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
+ * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
+ */
+std::vector<MonraceId> MonraceService::search_by_name(std::string_view name, bool is_known_only)
+{
+    std::vector<MonraceId> result_ids;
+    const auto lowered_search_name = str_tolower(name);
+
+    auto filter = [&](const MonraceDefinition &monrace) {
+        const auto lowered_en_name = str_tolower(monrace.name.en_string());
+
+#ifdef JP
+        return str_find(lowered_en_name, lowered_search_name) || str_find(monrace.name.string(), lowered_search_name);
+#else
+        return str_find(lowered_en_name, lowered_search_name);
+#endif
+    };
+
+    return search(std::move(filter), is_known_only);
+}
+
+/*!
+ * @brief モンスターのシンボルで検索する
+ *
+ * @param symbol 検索するモンスターのシンボル
+ * @param is_known_only trueならばプレイヤーが既知のモンスターのみを対象とする。falseならば全てのモンスターを対象とする。
+ * @return std::vector<MonraceId> 検索結果のモンスター種族IDリスト
+ */
+std::vector<MonraceId> MonraceService::search_by_symbol(char symbol, bool is_known_only)
+{
+    auto filter = [&](const MonraceDefinition &monrace) {
+        return monrace.symbol_char_is_any_of(std::string(1, symbol));
+    };
+
+    return search(std::move(filter), is_known_only);
+}

--- a/src/system/monrace/monrace-service.h
+++ b/src/system/monrace/monrace-service.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/*!
+ * @brief モンスター種族定義とプレイ中の記録を組み合わせて、モンスター種族に関する動的な情報を提供するサービスクラス
+ * @author Hourier
+ * @date 2026/05/26
+ */
+
+#include <functional>
+#include <string_view>
+#include <vector>
+
+enum class MonraceId : short;
+class MonraceDefinition;
+class MonraceService {
+public:
+    MonraceService() = delete;
+
+    static std::vector<MonraceId> search(const std::function<bool(const MonraceDefinition &)> &filter, bool is_known_only = false);
+    static std::vector<MonraceId> search_by_name(std::string_view name, bool is_known_only = false);
+    static std::vector<MonraceId> search_by_symbol(char symbol, bool is_known_only);
+};

--- a/src/system/monster-entity.cpp
+++ b/src/system/monster-entity.cpp
@@ -8,6 +8,7 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-records.h"
 #include "system/redrawing-flags-updater.h"
 #include "term/term-color-types.h"
 #include "tracking/lore-tracker.h"
@@ -575,6 +576,11 @@ void MonsterEntity::reset_target()
 void MonsterEntity::set_friendly()
 {
     this->mflag2.set(MonsterConstantFlagType::FRIENDLY);
+}
+
+void MonsterEntity::increment_seen_count() const
+{
+    MonraceRecords::get_instance().increment_seen_count(this->r_idx);
 }
 
 bool MonsterEntity::is_riding() const

--- a/src/system/monster-entity.h
+++ b/src/system/monster-entity.h
@@ -128,6 +128,7 @@ public:
     void set_target(const Pos2D &pos);
     void reset_target();
     void set_friendly();
+    void increment_seen_count() const;
 
 private:
     MonsterEntity(const MonsterEntity &) = default;

--- a/src/view/display-lore.cpp
+++ b/src/view/display-lore.cpp
@@ -17,6 +17,7 @@
 #include "system/enums/monrace/monrace-id.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-record.h"
 #include "system/player-type-definition.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
@@ -703,7 +704,7 @@ void display_monster_sometimes(lore_type *lore_ptr)
 void display_monster_guardian(lore_type *lore_ptr)
 {
     bool is_kingpin = lore_ptr->misc_flags.has(MonsterMiscType::QUESTOR);
-    is_kingpin &= lore_ptr->monrace->r_sights > 0;
+    is_kingpin &= lore_ptr->record->has_been_seen();
     is_kingpin &= lore_ptr->monrace->max_num > 0;
     is_kingpin &= (lore_ptr->monrace_id == MonraceId::OBERON) || (lore_ptr->monrace_id == MonraceId::SERPENT);
     if (is_kingpin) {

--- a/src/wizard/wizard-spells.cpp
+++ b/src/wizard/wizard-spells.cpp
@@ -34,6 +34,7 @@
 #include "system/floor/floor-info.h"
 #include "system/monrace/monrace-definition.h"
 #include "system/monrace/monrace-list.h"
+#include "system/monrace/monrace-service.h"
 #include "system/monster-entity.h"
 #include "system/player-type-definition.h"
 #include "target/grid-selector.h"
@@ -61,18 +62,16 @@ const std::vector<debug_spell_command> debug_spell_commands_list = {
 
 std::vector<MonraceId> wiz_collect_monster_candidates(char symbol)
 {
-    const auto &monraces = MonraceList::get_instance();
-
-    if (symbol == KTRL('M')) {
-        const auto monster_name = input_string("Monster name: ", MAX_MONSTER_NAME);
-        if (!monster_name || monster_name->empty()) {
-            return {};
-        }
-
-        return monraces.search_by_name(*monster_name, false);
+    if (symbol != KTRL('M')) {
+        return MonraceService::search_by_symbol(symbol, false);
     }
 
-    return monraces.search_by_symbol(symbol, false);
+    const auto monster_name = input_string("Monster name: ", MAX_MONSTER_NAME);
+    if (!monster_name || monster_name->empty()) {
+        return {};
+    }
+
+    return MonraceService::search_by_name(*monster_name, false);
 }
 
 tl::optional<MonraceId> wiz_select_summon_monrace_id()


### PR DESCRIPTION
/gemini review

日本語でレビューして
MonraceRecordの特殊コンストラクタをdeleteしているのは想定通りの設計です
コピーまたはムーブされるとシステム全体で整合性が取れません