### PR TITLE
English: correct some misspellings and awkward phrasings

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -65674,7 +65674,7 @@
       "id": 1074,
       "name": {
         "ja": "火の神『祝融』",
-        "en": "Lady Zhurong, the Avater of Flame Spirit",
+        "en": "Lady Zhurong, Avatar of the Flame Spirit",
       },
       "symbol": {
         "character": "p",

--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -3438,10 +3438,10 @@
             ],
             "en": [
               "trampled the wreckage of the Internet Exploder.",
-              "ridiculed when he saw the Internet Exploder.",
+              "scoffed at the Internet Exploder.",
               "is sending sensitive data without your permission.",
               "sent an ad to your email address.",
-              "was attempted to crack by someone, but the protection was not breached.",
+              "was relieved when a cracker could not breach its sandbox.",
               "grasped your propensity.",
             ],
           },

--- a/lib/file/w_low.txt
+++ b/lib/file/w_low.txt
@@ -38,7 +38,7 @@ N: 4:BIAS_COLD
 'Snow Avalanche'
 'Freeze!'
 'Freezing Blade'
-'Icy Clow'
+'Icy Claw'
 'Nimloth'
 'Bigfoot'
 of Liquid Helium
@@ -59,13 +59,13 @@ N: 5:BIAS_ACID
 N:12:BIAS_CHAOS
 'Koch'
 'Julia'
-'Cotortion Blade'
+'Contortion Blade'
 'Protean Edge'
 'cHaOs rEgIoN'
 'Schrodinger'
 'Mandelbrot'
 'Kaleidoscope'
-'Randamizer'
+'Randomizer'
 'Shapechanger'
 of Change
 of Logrus
@@ -103,7 +103,7 @@ of Holy Smoke
 N: 9:BIAS_DEX
 N:16:BIAS_ROGUE
 'Whirlwind'
-'Cat's Clow'
+'Cat's Claw'
 'Sands of Time'
 'Raid'
 'Elusiveness'

--- a/lib/file/w_med.txt
+++ b/lib/file/w_med.txt
@@ -130,7 +130,7 @@ of Soul
 N:16:BIAS_ROGUE
 'Thiefbane'
 'Quylthulg Smasher'
-'Cat's Clow'
+'Cat's Claw'
 'Shinobi'
 'Speed King'
 'Quicker'
@@ -200,7 +200,7 @@ of Marksmanship
 N:*:Default
 'Weapon Alpha'
 'Werebane'
-'Dragon Clow'
+'Dragon Claw'
 'Kraken'
 'Blue Steele'
 'Fury'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

**Bug Fixes**
* キャラクター名の英語表記（「Lady Zhurong, Avatar of the Flame Spirit」）を修正
* ゲーム内メッセージの文言（Internet Exploder 関連）を更新
* 武器名の複数の表記誤りを修正（スペルと名称の綴り、Icy Claw / Contortion Blade / Randomizer / Cat’s Claw / Dragon Claw）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->