### PR TITLE
[Feature] 最大フロア生成オプションを追加

### DIFF
--- a/lib/pref/pref-opt.prf
+++ b/lib/pref/pref-opt.prf
@@ -81,7 +81,9 @@ Y:stack_force_notes
 X:stack_force_costs
 Y:expand_list
 Y:allow_smallest_floor
+Y:allow_largest_floor
 X:always_small_floor
+X:always_large_floor
 Y:allow_arena_floor
 Y:bound_walls_perm
 Y:last_words

--- a/src/game-option/game-play-options.cpp
+++ b/src/game-option/game-play-options.cpp
@@ -5,6 +5,8 @@ bool stack_force_costs;
 bool expand_list;
 bool allow_smallest_floor;
 bool always_small_floor;
+bool allow_largest_floor;
+bool always_large_floor;
 bool allow_arena_floor;
 bool bound_walls_perm;
 bool last_words;

--- a/src/game-option/game-play-options.h
+++ b/src/game-option/game-play-options.h
@@ -7,6 +7,8 @@ extern bool stack_force_costs; /* Merge discounts when stacking */
 extern bool expand_list; /* Expand the power of the list commands */
 extern bool allow_smallest_floor; //!< 最小面積(金鉱/迷宮と同じ)のフロアを他ダンジョンでも生成可能にする.
 extern bool always_small_floor; //!< 常に小さいフロアを生成する(金鉱4ブロック分以下のフロア生成しか許可しない。但しLARGE/LARGESTフラグがついていれば対象外).
+extern bool allow_largest_floor; //!< 最大面積のフロアを他ダンジョンでも生成可能にする.
+extern bool always_large_floor; //!< 常に大きいフロアを生成する(4ブロック分以上のフロア生成しか許可しない。但しSMALL/SMALLESTフラグがついていれば対象外).
 extern bool allow_arena_floor; //!< 空っぽの「アリーナ」レベルの生成を可能にする.
 extern bool bound_walls_perm; /* Boundary walls become 'permanent wall' */
 extern bool last_words; /* Leave last words when your character dies */

--- a/src/game-option/option-types-table.cpp
+++ b/src/game-option/option-types-table.cpp
@@ -192,8 +192,13 @@ const std::vector<GameOption> option_info = validate_option_info({
 
     { &allow_smallest_floor, true, GameOptionType::ALLOW_SMALLEST_FLOOR, "allow_smallest_floor", _("非常に小さいフロアの生成を可能にする", "Allow unusually smallest floor"), GameOptionPage::GAMEPLAY },
 
+    { &allow_largest_floor, true, GameOptionType::ALLOW_LARGEST_FLOOR, "allow_largest_floor", _("非常に大きいフロアの生成を可能にする", "Allow unusually largest floor"), GameOptionPage::GAMEPLAY },
+
     { &always_small_floor, false, GameOptionType::ALWAYS_SMALL_FLOOR, "always_small_floor",
-        _("常に小さいフロアを生成する", "Always create unusually small dungeon floor"), GameOptionPage::GAMEPLAY },
+        _("常に小さめのフロアを生成する", "Always create unusually small dungeon floor"), GameOptionPage::GAMEPLAY },
+
+    { &always_large_floor, false, GameOptionType::ALWAYS_LARGE_FLOOR, "always_large_floor",
+        _("常に大きめのフロアを生成する", "Always create unusually large dungeon floor"), GameOptionPage::GAMEPLAY },
 
     { &allow_arena_floor, true, GameOptionType::ALLOW_ARENA_FLOOR, "allow_arena_floor", _("空っぽの「アリーナ」フロアの生成を可能にする", "Allow empty 'arena' floor"), GameOptionPage::GAMEPLAY },
 

--- a/src/game-option/option-types-table.h
+++ b/src/game-option/option-types-table.h
@@ -75,9 +75,9 @@ enum class GameOptionType : int {
 
     SHOW_ITEM_GRAPH = 64,
     BOUND_WALLS_PERM = 65,
-    // 66
+    ALLOW_LARGEST_FLOOR = 66,
     ALWAYS_SMALL_FLOOR = 67,
-    // 68
+    ALWAYS_LARGE_FLOOR = 68,
     TARGET_PET = 69,
     AUTO_MORE = 70,
     COMMAND_MENU = 71,

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -197,12 +197,16 @@ static void dump_aux_options(FILE *fff)
 
     if (ironman_smallest_floor) {
         fmt::print(fff, _("\n (鉄人)最小フロア:   ON", "\n Ironman Smallest Floor:  ON"));
-    } else if (always_small_floor) {
-        fmt::print(fff, _("\n 常に小さめフロア:   ON", "\n Always Small Floor:      ON"));
-    } else if (allow_smallest_floor) {
-        fmt::print(fff, _("\n 最小フロア許可  :   ON", "\n Possible Small Floor:    ON"));
+        fmt::print(fff, _("\n 常に小さめフロア:   IGNORED", "\n Always Small Floor:      IGNORED"));
+        fmt::print(fff, _("\n 常に大きめフロア:   IGNORED", "\n Always Large Floor:      IGNORED"));
+        fmt::print(fff, _("\n 最小フロア許可  :   IGNORED", "\n Possible Smallest Floor: IGNORED"));
+        fmt::print(fff, _("\n 最大フロア許可  :   IGNORED", "\n Possible Largest Floor:  IGNORED"));
     } else {
-        fmt::print(fff, _("\n 小さいフロア:       OFF", "\n Small Floor:             OFF"));
+        const auto always_large_floor_is_effective = always_large_floor && !always_small_floor;
+        fmt::print(fff, _("\n 常に小さめフロア:   {}", "\n Always Small Floor:      {}"), always_small_floor ? "ON" : "OFF");
+        fmt::print(fff, _("\n 常に大きめフロア:   {}", "\n Always Large Floor:      {}"), always_small_floor ? "IGNORED" : (always_large_floor ? "ON" : "OFF"));
+        fmt::print(fff, _("\n 最小フロア許可  :   {}", "\n Possible Smallest Floor: {}"), always_large_floor_is_effective ? "IGNORED" : (allow_smallest_floor ? "ON" : "OFF"));
+        fmt::print(fff, _("\n 最大フロア許可  :   {}", "\n Possible Largest Floor:  {}"), always_small_floor ? "IGNORED" : (allow_largest_floor ? "ON" : "OFF"));
     }
 
     if (vanilla_town) {

--- a/src/system/floor/floor-info.cpp
+++ b/src/system/floor/floor-info.cpp
@@ -1112,10 +1112,11 @@ tl::optional<std::pair<int, int>> FloorType::select_floor_size_small_option()
     }
 
     const auto min_area = allow_smallest_floor ? MIN_AREA_BLOCKS : MIN_AREA_BLOCKS * 2;
+    const auto max_area = MEDIUM_AREA_BLOCKS;
     const auto size = dungeon_blocks.size() - 1; // 効率上げのため、最大サイズのフロアを最初から除外する.
     auto is_retried_always_small = true;
     while (true) {
-        const auto selection = pick_block_size(size);
+        const auto selection = pick_block_size(size, min_area, max_area);
         const auto area = calc_blocks(selection);
         if (area > MEDIUM_AREA_BLOCKS) {
             continue;
@@ -1138,13 +1139,17 @@ tl::optional<std::pair<int, int>> FloorType::select_floor_size_small_option()
  */
 std::pair<int, int> FloorType::select_floor_size_large()
 {
-    constexpr auto max_blocks_num = dungeon_blocks.size() - 1;
-    while (true) {
-        const auto selection = dungeon_blocks.at(randint1(max_blocks_num));
-        if (calc_blocks(selection) >= MEDIUM_AREA_BLOCKS) {
-            return selection;
-        }
+    const auto max_area = allow_largest_floor ? MAX_AREA_BLOCKS : MAX_AREA_BLOCKS - 1;
+    return pick_block_size(dungeon_blocks.size(), MEDIUM_AREA_BLOCKS, max_area);
+}
+
+tl::optional<std::pair<int, int>> FloorType::select_floor_size_large_option()
+{
+    if (!always_large_floor) {
+        return tl::nullopt;
     }
+
+    return select_floor_size_large();
 }
 
 /*!
@@ -1155,10 +1160,11 @@ std::pair<int, int> FloorType::select_floor_size_large()
 std::pair<int, int> FloorType::select_floor_size_normal()
 {
     const auto min_area = allow_smallest_floor ? MIN_AREA_BLOCKS : MIN_AREA_BLOCKS * 2;
+    const auto max_area = allow_largest_floor ? MAX_AREA_BLOCKS : MAX_AREA_BLOCKS - 1;
     const auto size = dungeon_blocks.size();
     auto is_retried = true;
     while (true) {
-        const auto selection = pick_block_size(size);
+        const auto selection = pick_block_size(size, min_area, max_area);
         const auto area = calc_blocks(selection);
         if (is_retried && ((area == min_area) || (area == MAX_AREA_BLOCKS))) {
             is_retried = false;
@@ -1169,13 +1175,13 @@ std::pair<int, int> FloorType::select_floor_size_normal()
     }
 }
 
-std::pair<int, int> FloorType::pick_block_size(size_t size)
+std::pair<int, int> FloorType::pick_block_size(size_t size, int min_area, int max_area)
 {
-    const auto min_size = allow_smallest_floor ? MIN_AREA_BLOCKS : MIN_AREA_BLOCKS * 2;
     while (true) {
         const auto block_num = randnum0<size_t>(size);
         const auto selection = dungeon_blocks.at(block_num);
-        if (calc_blocks(selection) >= min_size) {
+        const auto area = calc_blocks(selection);
+        if ((area >= min_area) && (area <= max_area)) {
             return selection;
         }
     }
@@ -1206,7 +1212,7 @@ tl::optional<std::pair<int, int>> FloorType::try_select_largest_floor() const
     }
 
     constexpr auto chance_small_floor = 3;
-    auto is_largest = !always_small_floor;
+    auto is_largest = allow_largest_floor && !always_small_floor;
     is_largest &= dungeon.flags.has_none_of({ DungeonFeatureType::SMALLEST, DungeonFeatureType::SMALL });
     is_largest &= one_in_(chance_small_floor);
     if (is_largest) {
@@ -1230,7 +1236,7 @@ tl::optional<std::pair<int, int>> FloorType::try_select_smallest_floor() const
     }
 
     constexpr auto chance_large_floor = 3;
-    auto is_smallest = allow_smallest_floor;
+    auto is_smallest = allow_smallest_floor && !always_large_floor;
     is_smallest &= dungeon.flags.has_none_of({ DungeonFeatureType::LARGEST, DungeonFeatureType::LARGE });
     is_smallest &= one_in_(chance_large_floor);
     if (is_smallest) {
@@ -1270,6 +1276,10 @@ std::pair<int, int> FloorType::select_floor_size() const
     }
 
     if (const auto selection = select_floor_size_small_option(); selection) {
+        return *selection;
+    }
+
+    if (const auto selection = select_floor_size_large_option(); selection) {
         return *selection;
     }
 

--- a/src/system/floor/floor-info.h
+++ b/src/system/floor/floor-info.h
@@ -184,8 +184,9 @@ private:
     static std::pair<int, int> select_floor_size_small();
     static tl::optional<std::pair<int, int>> select_floor_size_small_option();
     static std::pair<int, int> select_floor_size_large();
+    static tl::optional<std::pair<int, int>> select_floor_size_large_option();
     static std::pair<int, int> select_floor_size_normal();
-    static std::pair<int, int> pick_block_size(size_t size);
+    static std::pair<int, int> pick_block_size(size_t size, int min_area, int max_area);
     static int calc_blocks(const std::pair<int, int> &block);
 
     void set_note_and_redraw_at(const Pos2D &pos);


### PR DESCRIPTION
allow_smallest_floor / always_small_floor と対になる allow_largest_floor / always_large_floor を追加する。

フロアサイズ選択ではダンジョン固有フラグを優先し、ゲームプレイオプションはその後に適用する。
always_small_floor は always_large_floor より優先する。
allow_smallest_floor と allow_largest_floor は最小/最大サイズを許可するかを制御する。

キャラクターダンプでは上位条件で無効化されたフロアサイズオプションを IGNORED として区別して表示する。