### PR TITLE
[Refactor] ArtifactDefinition::build_full_name() への差し替え

### DIFF
--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -308,8 +308,8 @@ void build_streamer(PlayerType *player_ptr, FEAT_IDX feat, int chance)
                     if (item.is_fixed_artifact()) {
                         item.set_fixed_artifact_generated(false);
                         if (cheat_peek) {
-                            const auto item_name = describe_flavor(player_ptr, item, (OD_NAME_ONLY | OD_STORE));
-                            msg_format(_("伝説のアイテム (%s) はストリーマーにより削除された。", "Artifact (%s) was deleted by streamer."), item_name.data());
+                            const auto fixed_artifact_name = item.get_fixed_artifact_name();
+                            msg_print(_("伝説のアイテム ({}) はストリーマーにより削除された。", "Artifact ({}) was deleted by streamer."), fixed_artifact_name);
                         }
                     } else if (cheat_peek && item.is_random_artifact()) {
                         msg_print(_("ランダム・アーティファクトの1つはストリーマーにより削除された。", "One of the random artifacts was deleted by streamer."));

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -335,8 +335,8 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
                         item.set_fixed_artifact_generated(false);
 
                         if (in_generate && cheat_peek) {
-                            const auto item_name = describe_flavor(player_ptr, item, (OD_NAME_ONLY | OD_STORE));
-                            msg_format(_("伝説のアイテム (%s) は生成中に*破壊*された。", "Artifact (%s) was *destroyed* during generation."), item_name.data());
+                            const auto fixed_artifact_name = item.get_fixed_artifact_name();
+                            msg_print(_("伝説のアイテム ({}) は生成中に*破壊*された。", "Artifact ({}) was *destroyed* during generation."), fixed_artifact_name);
                         }
                     } else if (in_generate && cheat_peek && item.is_random_artifact()) {
                         msg_print(

--- a/src/system/artifact/artifact-definition.cpp
+++ b/src/system/artifact/artifact-definition.cpp
@@ -46,8 +46,6 @@ bool ArtifactDefinition::is_instant_artifact() const
  * 例1：『ナルサンク』 → ダガー『ナルサンク』
  * 例2：シヴァの化身の → シヴァの化身の軟革ブーツ
  *
- * 「★」の要不要は表示したい箇所によって変わるので、このメソッドでは付けない.
- *
  * English version:
  * If the artifact has the FULL_NAME flag, return it as is.
  * All fixed artifacts with "The", then it starts capital always; there must not be any name starting other than "The", such as "the".
@@ -61,18 +59,19 @@ bool ArtifactDefinition::is_instant_artifact() const
 std::string ArtifactDefinition::build_full_name() const
 {
 #ifdef JP
+    std::string full_name("★");
     if (this->flags.has(tr_type::TR_FULL_NAME)) {
-        return this->name;
+        return full_name.append(this->name);
     }
 
     constexpr auto start = "『";
     const auto is_preposition = this->name.starts_with(start);
     const auto &baseitems = BaseitemList::get_instance();
     if (is_preposition) {
-        return baseitems.lookup_baseitem(this->bi_key).name + this->name;
+        return full_name.append(baseitems.lookup_baseitem(this->bi_key).name).append(this->name);
     }
 
-    return this->name + baseitems.lookup_baseitem(this->bi_key).name;
+    return full_name.append(this->name).append(baseitems.lookup_baseitem(this->bi_key).name);
 #else
     constexpr auto definite_article = "The";
     if (this->flags.has(tr_type::TR_FULL_NAME)) {

--- a/src/system/item/item-entity.cpp
+++ b/src/system/item/item-entity.cpp
@@ -1296,6 +1296,15 @@ bool ItemEntity::has_knowledge(ItemKindType tval) const
            this->is_special();
 }
 
+std::string ItemEntity::get_fixed_artifact_name() const
+{
+    if (this->fa_id == FixedArtifactId::NONE) {
+        return "";
+    }
+
+    return ArtifactList::get_instance().get_artifact(this->fa_id).build_full_name();
+}
+
 std::string ItemEntity::build_timeout_description(const ActivationType &act) const
 {
     const auto description = act.build_timeout_description();

--- a/src/system/item/item-entity.h
+++ b/src/system/item/item-entity.h
@@ -177,6 +177,7 @@ public:
     int get_lite_radius() const;
     Pos2D get_position() const;
     bool has_knowledge(ItemKindType tval) const;
+    std::string get_fixed_artifact_name() const;
 
     void mark_as_known();
     void mark_as_tried() const;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -801,19 +801,13 @@ void wiz_modify_item(PlayerType *player_ptr)
     }
 }
 
-static std::vector<FixedArtifactId> find_wishing_fixed_artifact(PlayerType *player_ptr, std::string_view pray_chars)
+static std::vector<FixedArtifactId> find_wishing_fixed_artifact(std::string_view pray_chars)
 {
     std::vector<FixedArtifactId> fa_ids;
     for (const auto &[fa_id, artifact] : ArtifactList::get_instance()) {
-        ItemEntity item(artifact.bi_key);
-        item.fa_id = fa_id;
-#ifdef JP
-        const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
-#else
-        const auto item_name = str_tolower(describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE)));
-#endif
         std::string art_description = artifact.name;
 #ifdef JP
+        const auto item_name = artifact.build_full_name();
         if (art_description.starts_with("『")) {
             art_description = art_description.substr(2);
             if (art_description.ends_with("』")) {
@@ -825,6 +819,7 @@ static std::vector<FixedArtifactId> find_wishing_fixed_artifact(PlayerType *play
             }
         }
 #else
+        const auto item_name = str_tolower(artifact.build_full_name());
         if (art_description.starts_with('\'')) {
             art_description = art_description.substr(1);
             const auto find_pos = art_description.find('\'');
@@ -840,9 +835,10 @@ static std::vector<FixedArtifactId> find_wishing_fixed_artifact(PlayerType *play
 
         art_description = str_tolower(art_description);
 #endif
-        const std::string match_name(_(item_name.substr(2), item_name));
+        //!< 先頭の「★」(日本語)、「The 」(英語)を除去する.
+        const auto match_name = item_name.substr(_(2, 4));
         if (cheat_xtra) {
-            msg_format("Matching artifact No.%d %s(%s)", enum2i(fa_id), art_description.data(), match_name.data());
+            msg_print("Matching artifact No.{} {}({})", enum2i(fa_id), art_description.data(), match_name.data());
         }
 
         std::vector<std::string> candidates = { match_name, artifact.name, art_description };
@@ -1057,7 +1053,7 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
         }
     }
 
-    const auto wishing_fa_ids = allow_art ? find_wishing_fixed_artifact(player_ptr, pray_chars) : std::vector<FixedArtifactId>{};
+    const auto wishing_fa_ids = allow_art ? find_wishing_fixed_artifact(pray_chars) : std::vector<FixedArtifactId>{};
     if (AngbandWorld::get_instance().wizard && ((wishing_fa_ids.size() > 1) || (ego_ids.size() > 1))) {
         msg_print(_("候補が多すぎる！", "Too many matches!"));
         return WishResultType::FAIL;

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -187,31 +187,17 @@ void wiz_create_item(PlayerType *player_ptr)
     msg_print("Allocated.");
 }
 
-/*!
- * @brief 指定したIDの固定アーティファクトの名称を取得する
- *
- * @param fa_id 固定アーティファクトのID
- * @return 固定アーティファクトの名称(Ex. ★ロング・ソード『リンギル』)を保持する std::string オブジェクト
- */
-static std::string wiz_make_named_artifact_desc(PlayerType *player_ptr, FixedArtifactId fa_id)
-{
-    const auto &artifact = ArtifactList::get_instance().get_artifact(fa_id);
-    ItemEntity item(artifact.bi_key);
-    item.fa_id = fa_id;
-    return describe_flavor(player_ptr, item, OD_NAME_ONLY | OD_STORE);
-}
-
 /**
  * @brief 固定アーティファクトをリストから選択する
  *
  * @param fa_ids 選択する候補となる固定アーティファクトのIDのリスト
  * @return 選択した固定アーティファクトのIDを返す。但しキャンセルした場合は tl::nullopt を返す。
  */
-static tl::optional<FixedArtifactId> wiz_select_named_artifact(PlayerType *player_ptr, const std::vector<FixedArtifactId> &fa_ids)
+static tl::optional<FixedArtifactId> wiz_select_named_artifact(const std::vector<FixedArtifactId> &fa_ids)
 {
     CandidateSelector cs("Which artifact: ", 15);
-
-    auto describe_artifact = [player_ptr](FixedArtifactId fa_id) { return wiz_make_named_artifact_desc(player_ptr, fa_id); };
+    const auto &artifacts = ArtifactList::get_instance();
+    const auto describe_artifact = [&artifacts](auto fa_id) { return artifacts.get_artifact(fa_id).build_full_name(); };
     const auto it = cs.select(fa_ids, describe_artifact);
     return (it != fa_ids.end()) ? tl::make_optional(*it) : tl::nullopt;
 }
@@ -264,8 +250,8 @@ void wiz_create_named_art(PlayerType *player_ptr)
         }
 
         auto fa_ids = wiz_collect_group_fa_ids(group_artifact_list[idx]);
-        std::sort(fa_ids.begin(), fa_ids.end(), [](FixedArtifactId id1, FixedArtifactId id2) { return ArtifactList::get_instance().order(id1, id2); });
-        created_fa_id = wiz_select_named_artifact(player_ptr, fa_ids);
+        std::sort(fa_ids.begin(), fa_ids.end(), [](auto id1, auto id2) { return ArtifactList::get_instance().order(id1, id2); });
+        created_fa_id = wiz_select_named_artifact(fa_ids);
     }
 
     screen_load();


### PR DESCRIPTION
デバッグ実行で固定アーティファクトを生成したり鑑定してみたりしましたが、特に表記上の問題はないように見えます
ご確認下さい
(今回置換した箇所の他にも差し替え可能な箇所があるかもしれません。見かけたら教えて下さい)

describe_flavor() の内、以下の全条件を満たす箇所を掲題のメソッドに差し替えた
NAME_ONLY フラグも固定アーティファクト表記に使われる場合があるが、数が多いので一旦見送った
- OD_STORE フラグがついている
- 周辺コードで固定アーティファクト表記を呼び出している

日本語版で影響範囲を調査した結果、全て先頭の「★」がついていることがロジック維持の上で必須だったので、ArtifactDefinition の方で「★」を付けて返すこととした 不要であればsubstr(2) で除去可能である
英語版も定冠詞として同一の意味を持つ「The」がついており、特別に日英で分ける必要はないと判断した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 固定アーティファクトの表示名に「★」プレフィックスを一貫して付与するようにしました
  * アーティファクトの破壊・削除時などの表示メッセージの文言と出力を更新しました

* **リファクタリング**
  * ウィザードモードの固定アーティファクト選択や表示ロジックを簡素化・整理しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->