### PR TITLE
[Fix] MonraceRecords の参照を軽量化

### DIFF
--- a/src/system/monrace/monrace-records.cpp
+++ b/src/system/monrace/monrace-records.cpp
@@ -14,16 +14,17 @@ MonraceRecords MonraceRecords::instance{};
  */
 void MonraceRecords::initialize(size_t size)
 {
-    if (!this->records.empty()) {
-        for (auto &[_, record] : this->records) {
-            record->reset_all();
+    if (this->records.size() < size) {
+        this->records.reserve(size);
+        while (this->records.size() < size) {
+            this->records.emplace_back(std::make_shared<MonraceRecord>());
         }
-
-        return;
+    } else if (this->records.size() > size) {
+        this->records.resize(size);
     }
 
-    for (size_t i = 0; i < size; i++) {
-        this->records.emplace(static_cast<MonraceId>(i), std::make_shared<MonraceRecord>());
+    for (auto &record : this->records) {
+        record->reset_all();
     }
 }
 
@@ -34,53 +35,60 @@ MonraceRecords &MonraceRecords::get_instance()
 
 std::shared_ptr<const MonraceRecord> MonraceRecords::get_record(MonraceId monrace_id) const
 {
-    this->validate_monrace_id(monrace_id);
-    return this->records.at(monrace_id);
+    return this->get_record_ref(monrace_id);
 }
 
 bool MonraceRecords::has_been_seen(MonraceId monrace_id) const
 {
-    this->validate_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return false;
     }
 
-    return this->records.at(monrace_id)->has_been_seen();
+    return this->get_record_ref(monrace_id)->has_been_seen();
 }
 
 void MonraceRecords::increment_seen_count(MonraceId monrace_id)
 {
-    this->validate_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return;
     }
 
-    this->records[monrace_id]->increment_seen_count();
+    this->get_record_ref(monrace_id)->increment_seen_count();
 }
 
 short MonraceRecords::get_seen_count(MonraceId monrace_id) const
 {
-    this->validate_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return 0;
     }
 
-    return this->records.at(monrace_id)->get_seen_count();
+    return this->get_record_ref(monrace_id)->get_seen_count();
 }
 
 void MonraceRecords::set_seen_count(MonraceId monrace_id, short count)
 {
-    this->validate_monrace_id(monrace_id);
     if (monrace_id == MonraceId::PLAYER) {
         return;
     }
 
-    this->records[monrace_id]->set_seen_count(count);
+    this->get_record_ref(monrace_id)->set_seen_count(count);
+}
+
+std::shared_ptr<MonraceRecord> &MonraceRecords::get_record_ref(MonraceId monrace_id)
+{
+    this->validate_monrace_id(monrace_id);
+    return this->records[enum2i(monrace_id)];
+}
+
+const std::shared_ptr<MonraceRecord> &MonraceRecords::get_record_ref(MonraceId monrace_id) const
+{
+    this->validate_monrace_id(monrace_id);
+    return this->records[enum2i(monrace_id)];
 }
 
 void MonraceRecords::validate_monrace_id(MonraceId monrace_id) const
 {
-    if ((monrace_id < MonraceId::PLAYER) || monrace_id >= i2enum<MonraceId>(this->records.size())) {
+    if ((monrace_id <= MonraceId::PLAYER) || monrace_id >= i2enum<MonraceId>(this->records.size())) {
         THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid Monrace ID: {}", enum2i(monrace_id)));
     }
 }

--- a/src/system/monrace/monrace-records.h
+++ b/src/system/monrace/monrace-records.h
@@ -7,11 +7,11 @@
  */
 
 #include "system/enums/monrace/monrace-id.h"
-#include "util/abstract-map-wrapper.h"
 #include <memory>
+#include <vector>
 
 class MonraceRecord;
-class MonraceRecords : public util::AbstractMapWrapper<MonraceId, std::shared_ptr<MonraceRecord>> {
+class MonraceRecords {
 public:
     MonraceRecords(MonraceRecords &&) = delete;
     MonraceRecords(const MonraceRecords &) = delete;
@@ -32,11 +32,9 @@ private:
 
     static MonraceRecords instance;
 
-    std::map<MonraceId, std::shared_ptr<MonraceRecord>> records;
-    std::map<MonraceId, std::shared_ptr<MonraceRecord>> &get_inner_container() override
-    {
-        return this->records;
-    }
+    std::vector<std::shared_ptr<MonraceRecord>> records;
 
+    std::shared_ptr<MonraceRecord> &get_record_ref(MonraceId monrace_id);
+    const std::shared_ptr<MonraceRecord> &get_record_ref(MonraceId monrace_id) const;
     void validate_monrace_id(MonraceId monrace_id) const;
 };


### PR DESCRIPTION
モンスター目撃回数の参照・更新が std::map 経由になり、視認処理で余分な探索コストが発生していた。
MonraceRecords の内部保持を vector に変更し、MonraceId から直接添字アクセスしてホットパスを軽量化した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * モンスター図鑑の内部実装を配列ベースに移行。初期化処理を統一して容量確保と不足分の追加を行い、常に全要素をリセットするよう変更。参照取得とID検証処理を共通化して内部処理を簡素化・一貫化。公開APIのシグネチャに変更なし。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->