### PR TITLE
English: insert space after comma in Magman's name

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -81085,7 +81085,7 @@
       "id": 1322,
       "name": {
         "ja": "溶岩の怪物『ヨガン』",
-        "en": "Magman,Lava monster",
+        "en": "Magman, Lava monster",
       },
       "symbol": {
         "character": "~",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * モンスター定義の英語名における句読点後のスペース書式を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->