### PR TITLE
[Refactor] utf-8.cppの関数群のシグネチャ変更

### DIFF
--- a/src/locale/utf-8.cpp
+++ b/src/locale/utf-8.cpp
@@ -1,4 +1,5 @@
 #include "locale/utf-8.h"
+#include <range/v3/algorithm.hpp>
 
 /*!
  * @brief 文字列の最初の文字のUTF-8エンコーディングにおけるバイト長を返す
@@ -6,63 +7,67 @@
  * UTF-8エンコーディングの文字列が渡されるのを想定し、
  * その文字列の最初の文字のバイト長を返す。
  * UTF-8エンコーディングとして適合しなければ0を返す。
- * また文字列終端文字('\\0')の場合も0を返す。
+ * また文字列が空の場合も0を返す。
  *
  * @note UTF-8エンコーディングの厳密なバリデーションにはなっていない。
  *       2バイト目以降は0x80-0xBF固定ではなく、バイト長・何バイト目かなど
  *       によって若干変化するが、ここでは簡便のため0x80-0xBFの範囲のみ
  *       チェックする
  *
- * @param str 判定する文字列へのポインタ
+ * @param str 判定する文字列
  *
  * @return 最初の文字のバイト長を返す。
- *         終端文字もしくはUTF-8エンコーディングに適合しない場合は0を返す。
+ *         空文字列もしくはUTF-8エンコーディングに適合しない場合は0を返す。
  */
-int utf8_next_char_byte_length(concptr str)
+int utf8_next_char_byte_length(std::string_view str)
 {
-    const unsigned char *p = (const unsigned char *)str;
-    int length = 0;
+    if (str.empty()) {
+        return 0;
+    }
+
+    const auto start_byte = static_cast<unsigned char>(str.front());
+    size_t length = 0;
 
     // バイト長の判定
-    if (0x00 < *p && *p <= 0x7f) {
-        length = 1;
-    } else if ((*p & 0xe0) == 0xc0) {
+    if (start_byte <= 0x7f) {
+        return 1;
+    } else if ((start_byte & 0xe0) == 0xc0) {
         length = 2;
-    } else if ((*p & 0xf0) == 0xe0) {
+    } else if ((start_byte & 0xf0) == 0xe0) {
         length = 3;
-    } else if ((*p & 0xf8) == 0xf0) {
+    } else if ((start_byte & 0xf8) == 0xf0) {
         length = 4;
     } else {
         return 0;
     }
 
-    // trailing bytesが0x80-0xBFである事のチェック
-    while ((++p) < (const unsigned char *)str + length) {
-        if ((*p & 0xc0) != 0x80) {
-            return 0;
-        }
+    if (str.size() < length) {
+        return 0;
     }
 
-    return length;
+    const auto trailing_bytes = str.substr(1, length - 1);
+    const auto is_valid_trailing_byte = [](unsigned char c) { return (c & 0xc0) == 0x80; };
+
+    return ranges::all_of(trailing_bytes, is_valid_trailing_byte) ? length : 0;
 }
 
 /*!
  * @brief 文字列がUTF-8の文字列として適合かどうかを判定する
  *
- * @param str 判定する文字列へのポインタ
+ * @param str 判定する文字列
  *
- * @return 文字列がUTF-8として適合ならTRUE、そうでなければFALSE
+ * @return 文字列がUTF-8として適合ならtrue、そうでなければfalse
  */
-bool is_utf8_str(concptr str)
+bool is_utf8_str(std::string_view str)
 {
-    while (*str) {
+    while (!str.empty()) {
         const int byte_length = utf8_next_char_byte_length(str);
 
         if (byte_length == 0) {
             return false;
         }
 
-        str += byte_length;
+        str.remove_prefix(byte_length);
     }
 
     return true;

--- a/src/locale/utf-8.h
+++ b/src/locale/utf-8.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "system/angband.h"
+#include <string_view>
 
-int utf8_next_char_byte_length(concptr s);
-bool is_utf8_str(concptr str);
+int utf8_next_char_byte_length(std::string_view str);
+bool is_utf8_str(std::string_view str);

--- a/src/main-x11.cpp
+++ b/src/main-x11.cpp
@@ -908,9 +908,9 @@ static void Infofnt_text_std_xft_draw_str(int px, int py, const XftColor &fg, co
 {
     int offset = 0;
     while (str < str_end) {
-        const int byte_len = utf8_next_char_byte_length(str);
+        const int byte_len = utf8_next_char_byte_length(std::string_view(str, str_end - str));
 
-        if (byte_len == 0 || str + byte_len > str_end) {
+        if (byte_len == 0) {
             return;
         }
 


### PR DESCRIPTION
utf-8.cppで定義されている関数 is_utf8_str と utf8_next_char_byte_length に渡す文字列の型を concptr から std::string_view に変更する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * UTF‑8 テキスト検証の内部実装を全面的に見直し、より堅牢で範囲検査に強い文字処理に改善しました。空文字や不正バイト列の判定が明確化され、不正データ検出の信頼性が向上しています。ユーザー向け挙動に変更はなく、文字列処理の安定性が高まりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->