### PR TITLE
[Implement] 固定アーティファクト記録の拡充 その1

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -311,8 +311,10 @@
     <ClCompile Include="..\..\src\info-reader\definition-hash-data.cpp" />
     <ClCompile Include="..\..\src\io\macro-configurations-store.cpp" />
     <ClCompile Include="..\..\src\io\temp-file.cpp" />
+    <ClCompile Include="..\..\src\load\artifact-record-loader.cpp" />
     <ClCompile Include="..\..\src\monster-floor\monster-movement-direction-list.cpp" />
     <ClCompile Include="..\..\src\player-info\bluemage-data.cpp" />
+    <ClCompile Include="..\..\src\save\artifact-record-writer.cpp" />
     <ClCompile Include="..\..\src\system\artifact\artifact-list.cpp" />
     <ClCompile Include="..\..\src\system\artifact\artifact-record.cpp" />
     <ClCompile Include="..\..\src\system\artifact\artifact-service.cpp" />
@@ -1046,9 +1048,11 @@
     <ClInclude Include="..\..\src\external-lib\include-json.h" />
     <ClInclude Include="..\..\src\io\macro-configurations-store.h" />
     <ClInclude Include="..\..\src\io\temp-file.h" />
+    <ClInclude Include="..\..\src\load\artifact-record-loader.h" />
     <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h" />
     <ClInclude Include="..\..\src\system\dungeon\quest-definition.h" />
     <ClInclude Include="..\..\src\system\dungeon\quest-list.h" />
+    <ClInclude Include="..\..\src\save\artifact-record-writer.h" />
     <ClInclude Include="..\..\src\system\enums\store-sale-type.h" />
     <ClInclude Include="..\..\src\system\enums\terrain\building-type.h" />
     <ClInclude Include="..\..\src\system\enums\terrain\pattern-tile-type.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2601,6 +2601,12 @@
     <ClCompile Include="..\..\src\system\dungeon\quest-list.cpp">
       <Filter>system\dungeon</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\save\artifact-record-writer.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\load\artifact-record-loader.cpp">
+      <Filter>load\item</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5639,6 +5645,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\system\dungeon\quest-list.h">
       <Filter>system\dungeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\save\artifact-record-writer.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\load\artifact-record-loader.h">
+      <Filter>load\item</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -672,6 +672,7 @@ hengband_SOURCES = \
 	knowledge/monster-group-table.cpp knowledge/monster-group-table.h \
 	\
 	load/angband-version-comparer.cpp load/angband-version-comparer.h \
+	load/artifact-record-loader.cpp load/artifact-record-loader.h \
 	load/birth-loader.cpp load/birth-loader.h \
 	load/dummy-loader.cpp load/dummy-loader.h \
 	load/dungeon-loader.cpp load/dungeon-loader.h \
@@ -1136,6 +1137,7 @@ hengband_SOURCES = \
 	room/treasure-deployment.cpp room/treasure-deployment.h \
 	room/vault-builder.cpp room/vault-builder.h \
 	\
+	save/artifact-record-writer.cpp save/artifact-record-writer.h \
 	save/floor-writer.cpp save/floor-writer.h \
 	save/info-writer.cpp save/info-writer.h \
 	save/item-writer.cpp save/item-writer.h \

--- a/src/cmd-io/cmd-knowledge.cpp
+++ b/src/cmd-io/cmd-knowledge.cpp
@@ -35,15 +35,16 @@ void do_cmd_knowledge(PlayerType *player_ptr)
         prt(_("現在の知識を確認する", "Display current knowledge"), 3, 0);
         if (p == 0) {
             prt(_("(1) 既知の伝説のアイテム                 の一覧", "(1) Display known artifacts"), 6, 5);
-            prt(_("(2) 既知のアイテム                       の一覧", "(2) Display known objects"), 7, 5);
-            prt(_("(3) 既知の生きているユニーク・モンスター の一覧", "(3) Display remaining uniques"), 8, 5);
-            prt(_("(4) 既知の撃破したユニーク・モンスター   の一覧", "(4) Display defeated uniques"), 9, 5);
-            prt(_("(5) 既知のモンスター                     の一覧", "(5) Display known monster"), 10, 5);
-            prt(_("(6) 倒した敵の数                         の一覧", "(6) Display kill count"), 11, 5);
+            prt(_("(2) 鑑定済の伝説のアイテム               の一覧", "(2) Display identified artifacts"), 7, 5);
+            prt(_("(3) 既知のアイテム                       の一覧", "(3) Display known objects"), 8, 5);
+            prt(_("(4) 既知の生きているユニーク・モンスター の一覧", "(4) Display remaining uniques"), 9, 5);
+            prt(_("(5) 既知の撃破したユニーク・モンスター   の一覧", "(5) Display defeated uniques"), 10, 5);
+            prt(_("(6) 既知のモンスター                     の一覧", "(6) Display known monster"), 11, 5);
+            prt(_("(7) 倒した敵の数                         の一覧", "(7) Display kill count"), 12, 5);
             if (!vanilla_town) {
-                prt(_("(7) 賞金首                               の一覧", "(7) Display wanted monsters"), 12, 5);
+                prt(_("(8) 賞金首                               の一覧", "(8) Display wanted monsters"), 13, 5);
             }
-            prt(_("(8) 現在のペット                         の一覧", "(8) Display current pets"), 13, 5);
+
             prt(_("(9) 我が家のアイテム                     の一覧", "(9) Display home inventory"), 14, 5);
             prt(_("(0) *鑑定*済み装備の耐性                 の一覧", "(0) Display *identified* equip."), 15, 5);
         } else {
@@ -56,7 +57,8 @@ void do_cmd_knowledge(PlayerType *player_ptr)
             prt(_("(g) プレイヤーの徳                       の一覧", "(g) Display virtues"), 12, 5);
             prt(_("(h) 入ったダンジョン                     の一覧", "(h) Display dungeons"), 13, 5);
             prt(_("(i) 実行中のクエスト                     の一覧", "(i) Display current quests"), 14, 5);
-            prt(_("(k) 現在の自動拾い/破壊設定              の一覧", "(k) Display auto pick/destroy"), 15, 5);
+            prt(_("(j) 現在のペット                         の一覧", "(j) Display current pets"), 15, 5);
+            prt(_("(k) 現在の自動拾い/破壊設定              の一覧", "(k) Display auto pick/destroy"), 16, 5);
         }
 
         prt(_("-続く-", "-more-"), 17, 8);
@@ -74,30 +76,30 @@ void do_cmd_knowledge(PlayerType *player_ptr)
             p = 1 - p;
             break;
         case '1': /* Artifacts */
-            do_cmd_knowledge_artifacts(player_ptr);
+            do_cmd_knowledge_artifacts(player_ptr, ArtifactKnowledgeMode::KNOWN);
             break;
-        case '2': /* Objects */
+        case '2': /* Artifacts */
+            do_cmd_knowledge_artifacts(player_ptr, ArtifactKnowledgeMode::IDENTIFIED);
+            break;
+        case '3': /* Objects */
             do_cmd_knowledge_objects(player_ptr, &need_redraw, false, -1);
             break;
-        case '3': /* Uniques */
+        case '4': /* Uniques */
             do_cmd_knowledge_uniques(player_ptr, true);
             break;
-        case '4': /* Uniques */
+        case '5': /* Uniques */
             do_cmd_knowledge_uniques(player_ptr, false);
             break;
-        case '5': /* Monsters */
+        case '6': /* Monsters */
             do_cmd_knowledge_monsters(player_ptr, &need_redraw, false);
             break;
-        case '6': /* Kill count  */
+        case '7': /* Kill count  */
             do_cmd_knowledge_kill_count(player_ptr);
             break;
-        case '7': /* wanted */
+        case '8': /* wanted */
             if (!vanilla_town) {
                 do_cmd_knowledge_bounty(player_ptr->name);
             }
-            break;
-        case '8': /* Pets */
-            do_cmd_knowledge_pets(player_ptr);
             break;
         case '9': /* Home */
             do_cmd_knowledge_home(player_ptr);
@@ -135,6 +137,9 @@ void do_cmd_knowledge(PlayerType *player_ptr)
             break;
         case 'i': /* Quests */
             do_cmd_knowledge_quests(player_ptr);
+            break;
+        case 'j': /* Pets */
+            do_cmd_knowledge_pets(player_ptr);
             break;
         case 'k': /* Autopick */
             do_cmd_knowledge_autopick(player_ptr);

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -10,89 +10,38 @@
 #include "flavor/flavor-describer.h"
 #include "flavor/object-flavor-types.h"
 #include "game-option/special-options.h"
-#include "inventory/inventory-slot-types.h"
 #include "io-dump/dump-util.h"
 #include "io/input-key-acceptor.h"
 #include "io/temp-file.h"
 #include "knowledge/item-group-table.h"
-#include "object/tval-types.h"
 #include "perception/identification.h"
-#include "perception/object-perception.h"
+#include "system/angband-exceptions.h"
 #include "system/artifact/artifact-definition.h"
 #include "system/artifact/artifact-list.h"
 #include "system/artifact/artifact-record.h"
-#include "system/baseitem/baseitem-definition.h"
-#include "system/baseitem/baseitem-list.h"
 #include "system/floor/floor-info.h"
-#include "system/grid-type-definition.h"
 #include "system/item/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
 #include "term/screen-processor.h"
 #include "term/term-color-types.h"
 #include "tracking/baseitem-tracker.h"
-#include "util/angband-files.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <algorithm>
 #include <fmt/format.h>
+#include <memory>
 #include <numeric>
-#include <set>
+#include <string>
 #include <vector>
 
-namespace {
-auto collect_known_fixed_artifacts(PlayerType *player_ptr)
-{
-    const auto &artifacts = ArtifactList::get_instance();
-    const auto comparer = [&artifacts](auto id1, auto id2) { return artifacts.order(id1, id2); };
-    std::set<FixedArtifactId, decltype(comparer)> fa_ids(comparer);
-    for (const auto &[fa_id, record] : ArtifactRecords::get_instance()) {
-        if (!record.get_generated()) {
-            continue;
-        }
-
-        fa_ids.insert(fa_id);
-    }
-
-    const auto &floor = *player_ptr->current_floor_ptr;
-    for (const auto &pos : floor.get_area()) {
-        const auto &grid = floor.get_grid(pos);
-        for (const auto this_o_idx : grid.o_idx_list) {
-            const auto &item = *floor.o_list[this_o_idx];
-            if (!item.is_fixed_artifact() || item.is_known()) {
-                continue;
-            }
-
-            fa_ids.erase(item.fa_id);
-        }
-    }
-
-    for (auto i = 0; i < INVEN_TOTAL; i++) {
-        const auto &item = *player_ptr->inventory[i];
-        if (!item.is_valid()) {
-            continue;
-        }
-
-        if (!item.is_fixed_artifact()) {
-            continue;
-        }
-
-        if (item.is_known()) {
-            continue;
-        }
-
-        fa_ids.erase(item.fa_id);
-    }
-
-    return fa_ids;
-}
-}
-
 /*!
- * @brief Check the status of "artifacts"
+ * @brief 入手済の固定アーティファクト一覧を一時ファイルへ保存して表示する
  * @param player_ptr プレイヤーへの参照ポインタ
+ * @param mode 表示モード
  */
-void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
+void do_cmd_knowledge_artifacts(PlayerType *player_ptr, ArtifactKnowledgeMode mode)
 {
     TempFile temp_file;
     if (const auto &error_message = temp_file.get_error_message(); error_message) {
@@ -100,9 +49,27 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
         return;
     }
 
-    std::vector<std::string> lines;
+    const auto &records = ArtifactRecords::get_instance();
+    std::vector<FixedArtifactId> fa_ids;
+    std::string title;
+    switch (mode) {
+    case ArtifactKnowledgeMode::KNOWN:
+        fa_ids = records.collect_known_ids();
+        title = _("既知の伝説のアイテム", "Known Artifacts");
+        break;
+    case ArtifactKnowledgeMode::IDENTIFIED:
+        fa_ids = records.collect_identified_ids();
+        title = _("鑑定済の伝説のアイテム", "Identified Artifacts");
+        break;
+    default:
+        THROW_EXCEPTION(std::logic_error, fmt::format("Invalid ArtifactKnowledgeMode: {}", enum2i(mode)));
+    }
+
     const auto &artifacts = ArtifactList::get_instance();
-    const auto fa_ids = collect_known_fixed_artifacts(player_ptr);
+    std::stable_sort(fa_ids.begin(), fa_ids.end(), [&artifacts](auto x, auto y) {
+        return artifacts.order(x, y);
+    });
+    std::vector<std::string> lines;
     for (const auto fa_id : fa_ids) {
         const auto &artifact = artifacts.get_artifact(fa_id);
         constexpr auto template_basename = _("     {}", "     The {}");
@@ -119,7 +86,7 @@ void do_cmd_knowledge_artifacts(PlayerType *player_ptr)
         return;
     }
 
-    FileDisplayer(player_ptr->name).display(true, temp_file.get_path().string(), 0, 0, _("既知の伝説のアイテム", "Artifacts Seen"));
+    FileDisplayer(player_ptr->name).display(true, temp_file.get_path().string(), 0, 0, title);
 }
 
 /*!

--- a/src/knowledge/knowledge-items.h
+++ b/src/knowledge/knowledge-items.h
@@ -1,5 +1,10 @@
 #pragma once
 
+enum class ArtifactKnowledgeMode {
+    KNOWN, //!< 既知のアーティファクト
+    IDENTIFIED, //!< 当該セーブデータで入手済のアーティファクト
+};
+
 class PlayerType;
-void do_cmd_knowledge_artifacts(PlayerType *player_ptr);
+void do_cmd_knowledge_artifacts(PlayerType *player_ptr, ArtifactKnowledgeMode mode);
 void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool visual_only, short direct_k_idx);

--- a/src/load/artifact-record-loader.cpp
+++ b/src/load/artifact-record-loader.cpp
@@ -1,0 +1,23 @@
+#include "load/artifact-record-loader.h"
+#include "load/load-util.h"
+#include "system/artifact/artifact-record.h"
+#include "util/enum-converter.h"
+#include <cstdint>
+#include <tl/optional.hpp>
+
+void rd_artifact_records()
+{
+    const auto tmp16u = rd_u16b();
+    auto &records = ArtifactRecords::get_instance();
+    for (uint16_t i = 1; i <= tmp16u; i++) {
+        const auto fa_id = i2enum<FixedArtifactId>(i);
+        records.set_generated(fa_id, rd_bool());
+        records.set_identified(fa_id, rd_bool());
+        records.set_known(fa_id, rd_bool());
+        records.set_quest_reward(fa_id, rd_bool());
+        const auto floor_id = rd_s16b();
+        records.set_floor_id(fa_id, (floor_id > 0) ? tl::optional<int16_t>(floor_id) : tl::nullopt);
+    }
+
+    load_note(_("伝説のアイテムをロードしました", "Loaded Artifacts"));
+}

--- a/src/load/artifact-record-loader.h
+++ b/src/load/artifact-record-loader.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void rd_artifact_records();

--- a/src/load/item/item-loader-base.cpp
+++ b/src/load/item/item-loader-base.cpp
@@ -28,8 +28,10 @@ void ItemLoaderBase::load_item()
 
 /*!
  * @brief 固定アーティファクトの出現情報をロードする.
+ *
+ * セーブファイルバージョン26未満専用.
  */
-void ItemLoaderBase::load_artifact()
+void ItemLoaderBase::load_artifact_older_than_26()
 {
     auto &records = ArtifactRecords::get_instance();
     auto loading_max_a_idx = rd_u16b();
@@ -44,5 +46,5 @@ void ItemLoaderBase::load_artifact()
         }
     }
 
-    load_note(_("伝説のアイテムをロードしました", "Loaded Artifacts"));
+    load_note(_("伝説のアイテム(旧版)をロードしました", "Loaded Artifacts (old versions)"));
 }

--- a/src/load/item/item-loader-base.h
+++ b/src/load/item/item-loader-base.h
@@ -7,7 +7,7 @@ public:
 
     virtual void rd_item(ItemEntity *o_ptr) = 0;
     void load_item();
-    void load_artifact();
+    void load_artifact_older_than_26();
 
 protected:
     ItemLoaderBase() = default;

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -12,10 +12,12 @@
 #include "load/load.h"
 #include "core/asking-player.h"
 #include "game-option/birth-options.h"
+#include "inventory/inventory-slot-types.h"
 #include "io/files-util.h"
 #include "io/report.h"
 #include "io/uid-checker.h"
 #include "load/angband-version-comparer.h"
+#include "load/artifact-record-loader.h"
 #include "load/dummy-loader.h"
 #include "load/dungeon-loader.h"
 #include "load/extra-loader.h"
@@ -42,18 +44,75 @@
 #include "system/angband-exceptions.h"
 #include "system/angband-system.h"
 #include "system/angband-version.h"
+#include "system/artifact/artifact-list.h"
+#include "system/artifact/artifact-record.h"
 #include "system/dungeon/quest-definition.h"
 #include "system/dungeon/quest-list.h"
+#include "system/floor/floor-info.h"
+#include "system/grid-type-definition.h"
 #include "system/inner-game-data.h"
+#include "system/item/item-entity.h"
 #include "system/player-type-definition.h"
 #include "system/system-variables.h"
 #include "util/angband-files.h"
 #include "util/enum-converter.h"
 #include "view/display-messages.h"
 #include "world/world.h"
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>
+
+namespace {
+/*!
+ * @brief 既知の固定アーティファクトIDを収集する（V26未満のセーブデータ用）
+ */
+auto collect_known_fixed_artifacts_old(PlayerType *player_ptr)
+{
+    const auto &artifacts = ArtifactList::get_instance();
+    const auto comparer = [&artifacts](auto id1, auto id2) { return artifacts.order(id1, id2); };
+    std::set<FixedArtifactId, decltype(comparer)> fa_ids(comparer);
+    for (const auto &[fa_id, record] : ArtifactRecords::get_instance()) {
+        if (!record.get_generated()) {
+            continue;
+        }
+
+        fa_ids.insert(fa_id);
+    }
+
+    const auto &floor = *player_ptr->current_floor_ptr;
+    for (const auto &pos : floor.get_area()) {
+        const auto &grid = floor.get_grid(pos);
+        for (const auto this_o_idx : grid.o_idx_list) {
+            const auto &item = *floor.o_list[this_o_idx];
+            if (!item.is_fixed_artifact() || item.is_known()) {
+                continue;
+            }
+
+            fa_ids.erase(item.fa_id);
+        }
+    }
+
+    for (auto i = 0; i < INVEN_TOTAL; i++) {
+        const auto &item = *player_ptr->inventory[i];
+        if (!item.is_valid()) {
+            continue;
+        }
+
+        if (!item.is_fixed_artifact()) {
+            continue;
+        }
+
+        if (item.is_known()) {
+            continue;
+        }
+
+        fa_ids.erase(item.fa_id);
+    }
+
+    return fa_ids;
+}
+}
 
 /*!
  * @brief 変愚蛮怒 v2.1.3で追加された街とクエストについて読み込む
@@ -191,6 +250,16 @@ static errr verify_encoded_checksum()
     return 11;
 }
 
+static errr verify_savedata()
+{
+    const auto checksum_result = verify_checksum();
+    if (checksum_result != 0) {
+        return checksum_result;
+    }
+
+    return verify_encoded_checksum();
+}
+
 /*!
  * @brief セーブファイル読み込み処理の実体 / Actually read the savefile
  * @return エラーコード
@@ -214,7 +283,10 @@ static errr exe_reading_savefile(PlayerType *player_ptr)
     }
 
     load_note(_("クエスト情報をロードしました", "Loaded Quests"));
-    item_loader->load_artifact();
+    if (loading_savefile_version_is_older_than(26)) {
+        item_loader->load_artifact_older_than_26();
+    }
+
     load_player_world(player_ptr);
     auto load_hp_result = load_hp(player_ptr);
     if (load_hp_result != 0) {
@@ -261,12 +333,20 @@ static errr exe_reading_savefile(PlayerType *player_ptr)
         remove_water_cave(player_ptr);
     }
 
-    auto checksum_result = verify_checksum();
-    if (checksum_result != 0) {
-        return checksum_result;
+    if (loading_savefile_version_is_older_than(26)) {
+        auto &artifact_records = ArtifactRecords::get_instance();
+        const auto known_fixed_artifacts = collect_known_fixed_artifacts_old(player_ptr);
+        for (const auto fa_id : known_fixed_artifacts) {
+            artifact_records.set_generated(fa_id, true);
+            artifact_records.set_known(fa_id);
+            artifact_records.set_identified(fa_id);
+        }
+
+        return verify_savedata();
     }
 
-    return verify_encoded_checksum();
+    rd_artifact_records();
+    return verify_savedata();
 }
 
 /*!

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -44,6 +44,7 @@
 #include "system/angband-exceptions.h"
 #include "system/angband-system.h"
 #include "system/angband-version.h"
+#include "system/artifact/artifact-definition.h"
 #include "system/artifact/artifact-list.h"
 #include "system/artifact/artifact-record.h"
 #include "system/dungeon/quest-definition.h"

--- a/src/load/quest-loader.cpp
+++ b/src/load/quest-loader.cpp
@@ -70,10 +70,10 @@ static void load_quest_details(PlayerType *player_ptr, QuestId loading_quest_id)
         determine_random_questor(player_ptr, quests.get_quest(loading_quest_id));
     }
 
-    quests.get_quest(loading_quest_id).reset_reward();
+    quests.reset_reward(loading_quest_id);
     const auto reward_fa_id = i2enum<FixedArtifactId>(rd_s16b());
     if (reward_fa_id != FixedArtifactId::NONE) {
-        quests.get_quest(loading_quest_id).set_reward(reward_fa_id);
+        quests.set_reward(loading_quest_id, reward_fa_id);
     }
 
     quests.set_flags(loading_quest_id, rd_byte());

--- a/src/save/artifact-record-writer.cpp
+++ b/src/save/artifact-record-writer.cpp
@@ -1,0 +1,21 @@
+#include "save/artifact-record-writer.h"
+#include "save/save-util.h"
+#include "system/artifact/artifact-record.h"
+#include "util/enum-converter.h"
+#include <cstdint>
+
+void wr_artifact_records()
+{
+    const auto &records = ArtifactRecords::get_instance();
+    const auto records_size = static_cast<uint16_t>(records.size());
+    wr_u16b(records_size);
+    for (uint16_t i = 1; i <= records_size; i++) {
+        const auto fa_id = i2enum<FixedArtifactId>(i);
+        wr_bool(records.get_generated(fa_id));
+        wr_bool(records.get_identified(fa_id));
+        wr_bool(records.get_known(fa_id));
+        wr_bool(records.get_quest_reward(fa_id));
+        const auto floor_id = records.get_floor_id(fa_id);
+        wr_s16b(floor_id ? *floor_id : 0); // 地上(0F)では固定アーティファクトは生成されないので、0を書き込んでも問題ない.
+    }
+}

--- a/src/save/artifact-record-writer.h
+++ b/src/save/artifact-record-writer.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void wr_artifact_records();

--- a/src/save/item-writer.cpp
+++ b/src/save/item-writer.cpp
@@ -167,7 +167,7 @@ static void write_item_info(const ItemEntity &item, const BIT_FLAGS flags)
     }
 
     if (any_bits(flags, SaveDataItemFlagType::IDENT)) {
-        wr_FlagGroup(item.get_special_flags(), wr_byte);
+        wr_FlagGroup(item.get_identification_flags(), wr_byte);
     }
 
     if (any_bits(flags, SaveDataItemFlagType::MARKED)) {

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -21,6 +21,7 @@
 #include "locale/character-encoding.h"
 #include "monster/monster-compaction.h"
 #include "player/player-status.h"
+#include "save/artifact-record-writer.h"
 #include "save/floor-writer.h"
 #include "save/info-writer.h"
 #include "save/item-writer.h"
@@ -156,18 +157,6 @@ static bool wr_savefile_new(PlayerType *player_ptr)
         }
     }
 
-    const auto &artifacts = ArtifactList::get_instance();
-    const auto &artifact_records = ArtifactRecords::get_instance();
-    auto max_a_num = enum2i(artifacts.rbegin()->first);
-    tmp16u = max_a_num + 1;
-    wr_u16b(tmp16u);
-    for (auto i = 0U; i < tmp16u; i++) {
-        const auto fa_id = i2enum<FixedArtifactId>(i);
-        wr_bool(artifact_records.get_generated(fa_id));
-        const auto floor_id = artifact_records.get_floor_id(fa_id);
-        wr_s16b(floor_id ? *floor_id : 0);
-    }
-
     wr_u32b(InnerGameData::get_instance().get_total_play_time());
     const auto &igd = InnerGameData::get_instance();
     wr_FlagGroup(igd.get_won_classes(), wr_byte);
@@ -231,6 +220,7 @@ static bool wr_savefile_new(PlayerType *player_ptr)
         wr_s32b(0);
     }
 
+    wr_artifact_records();
     wr_u32b(v_stamp);
     wr_u32b(x_stamp);
     return !ferror(saving_savefile) && (fflush(saving_savefile) != EOF);

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -20,6 +20,7 @@
 #include "object/object-mark-types.h"
 #include "perception/identification.h"
 #include "perception/object-perception.h"
+#include "system/artifact/artifact-record.h"
 #include "system/item/item-entity.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
@@ -68,6 +69,11 @@ bool identify_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     object_aware(player_ptr, *o_ptr);
     o_ptr->mark_as_known();
     o_ptr->marked.set(OmType::TOUCHED);
+    if (o_ptr->is_fixed_artifact()) {
+        auto &records = ArtifactRecords::get_instance();
+        records.set_known(o_ptr->fa_id);
+        records.set_identified(o_ptr->fa_id);
+    }
 
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     static constexpr auto flags_srf = {

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -29,7 +29,7 @@ constexpr std::string_view ROOT_VARIANT_NAME("Hengband");
 /*!
  * @brief セーブファイルのバージョン(3.0.0から導入)
  */
-constexpr uint32_t SAVEFILE_VERSION = 25;
+constexpr uint32_t SAVEFILE_VERSION = 26;
 
 /*!
  * @brief バージョンが開発版が安定版かを返す(廃止予定)

--- a/src/system/artifact/artifact-record.cpp
+++ b/src/system/artifact/artifact-record.cpp
@@ -212,3 +212,27 @@ void ArtifactRecords::validate_fixed_artifact_id(FixedArtifactId fa_id) const
         THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid Fixed Artifact ID: {}", enum2i(fa_id)));
     }
 }
+
+std::vector<FixedArtifactId> ArtifactRecords::collect_known_ids() const
+{
+    std::vector<FixedArtifactId> result;
+    for (const auto &[fa_id, record] : this->records) {
+        if (record.get_known()) {
+            result.push_back(fa_id);
+        }
+    }
+
+    return result;
+}
+
+std::vector<FixedArtifactId> ArtifactRecords::collect_identified_ids() const
+{
+    std::vector<FixedArtifactId> result;
+    for (const auto &[fa_id, record] : this->records) {
+        if (record.get_identified()) {
+            result.push_back(fa_id);
+        }
+    }
+
+    return result;
+}

--- a/src/system/artifact/artifact-record.cpp
+++ b/src/system/artifact/artifact-record.cpp
@@ -24,6 +24,11 @@ bool ArtifactRecord::get_known() const
     return this->is_known;
 }
 
+bool ArtifactRecord::get_quest_reward() const
+{
+    return this->is_quest_reward;
+}
+
 bool ArtifactRecord::can_generate() const
 {
     return !this->is_generated && !this->is_quest_reward;
@@ -119,6 +124,16 @@ bool ArtifactRecords::get_known(FixedArtifactId fa_id) const
     }
 
     return this->records.at(fa_id).get_known();
+}
+
+bool ArtifactRecords::get_quest_reward(FixedArtifactId fa_id) const
+{
+    this->validate_fixed_artifact_id(fa_id);
+    if (fa_id == FixedArtifactId::NONE) {
+        return false;
+    }
+
+    return this->records.at(fa_id).get_quest_reward();
 }
 
 bool ArtifactRecords::can_generate(FixedArtifactId fa_id) const

--- a/src/system/artifact/artifact-record.h
+++ b/src/system/artifact/artifact-record.h
@@ -18,6 +18,7 @@ public:
     bool get_generated() const;
     bool get_identified() const;
     bool get_known() const;
+    bool get_quest_reward() const;
     bool can_generate() const;
 
     void set_floor_id(const tl::optional<short> &id);
@@ -51,6 +52,7 @@ public:
     bool get_generated(FixedArtifactId fa_id) const;
     bool get_identified(FixedArtifactId fa_id) const;
     bool get_known(FixedArtifactId fa_id) const;
+    bool get_quest_reward(FixedArtifactId fa_id) const;
     bool can_generate(FixedArtifactId fa_id) const;
 
     void set_floor_id(FixedArtifactId fa_id, const tl::optional<short> &id);

--- a/src/system/artifact/artifact-record.h
+++ b/src/system/artifact/artifact-record.h
@@ -9,6 +9,7 @@
 
 #include "util/abstract-map-wrapper.h"
 #include <tl/optional.hpp>
+#include <vector>
 
 class ArtifactRecord {
 public:
@@ -36,7 +37,6 @@ private:
 };
 
 enum class FixedArtifactId : short;
-class ArtifactRecord;
 class ArtifactRecords : public util::AbstractMapWrapper<FixedArtifactId, ArtifactRecord> {
 public:
     ArtifactRecords(ArtifactRecords &&) = delete;
@@ -61,6 +61,9 @@ public:
     void set_known(FixedArtifactId fa_id, bool new_state = true);
     void set_quest_reward(FixedArtifactId fa_id, bool new_state);
     void reset_all_without_knowledge();
+
+    std::vector<FixedArtifactId> collect_known_ids() const;
+    std::vector<FixedArtifactId> collect_identified_ids() const;
 
 private:
     ArtifactRecords() = default;

--- a/src/system/artifact/artifact-service.h
+++ b/src/system/artifact/artifact-service.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <memory>
 #include <tl/optional.hpp>
-#include <utility>
 
 enum class FixedArtifactId : short;
 class ArtifactDefinition;

--- a/src/system/dungeon/quest-list.cpp
+++ b/src/system/dungeon/quest-list.cpp
@@ -165,6 +165,16 @@ void QuestList::set_flags(QuestId id, uint32_t flags)
     this->quests.at(id).flags = flags;
 }
 
+void QuestList::set_reward(QuestId id, FixedArtifactId fa_id)
+{
+    this->quests.at(id).set_reward(fa_id);
+}
+
+void QuestList::reset_reward(QuestId id)
+{
+    this->quests.at(id).reset_reward();
+}
+
 bool QuestList::is_quest_equals(QuestId id, QuestKindType type) const
 {
     return this->quests.at(id).type == type;

--- a/src/system/dungeon/quest-list.h
+++ b/src/system/dungeon/quest-list.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+enum class FixedArtifactId : short;
 enum class MonraceId : short;
 enum class QuestId : short;
 enum class QuestKindType : short;
@@ -27,6 +28,8 @@ public:
     void set_type(QuestId id, QuestKindType type);
     void set_monrace_id(QuestId id, MonraceId monrace_id);
     void set_flags(QuestId id, uint32_t flags);
+    void set_reward(QuestId id, FixedArtifactId fa_id);
+    void reset_reward(QuestId id);
     bool is_quest_equals(QuestId id, QuestKindType type) const;
     bool is_bounty_valid(QuestId id) const;
 

--- a/src/system/item/item-entity.cpp
+++ b/src/system/item/item-entity.cpp
@@ -1469,7 +1469,7 @@ bool ItemEntity::any_identification_flag() const
     return this->identification_flags.any();
 }
 
-const EnumClassFlagGroup<IdentificationFlag> &ItemEntity::get_special_flags() const
+const EnumClassFlagGroup<IdentificationFlag> &ItemEntity::get_identification_flags() const
 {
     return this->identification_flags;
 }

--- a/src/system/item/item-entity.h
+++ b/src/system/item/item-entity.h
@@ -192,7 +192,7 @@ public:
     bool has_identification_flag(IdentificationFlag flag) const;
     bool has_not_identification_flag(IdentificationFlag flag) const;
     bool any_identification_flag() const;
-    const EnumClassFlagGroup<IdentificationFlag> &get_special_flags() const; //!< セーブとデバッグ専用.
+    const EnumClassFlagGroup<IdentificationFlag> &get_identification_flags() const; //!< セーブとデバッグ専用.
     void load_identification_flags(const EnumClassFlagGroup<IdentificationFlag> &flags); //!< ロード専用.
 
 private:

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -403,7 +403,7 @@ static void wiz_display_item(PlayerType *player_ptr, ItemEntity *o_ptr)
     prt(format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %s", o_ptr->number, o_ptr->weight, o_ptr->ac, o_ptr->damage_dice.to_string().data()), ++line, j);
     prt(format("pval = %-5d  toac = %-5d  tohit = %-4d  todam = %-4d", o_ptr->pval, o_ptr->to_a, o_ptr->to_h, o_ptr->to_d), ++line, j);
     prt(format("fixed_artifact_id = %-4d  ego_idx = %-4d  cost = %d", enum2i(o_ptr->fa_id), enum2i(o_ptr->ego_idx), object_value_real(o_ptr)), ++line, j);
-    prt(format("special flags = %02x  activation_id = %-4d  timeout = %-d", static_cast<uint8_t>(o_ptr->get_special_flags().to_ulong()), enum2i(o_ptr->activation_id), o_ptr->timeout), ++line, j);
+    prt(format("special flags = %02x  activation_id = %-4d  timeout = %-d", static_cast<uint8_t>(o_ptr->get_identification_flags().to_ulong()), enum2i(o_ptr->activation_id), o_ptr->timeout), ++line, j);
     prt(format("chest_level = %-4d  fuel = %-d", o_ptr->chest_level, o_ptr->fuel), ++line, j);
     prt(format("smith_hit = %-4d  smith_damage = %-4d", o_ptr->smith_hit, o_ptr->smith_damage), ++line, j);
     prt(format("cursed  = %-4lX  captured_monster_speed = %-4d", o_ptr->curse_flags.to_ulong(), o_ptr->captured_monster_speed), ++line, j);


### PR DESCRIPTION
/gemini review

日本語でレビューして

- 今までは、固定アーティファクトの噂を聞いても一切記録されませんでした。これからはis_knownだけをtrueにすることができるようになりましたが、噂に基づく具体的な記録処理は次以降のPRで行います
- 知識フラグと鑑定フラグを分離したことにより、モンスターの思い出と同様にセーブデータ固定アーティファクト図鑑を作れるようになりました
- セーブデータV25からのアーティファクト一覧読み取り、V26での再読み取り、両方確認済です
- 宝物庫の報酬情報は、クエスト情報のロード処理とアーティファクト記録のロード処理で重複していますが、今のところ放置です。まだしっかり調査していませんが、クエストロード処理から安全に削除できそうならコメント頂けると助かります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge menu restructured: artifacts split into discovered vs identified entries; pets moved to the second page.
  * Artifact tracking improved: identifying or finding artifacts now updates persistent artifact data and is reflected in knowledge lists.

* **Chores**
  * Savefile format bumped to version 26; saves will be migrated automatically to include artifact records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->