### PR TITLE
[Fix] =gを刻んだアイテムの自動拾いを復旧

### DIFF
--- a/src/autopick/autopick-entry.cpp
+++ b/src/autopick/autopick-entry.cpp
@@ -294,15 +294,6 @@ bool autopick_new_entry(autopick_type *entry, std::string_view line_input, bool 
         entry->action = act;
         entry->insc = std::move(inscription);
     });
-    if (!previous_flag) {
-        if (sv.empty()) {
-            entry->add(FLG_ITEMS);
-            previous_flag = FLG_ITEMS;
-        }
-
-        return true;
-    }
-
     if (sv.starts_with(':')) {
         sv.remove_prefix(1);
         sv = ltrim_sv(sv);
@@ -316,6 +307,15 @@ bool autopick_new_entry(autopick_type *entry, std::string_view line_input, bool 
         return true;
     }
 #endif
+
+    if (!previous_flag) {
+        if (sv.empty()) {
+            entry->add(FLG_ITEMS);
+            previous_flag = FLG_ITEMS;
+        }
+
+        return true;
+    }
 
     if (sv.empty()) {
         return true;

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -346,13 +346,15 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
         return false;
     }
 
-    if (entry.name[0] == '^') {
-        if (!item_name.starts_with(std::string_view(entry.name).substr(1))) {
-            return false;
-        }
-    } else {
-        if (!str_find(std::string(item_name), entry.name)) {
-            return false;
+    if (!entry.name.empty()) {
+        if (entry.name[0] == '^') {
+            if (!item_name.starts_with(std::string_view(entry.name).substr(1))) {
+                return false;
+            }
+        } else {
+            if (!str_find(std::string(item_name), entry.name)) {
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
fix #5440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed improper processing of item entries with special prefix characters to ensure correct formatting and matching behavior
  * Fixed potential crash when matching items with empty names by adding proper validation checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->