### PR TITLE
[Refactor] SpellInfoListからJSON変換処理の分離

### DIFF
--- a/src/info-reader/spell-reader.cpp
+++ b/src/info-reader/spell-reader.cpp
@@ -35,10 +35,11 @@ static errr set_realm(const nlohmann::json &spell_data, RealmType &realm)
 /*!
  * @brief JSON Objectから各呪文の詳細を取得する
  * @param spell_data 情報の格納されたJSON Object
- * @param realm_spell_list 呪文情報を格納するvector
+ * @param spell_info_list 呪文情報リスト
+ * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_spell_data(const nlohmann::json &spell_data, std::vector<SpellInfo> &realm_spell_list)
+static errr set_spell_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
 {
     if (spell_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -67,7 +68,7 @@ static errr set_spell_data(const nlohmann::json &spell_data, std::vector<SpellIn
         msg_format(_("呪文説明読込失敗。ID: '%d'。", "Failed to load spell description. ID: '%d'."), error_idx);
         return err;
     }
-    realm_spell_list[spell_id] = std::move(info);
+    spell_info_list.set_spell_info(realm, spell_id, std::move(info));
 
     return PARSE_ERROR_NONE;
 }
@@ -75,10 +76,11 @@ static errr set_spell_data(const nlohmann::json &spell_data, std::vector<SpellIn
 /*!
  * @brief JSON Objectから各呪文の詳細を呪文書単位で取得する
  * @param spell_data 情報の格納されたJSON Object
- * @param realm_spell_list 呪文情報を格納するvector
+ * @param spell_info_list 呪文情報リスト
+ * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_book_data(const nlohmann::json &spell_data, std::vector<SpellInfo> &realm_spell_list)
+static errr set_book_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
 {
     auto &book_obj = spell_data["books"];
     if (book_obj.is_null()) {
@@ -94,7 +96,9 @@ static errr set_book_data(const nlohmann::json &spell_data, std::vector<SpellInf
 
         for (auto &spell_element : spells_obj.items()) {
             auto &spell = spell_element.value();
-            set_spell_data(spell, realm_spell_list);
+            if (auto err = set_spell_data(spell, spell_info_list, realm)) {
+                return err;
+            }
         }
     }
     return PARSE_ERROR_NONE;
@@ -103,10 +107,10 @@ static errr set_book_data(const nlohmann::json &spell_data, std::vector<SpellInf
 /*!
  * @brief 職業魔法情報(ClassMagicDefinitions)のパース関数
  * @param buf テキスト列
- * @param spell_list パースした結果を格納する領域
+ * @param spell_info_list パースした結果を格納する領域
  * @return エラーコード
  */
-errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellInfo>> &spell_list)
+errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list)
 {
     RealmType realm_id;
     if (auto err = set_realm(spell_data, realm_id)) {
@@ -114,9 +118,7 @@ errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellI
         return err;
     }
 
-    auto &realm_spell_list = spell_list[enum2i(realm_id)];
-
-    if (auto err = set_book_data(spell_data, realm_spell_list)) {
+    if (auto err = set_book_data(spell_data, spell_info_list, realm_id)) {
         msg_format(_("呪文詳細読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
         return err;
     }

--- a/src/info-reader/spell-reader.h
+++ b/src/info-reader/spell-reader.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "external-lib/include-json.h"
 #include "system/angband.h"
-#include <vector>
+#include <external-lib/include-json.h>
 
-class SpellInfo;
-errr parse_spell_info(nlohmann::json &spell_data, std::vector<std::vector<SpellInfo>> &spell_list);
+class SpellInfoList;
+
+errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list);

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -18,6 +18,7 @@
 #include "info-reader/message-reader.h"
 #include "info-reader/race-reader.h"
 #include "info-reader/skill-reader.h"
+#include "info-reader/spell-reader.h"
 #include "info-reader/terrain-reader.h"
 #include "info-reader/vault-reader.h"
 #include "io/files-util.h"
@@ -248,7 +249,7 @@ void init_spell_info()
     auto &spell_info_list = SpellInfoList::get_instance();
     spell_info_list.initialize();
     auto parser = [&spell_info_list](nlohmann::json &spell_data) {
-        return spell_info_list.parse(spell_data);
+        return parse_spell_info(spell_data, spell_info_list);
     };
     init_json("SpellDefinitions.jsonc", "realms", DefinitionHashDataType::SPELLS, spell_info_list, parser);
 }

--- a/src/system/spell-info-list.cpp
+++ b/src/system/spell-info-list.cpp
@@ -1,7 +1,10 @@
 #include "system/spell-info-list.h"
-#include "info-reader/spell-reader.h"
 #include "realm/realm-types.h"
+#include "system/angband-exceptions.h"
 #include <algorithm>
+#include <fmt/format.h>
+#include <stdexcept>
+#include <utility>
 
 SpellInfoList SpellInfoList::instance{};
 
@@ -33,7 +36,17 @@ const SpellInfo &SpellInfoList::get_spell_info(RealmType realm, int spell_id) co
     return this->spell_list[enum2i(realm)][spell_id];
 }
 
-int SpellInfoList::parse(nlohmann::json &spell_data)
+void SpellInfoList::set_spell_info(RealmType realm, int spell_id, SpellInfo &&spell_info)
 {
-    return parse_spell_info(spell_data, this->spell_list);
+    const auto realm_index = enum2i(realm);
+    if (realm_index < 0 || realm_index >= static_cast<int>(this->spell_list.size())) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid realm: {}", realm_index));
+    }
+
+    auto &spells = this->spell_list[realm_index];
+    if (spell_id < 0 || spell_id >= static_cast<int>(spells.size())) {
+        THROW_EXCEPTION(std::out_of_range, fmt::format("Invalid spell ID: {}", spell_id));
+    }
+
+    spells[spell_id] = std::move(spell_info);
 }

--- a/src/system/spell-info-list.h
+++ b/src/system/spell-info-list.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "external-lib/include-json.h"
 #include "realm/realm-types.h"
 #include "system/angband.h"
 #include <string>
@@ -49,7 +48,7 @@ public:
     ~SpellInfoList() = default;
 
     void initialize();
-    int parse(nlohmann::json &spell_data);
+    void set_spell_info(RealmType realm, int spell_id, SpellInfo &&spell_info);
 
     static SpellInfoList &get_instance();
 


### PR DESCRIPTION
SpellInfoListは呪文データの保持と更新に専念させる。

JSON読込はspell-reader経由に整理し、呪文単位のパースエラーを伝播する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 呪文情報の取り扱いを一括JSONパース中心から、領域とID単位で個別に設定するAPIへ変更し、初期化フローを簡素化しました。
* **Bug Fix**
  * 呪文要素ごとの設定時に戻り値や範囲検証で早期検出・処理するようにし、読み込みの安定性とエラー報告を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->