### PR TITLE
[Fix] 死亡済み旧セーブデータ読み込み時のクラッシュを修正

### DIFF
--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -81,16 +81,18 @@ auto collect_known_fixed_artifacts_old(PlayerType *player_ptr)
         fa_ids.insert(fa_id);
     }
 
-    const auto &floor = *player_ptr->current_floor_ptr;
-    for (const auto &pos : floor.get_area()) {
-        const auto &grid = floor.get_grid(pos);
-        for (const auto this_o_idx : grid.o_idx_list) {
-            const auto &item = *floor.o_list[this_o_idx];
-            if (!item.is_fixed_artifact() || item.is_known()) {
-                continue;
-            }
+    if (!player_ptr->is_dead) {
+        const auto &floor = *player_ptr->current_floor_ptr;
+        for (const auto &pos : floor.get_area()) {
+            const auto &grid = floor.get_grid(pos);
+            for (const auto this_o_idx : grid.o_idx_list) {
+                const auto &item = *floor.o_list[this_o_idx];
+                if (!item.is_fixed_artifact() || item.is_known()) {
+                    continue;
+                }
 
-            fa_ids.erase(item.fa_id);
+                fa_ids.erase(item.fa_id);
+            }
         }
     }
 


### PR DESCRIPTION
fix #5452

死亡済みキャラクターのセーブデータにはダンジョンのフロアデータが保存されない。
restore_dungeon() は player_ptr->is_dead が true の場合にフロア復元を意図的にスキップするが、SAVEFILE_VERSION 26 未満向けの固定アーティファクト移行処理はその後も player_ptr->current_floor_ptr を辿って床上アイテムを走査していた。

そのため、死亡済みセーブデータの読み込み中に未初期化または無効なフロアデータを参照し、クラッシュする可能性があった。

死亡済みキャラクターでは旧アーティファクト移行時の床上アイテム走査をスキップする。
所持品内の固定アーティファクト確認は従来通り行い、生存中のセーブデータでは既存の床上アイテム走査を維持する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プレイヤー死亡時に固定アーティファクトの既知状態の更新処理を行わないように調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->