### PR TITLE
[Fix] format.cc が再コンパイルされない

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1495,6 +1495,7 @@ stdafx.h.gch: stdafx.h stdafx.cpp Makefile
 	fi
 
 $(hengband_SOURCES:.cpp=.$(OBJEXT)): stdafx.h.gch
+$(hengband_SOURCES:.cc=.$(OBJEXT)): stdafx.h.gch
 endif
 
 install-exec-hook:


### PR DESCRIPTION
format.cc のみ外部ライブラリ由来のため拡張子が cpp でなく cc となっており、プリコンパイルヘッダが更新されたときにビルドすると再コンパイルされずリンクエラーが発生することがある。
拡張子 cc のファイルもプリコンパイルヘッダが更新されたら再コンパイルされるよう修正する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルドシステムにおけるプリコンパイルヘッダーの依存関係処理を改善しました。これにより、ビルド過程の効率性と正確性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->