### PR TITLE
[Fix] 生きている既知のユニーク一覧で撃破レベル・時間が表示される

### DIFF
--- a/src/knowledge/knowledge-uniques.cpp
+++ b/src/knowledge/knowledge-uniques.cpp
@@ -108,7 +108,7 @@ static void display_uniques(UniqueList *unique_list_ptr, FILE *fff)
     for (auto monrace_id : unique_list_ptr->monrace_ids) {
         const auto &monrace = monraces.get_monrace(monrace_id);
         std::string details;
-        if (monrace.defeat_level && monrace.defeat_time) {
+        if (!unique_list_ptr->is_alive && monrace.defeat_level && monrace.defeat_time) {
             details = format(_(" - レベル%2d - %d:%02d:%02d", " - level %2d - %d:%02d:%02d"), monrace.defeat_level, monrace.defeat_time / (60 * 60),
                 (monrace.defeat_time / 60) % 60, monrace.defeat_time % 60);
         }


### PR DESCRIPTION
ユニークモンスターの撃破レベル・時間はゲームリセット時にクリアされないため、生きている既知のユニーク一覧で前回のゲームまでで最後に撃破した時の撃破レベル・時間が表示されてしまっている。
生きている既知のユニーク一覧表示では撃破レベル・時間は表示しないようにする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ユニーク敵が生存している場合に、撃破情報の詳細表示が不適切に表示される問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->