### PR TITLE
[Refactor] ArtifactReaderをクラス化

### DIFF
--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -14,7 +14,22 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 
-ArtifactReader::ArtifactReader(nlohmann::json &art_data)
+namespace {
+
+const nlohmann::json &get_json_value(const nlohmann::json &json, std::string_view key)
+{
+    static const nlohmann::json null_json;
+    if (!json.is_object()) {
+        return null_json;
+    }
+
+    const auto it = json.find(key);
+    return it != json.end() ? *it : null_json;
+}
+
+}
+
+ArtifactReader::ArtifactReader(const nlohmann::json &art_data)
     : art_data(art_data)
 {
 }
@@ -26,12 +41,12 @@ ArtifactReader::ArtifactReader(nlohmann::json &art_data)
  */
 int ArtifactReader::read() const
 {
-    if (!this->art_data["id"].is_number_integer()) {
+    if (!get_json_value(this->art_data, "id").is_number_integer()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    const auto int_id = this->art_data["id"].get<int>();
-    if (int_id < error_idx) {
+    const auto int_id = get_json_value(this->art_data, "id").get<int>();
+    if (int_id <= error_idx) {
         return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
     }
     const auto artifact_id = i2enum<FixedArtifactId>(int_id);
@@ -43,7 +58,7 @@ int ArtifactReader::read() const
     artifact.flags.set(TR_IGNORE_FIRE);
     artifact.flags.set(TR_IGNORE_COLD);
 
-    if (auto err = info_set_string(this->art_data["name"], artifact.name, true)) {
+    if (auto err = info_set_string(get_json_value(this->art_data, "name"), artifact.name, true)) {
         msg_format(_("アーティファクトの名称読込失敗。ID: '%d'。", "Failed to load artifact name. ID: '%d'."), error_idx);
         return err;
     }
@@ -51,43 +66,43 @@ int ArtifactReader::read() const
         msg_format(_("アーティファクトのベースアイテム読込失敗。ID: '%d'。", "Failed to load base item of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["parameter_value"], artifact.pval, false, Range(-128, 128))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "parameter_value"), artifact.pval, false, Range(-128, 128))) {
         msg_format(_("アーティファクトのパラメータ値読込失敗。ID: '%d'。", "Failed to load parameter value of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["level"], artifact.level, true, Range(0, 128))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "level"), artifact.level, true, Range(0, 128))) {
         msg_format(_("アーティファクトのレベル読込失敗。ID: '%d'。", "Failed to load level of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["rarity"], artifact.rarity, true)) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "rarity"), artifact.rarity, true)) {
         msg_format(_("アーティファクトの希少度読込失敗。ID: '%d'。", "Failed to load rarity of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["weight"], artifact.weight, true, Range(0, 9999))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "weight"), artifact.weight, true, Range(0, 9999))) {
         msg_format(_("アーティファクトの重量読込失敗。ID: '%d'。", "Failed to load weight of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["cost"], artifact.cost, true, Range(0, 99999999))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "cost"), artifact.cost, true, Range(0, 99999999))) {
         msg_format(_("アーティファクトの売値読込失敗。ID: '%d'。", "Failed to load cost of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["base_ac"], artifact.ac, false, Range(-99, 99))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "base_ac"), artifact.ac, false, Range(-99, 99))) {
         msg_format(_("アーティファクトのベースAC読込失敗。ID: '%d'。", "Failed to load base AC of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_dice(this->art_data["base_dice"], artifact.damage_dice, false)) {
+    if (auto err = info_set_dice(get_json_value(this->art_data, "base_dice"), artifact.damage_dice, false)) {
         msg_format(_("アーティファクトのベースダイス読込失敗。ID: '%d'。", "Failed to load base dice of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["hit_bonus"], artifact.to_h, false, Range(-99, 99))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "hit_bonus"), artifact.to_h, false, Range(-99, 99))) {
         msg_format(_("アーティファクトの命中補正値読込失敗。ID: '%d'。", "Failed to load hit bonus of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["damage_bonus"], artifact.to_d, false, Range(-99, 99))) {
-        msg_format(_("アーティファクトの命中補正値読込失敗。ID: '%d'。", "Failed to load damage bonus of artifact. ID: '%d'."), error_idx);
+    if (auto err = info_set_integer(get_json_value(this->art_data, "damage_bonus"), artifact.to_d, false, Range(-99, 99))) {
+        msg_format(_("アーティファクトのダメージ補正値読込失敗。ID: '%d'。", "Failed to load damage bonus of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_integer(this->art_data["ac_bonus"], artifact.to_a, false, Range(-99, 99))) {
+    if (auto err = info_set_integer(get_json_value(this->art_data, "ac_bonus"), artifact.to_a, false, Range(-99, 99))) {
         msg_format(_("アーティファクトのAC補正値読込失敗。ID: '%d'。", "Failed to load AC bonus of artifact. ID: '%d'."), error_idx);
         return err;
     }
@@ -99,7 +114,7 @@ int ArtifactReader::read() const
         msg_format(_("アーティファクトの能力フラグ読込失敗。ID: '%d'。", "Failed to load ability flags of artifact. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_string(this->art_data["flavor"], artifact.text, false)) {
+    if (auto err = info_set_string(get_json_value(this->art_data, "flavor"), artifact.text, false)) {
         msg_format(_("アーティファクトのフレーバーテキスト読込失敗。ID: '%d'。", "Failed to load flavor text of artifact. ID: '%d'."), error_idx);
         return err;
     }
@@ -137,18 +152,18 @@ bool ArtifactReader::grab_one_artifact_flag(ArtifactDefinition &artifact, std::s
  */
 int ArtifactReader::set_art_baseitem(ArtifactDefinition &artifact) const
 {
-    auto &baseitem_data = this->art_data["base_item"];
+    const auto &baseitem_data = get_json_value(this->art_data, "base_item");
     if (baseitem_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
     ItemKindType type_value;
-    if (auto err = info_set_integer(baseitem_data["type_value"], type_value, true, Range(0, 128))) {
+    if (auto err = info_set_integer(get_json_value(baseitem_data, "type_value"), type_value, true, Range(0, 128))) {
         return err;
     }
 
     int subtype_value;
-    if (auto err = info_set_integer(baseitem_data["subtype_value"], subtype_value, true, Range(0, 128))) {
+    if (auto err = info_set_integer(get_json_value(baseitem_data, "subtype_value"), subtype_value, true, Range(0, 128))) {
         return err;
     }
 
@@ -164,9 +179,12 @@ int ArtifactReader::set_art_baseitem(ArtifactDefinition &artifact) const
  */
 int ArtifactReader::set_art_activate(ArtifactDefinition &artifact) const
 {
-    const auto &act_data = this->art_data["activate"];
-    if (!act_data.is_string()) {
+    const auto &act_data = get_json_value(this->art_data, "activate");
+    if (act_data.is_null()) {
         return PARSE_ERROR_NONE;
+    }
+    if (!act_data.is_string()) {
+        return PARSE_ERROR_INVALID_TYPE;
     }
 
     auto activation = grab_one_activation_flag(act_data.get<std::string>());
@@ -187,7 +205,7 @@ int ArtifactReader::set_art_activate(ArtifactDefinition &artifact) const
  */
 int ArtifactReader::set_art_flags(ArtifactDefinition &artifact) const
 {
-    const auto &flag_data = this->art_data["flags"];
+    const auto &flag_data = get_json_value(this->art_data, "flags");
     if (flag_data.is_null()) {
         return PARSE_ERROR_NONE;
     }
@@ -196,6 +214,9 @@ int ArtifactReader::set_art_flags(ArtifactDefinition &artifact) const
     }
 
     for (auto &flag : flag_data) {
+        if (!flag.is_string()) {
+            return PARSE_ERROR_INVALID_FLAG;
+        }
         if (!this->grab_one_artifact_flag(artifact, flag.get<std::string>())) {
             return PARSE_ERROR_INVALID_FLAG;
         }

--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -14,6 +14,100 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 
+ArtifactReader::ArtifactReader(nlohmann::json &art_data)
+    : art_data(art_data)
+{
+}
+
+/*!
+ * @brief 固定アーティファクト情報(JSON Object)のパース関数
+ * @param art_data 固定アーティファクトデータの格納されたJSON Object
+ * @return エラーコード
+ */
+int ArtifactReader::read() const
+{
+    if (!this->art_data["id"].is_number_integer()) {
+        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
+    }
+
+    const auto int_id = this->art_data["id"].get<int>();
+    if (int_id < error_idx) {
+        return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+    }
+    const auto artifact_id = i2enum<FixedArtifactId>(int_id);
+
+    error_idx = int_id;
+    ArtifactDefinition artifact;
+    artifact.flags.set(TR_IGNORE_ACID);
+    artifact.flags.set(TR_IGNORE_ELEC);
+    artifact.flags.set(TR_IGNORE_FIRE);
+    artifact.flags.set(TR_IGNORE_COLD);
+
+    if (auto err = info_set_string(this->art_data["name"], artifact.name, true)) {
+        msg_format(_("アーティファクトの名称読込失敗。ID: '%d'。", "Failed to load artifact name. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = this->set_art_baseitem(artifact)) {
+        msg_format(_("アーティファクトのベースアイテム読込失敗。ID: '%d'。", "Failed to load base item of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["parameter_value"], artifact.pval, false, Range(-128, 128))) {
+        msg_format(_("アーティファクトのパラメータ値読込失敗。ID: '%d'。", "Failed to load parameter value of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["level"], artifact.level, true, Range(0, 128))) {
+        msg_format(_("アーティファクトのレベル読込失敗。ID: '%d'。", "Failed to load level of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["rarity"], artifact.rarity, true)) {
+        msg_format(_("アーティファクトの希少度読込失敗。ID: '%d'。", "Failed to load rarity of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["weight"], artifact.weight, true, Range(0, 9999))) {
+        msg_format(_("アーティファクトの重量読込失敗。ID: '%d'。", "Failed to load weight of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["cost"], artifact.cost, true, Range(0, 99999999))) {
+        msg_format(_("アーティファクトの売値読込失敗。ID: '%d'。", "Failed to load cost of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["base_ac"], artifact.ac, false, Range(-99, 99))) {
+        msg_format(_("アーティファクトのベースAC読込失敗。ID: '%d'。", "Failed to load base AC of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_dice(this->art_data["base_dice"], artifact.damage_dice, false)) {
+        msg_format(_("アーティファクトのベースダイス読込失敗。ID: '%d'。", "Failed to load base dice of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["hit_bonus"], artifact.to_h, false, Range(-99, 99))) {
+        msg_format(_("アーティファクトの命中補正値読込失敗。ID: '%d'。", "Failed to load hit bonus of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["damage_bonus"], artifact.to_d, false, Range(-99, 99))) {
+        msg_format(_("アーティファクトの命中補正値読込失敗。ID: '%d'。", "Failed to load damage bonus of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_integer(this->art_data["ac_bonus"], artifact.to_a, false, Range(-99, 99))) {
+        msg_format(_("アーティファクトのAC補正値読込失敗。ID: '%d'。", "Failed to load AC bonus of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = this->set_art_activate(artifact)) {
+        msg_format(_("アーティファクトの発動能力読込失敗。ID: '%d'。", "Failed to load activate ability of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = this->set_art_flags(artifact)) {
+        msg_format(_("アーティファクトの能力フラグ読込失敗。ID: '%d'。", "Failed to load ability flags of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+    if (auto err = info_set_string(this->art_data["flavor"], artifact.text, false)) {
+        msg_format(_("アーティファクトのフレーバーテキスト読込失敗。ID: '%d'。", "Failed to load flavor text of artifact. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    ArtifactList::get_instance().emplace(artifact_id, std::move(artifact));
+    return PARSE_ERROR_NONE;
+}
+
 /*!
  * @brief テキストトークンを走査してフラグを一つ得る(アーティファクト用) /
  * Grab one activation index flag
@@ -21,13 +115,13 @@
  * @param what 参照元の文字列ポインタ
  * @return 見つかったらtrue
  */
-static bool grab_one_artifact_flag(ArtifactDefinition *a_ptr, std::string_view what)
+bool ArtifactReader::grab_one_artifact_flag(ArtifactDefinition &artifact, std::string_view what) const
 {
-    if (TrFlags::grab_one_flag(a_ptr->flags, baseitem_flags, what)) {
+    if (TrFlags::grab_one_flag(artifact.flags, baseitem_flags, what)) {
         return true;
     }
 
-    if (EnumClassFlagGroup<ItemGenerationTraitType>::grab_one_flag(a_ptr->gen_flags, baseitem_geneneration_flags, what)) {
+    if (EnumClassFlagGroup<ItemGenerationTraitType>::grab_one_flag(artifact.gen_flags, baseitem_geneneration_flags, what)) {
         return true;
     }
 
@@ -41,8 +135,9 @@ static bool grab_one_artifact_flag(ArtifactDefinition *a_ptr, std::string_view w
  * @param artifact 保管先のアーティファクト
  * @return エラーコード
  */
-static errr set_art_baseitem(nlohmann::json &baseitem_data, ArtifactDefinition &artifact)
+int ArtifactReader::set_art_baseitem(ArtifactDefinition &artifact) const
 {
+    auto &baseitem_data = this->art_data["base_item"];
     if (baseitem_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -67,8 +162,9 @@ static errr set_art_baseitem(nlohmann::json &baseitem_data, ArtifactDefinition &
  * @param artifact 保管先のアーティファクト
  * @return エラーコード
  */
-static errr set_art_activate(const nlohmann::json &act_data, ArtifactDefinition &artifact)
+int ArtifactReader::set_art_activate(ArtifactDefinition &artifact) const
 {
+    const auto &act_data = this->art_data["activate"];
     if (!act_data.is_string()) {
         return PARSE_ERROR_NONE;
     }
@@ -89,8 +185,9 @@ static errr set_art_activate(const nlohmann::json &act_data, ArtifactDefinition 
  * @param artifact 保管先のアーティファクト
  * @return エラーコード
  */
-static errr set_art_flags(const nlohmann::json &flag_data, ArtifactDefinition &artifact)
+int ArtifactReader::set_art_flags(ArtifactDefinition &artifact) const
 {
+    const auto &flag_data = this->art_data["flags"];
     if (flag_data.is_null()) {
         return PARSE_ERROR_NONE;
     }
@@ -99,98 +196,9 @@ static errr set_art_flags(const nlohmann::json &flag_data, ArtifactDefinition &a
     }
 
     for (auto &flag : flag_data) {
-        if (!grab_one_artifact_flag(&artifact, flag.get<std::string>())) {
+        if (!this->grab_one_artifact_flag(artifact, flag.get<std::string>())) {
             return PARSE_ERROR_INVALID_FLAG;
         }
     }
-    return PARSE_ERROR_NONE;
-}
-
-/*!
- * @brief 固定アーティファクト情報(JSON Object)のパース関数
- * @param art_data 固定アーティファクトデータの格納されたJSON Object
- * @return エラーコード
- */
-int parse_artifacts_info(nlohmann::json &art_data)
-{
-    if (!art_data["id"].is_number_integer()) {
-        return PARSE_ERROR_TOO_FEW_ARGUMENTS;
-    }
-
-    const auto int_id = art_data["id"].get<int>();
-    if (int_id < error_idx) {
-        return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
-    }
-    const auto artifact_id = i2enum<FixedArtifactId>(int_id);
-
-    error_idx = int_id;
-    ArtifactDefinition artifact;
-    artifact.flags.set(TR_IGNORE_ACID);
-    artifact.flags.set(TR_IGNORE_ELEC);
-    artifact.flags.set(TR_IGNORE_FIRE);
-    artifact.flags.set(TR_IGNORE_COLD);
-
-    if (auto err = info_set_string(art_data["name"], artifact.name, true)) {
-        msg_format(_("アーティファクトの名称読込失敗。ID: '%d'。", "Failed to load artifact name. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = set_art_baseitem(art_data["base_item"], artifact)) {
-        msg_format(_("アーティファクトのベースアイテム読込失敗。ID: '%d'。", "Failed to load base item of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["parameter_value"], artifact.pval, false, Range(-128, 128))) {
-        msg_format(_("アーティファクトのパラメータ値読込失敗。ID: '%d'。", "Failed to load parameter value of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["level"], artifact.level, true, Range(0, 128))) {
-        msg_format(_("アーティファクトのレベル読込失敗。ID: '%d'。", "Failed to load level of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["rarity"], artifact.rarity, true)) {
-        msg_format(_("アーティファクトの希少度読込失敗。ID: '%d'。", "Failed to load rarity of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["weight"], artifact.weight, true, Range(0, 9999))) {
-        msg_format(_("アーティファクトの重量読込失敗。ID: '%d'。", "Failed to load weight of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["cost"], artifact.cost, true, Range(0, 99999999))) {
-        msg_format(_("アーティファクトの売値読込失敗。ID: '%d'。", "Failed to load cost of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["base_ac"], artifact.ac, false, Range(-99, 99))) {
-        msg_format(_("アーティファクトのベースAC読込失敗。ID: '%d'。", "Failed to load base AC of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_dice(art_data["base_dice"], artifact.damage_dice, false)) {
-        msg_format(_("アーティファクトのベースダイス読込失敗。ID: '%d'。", "Failed to load base dice of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["hit_bonus"], artifact.to_h, false, Range(-99, 99))) {
-        msg_format(_("アーティファクトの命中補正値読込失敗。ID: '%d'。", "Failed to load hit bonus of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["damage_bonus"], artifact.to_d, false, Range(-99, 99))) {
-        msg_format(_("アーティファクトの命中補正値読込失敗。ID: '%d'。", "Failed to load damage bonus of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_integer(art_data["ac_bonus"], artifact.to_a, false, Range(-99, 99))) {
-        msg_format(_("アーティファクトのAC補正値読込失敗。ID: '%d'。", "Failed to load AC bonus of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = set_art_activate(art_data["activate"], artifact)) {
-        msg_format(_("アーティファクトの発動能力読込失敗。ID: '%d'。", "Failed to load activate ability of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = set_art_flags(art_data["flags"], artifact)) {
-        msg_format(_("アーティファクトの能力フラグ読込失敗。ID: '%d'。", "Failed to load ability flags of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-    if (auto err = info_set_string(art_data["flavor"], artifact.text, false)) {
-        msg_format(_("アーティファクトのフレーバーテキスト読込失敗。ID: '%d'。", "Failed to load flavor text of artifact. ID: '%d'."), error_idx);
-        return err;
-    }
-
-    ArtifactList::get_instance().emplace(artifact_id, std::move(artifact));
     return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/artifact-reader.h
+++ b/src/info-reader/artifact-reader.h
@@ -1,5 +1,25 @@
 #pragma once
 
 #include <nlohmann/json.hpp>
+#include <string_view>
 
-int parse_artifacts_info(nlohmann::json &element);
+class ArtifactDefinition;
+
+class ArtifactReader {
+public:
+    explicit ArtifactReader(nlohmann::json &art_data);
+    ArtifactReader(const ArtifactReader &) = delete;
+    ArtifactReader(ArtifactReader &&) = delete;
+    ArtifactReader &operator=(const ArtifactReader &) = delete;
+    ArtifactReader &operator=(ArtifactReader &&) = delete;
+
+    int read() const;
+
+private:
+    bool grab_one_artifact_flag(ArtifactDefinition &artifact, std::string_view what) const;
+    int set_art_baseitem(ArtifactDefinition &artifact) const;
+    int set_art_activate(ArtifactDefinition &artifact) const;
+    int set_art_flags(ArtifactDefinition &artifact) const;
+
+    nlohmann::json &art_data;
+};

--- a/src/info-reader/artifact-reader.h
+++ b/src/info-reader/artifact-reader.h
@@ -7,7 +7,7 @@ class ArtifactDefinition;
 
 class ArtifactReader {
 public:
-    explicit ArtifactReader(nlohmann::json &art_data);
+    explicit ArtifactReader(const nlohmann::json &art_data);
     ArtifactReader(const ArtifactReader &) = delete;
     ArtifactReader(ArtifactReader &&) = delete;
     ArtifactReader &operator=(const ArtifactReader &) = delete;
@@ -21,5 +21,5 @@ private:
     int set_art_activate(ArtifactDefinition &artifact) const;
     int set_art_flags(ArtifactDefinition &artifact) const;
 
-    nlohmann::json &art_data;
+    const nlohmann::json &art_data;
 };

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -161,7 +161,10 @@ void init_json(std::string_view filename, std::string_view keyname, DefinitionHa
 void init_artifacts_info()
 {
     auto &artifacts = ArtifactList::get_instance();
-    init_json("ArtifactDefinitions.jsonc", "artifacts", DefinitionHashDataType::ARTIFACTS, ArtifactList::get_instance(), parse_artifacts_info);
+    auto parser = [](nlohmann::json &art_data) {
+        return ArtifactReader(art_data).read();
+    };
+    init_json("ArtifactDefinitions.jsonc", "artifacts", DefinitionHashDataType::ARTIFACTS, ArtifactList::get_instance(), parser);
     ArtifactRecords::get_instance().initialize(artifacts.size());
 }
 


### PR DESCRIPTION
artifact-readerのJSON読込処理をArtifactReaderへ移動する。
初期化処理ではReaderオブジェクトを使用する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 固定アーティファクト情報の読み取り処理を専用リーダーへ集約し、初期化フローを整理して責務を明確化しました。
* **Bug Fixes**
  * 欠落値や不正値の安全な扱い、識別子の順序性チェック、フラグと発動設定の厳密な検証を追加し解析の堅牢性を向上。ユーザー向けの挙動やデータ仕様に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->