### PR TITLE
[Refactor] BaseitemDefinition からBaseitemConfig クラスを分離した

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -324,6 +324,7 @@
     <ClCompile Include="..\..\src\system\artifact\artifact-service.cpp" />
     <ClCompile Include="..\..\src\system\baseitem\baseitem-config.cpp" />
     <ClCompile Include="..\..\src\system\baseitem\baseitem-configs.cpp" />
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-service.cpp" />
     <ClCompile Include="..\..\src\system\dungeon\quest-definition.cpp" />
     <ClCompile Include="..\..\src\system\dungeon\quest-list.cpp" />
     <ClCompile Include="..\..\src\system\floor\town-records.cpp" />
@@ -1059,6 +1060,7 @@
     <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h" />
     <ClInclude Include="..\..\src\system\baseitem\baseitem-config.h" />
     <ClInclude Include="..\..\src\system\baseitem\baseitem-configs.h" />
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-service.h" />
     <ClInclude Include="..\..\src\system\dungeon\quest-definition.h" />
     <ClInclude Include="..\..\src\system\dungeon\quest-list.h" />
     <ClInclude Include="..\..\src\save\artifact-record-writer.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -322,6 +322,8 @@
     <ClCompile Include="..\..\src\system\artifact\artifact-list.cpp" />
     <ClCompile Include="..\..\src\system\artifact\artifact-record.cpp" />
     <ClCompile Include="..\..\src\system\artifact\artifact-service.cpp" />
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-config.cpp" />
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-configs.cpp" />
     <ClCompile Include="..\..\src\system\dungeon\quest-definition.cpp" />
     <ClCompile Include="..\..\src\system\dungeon\quest-list.cpp" />
     <ClCompile Include="..\..\src\system\floor\town-records.cpp" />
@@ -1055,6 +1057,8 @@
     <ClInclude Include="..\..\src\io\temp-file.h" />
     <ClInclude Include="..\..\src\load\artifact-record-loader.h" />
     <ClInclude Include="..\..\src\monster-floor\monster-movement-direction-list.h" />
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-config.h" />
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-configs.h" />
     <ClInclude Include="..\..\src\system\dungeon\quest-definition.h" />
     <ClInclude Include="..\..\src\system\dungeon\quest-list.h" />
     <ClInclude Include="..\..\src\save\artifact-record-writer.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2613,6 +2613,12 @@
     <ClCompile Include="..\..\src\rumor\rumor-service.cpp">
       <Filter>rumor</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-config.cpp">
+      <Filter>system\baseitem</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-configs.cpp">
+      <Filter>system\baseitem</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5660,6 +5666,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\rumor\rumor-rarity.h">
       <Filter>rumor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-config.h">
+      <Filter>system\baseitem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-configs.h">
+      <Filter>system\baseitem</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2619,6 +2619,9 @@
     <ClCompile Include="..\..\src\system\baseitem\baseitem-configs.cpp">
       <Filter>system\baseitem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\system\baseitem\baseitem-service.cpp">
+      <Filter>system\baseitem</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5671,6 +5674,9 @@
       <Filter>system\baseitem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\system\baseitem\baseitem-configs.h">
+      <Filter>system\baseitem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\system\baseitem\baseitem-service.h">
       <Filter>system\baseitem</Filter>
     </ClInclude>
   </ItemGroup>

--- a/lib/edit/BaseitemDefinitions.jsonc
+++ b/lib/edit/BaseitemDefinitions.jsonc
@@ -81,8 +81,8 @@
     {
       "id": 0,
       "name": {
-        "ja": "何",
-        "en": "something",
+        "ja": "異常アイテム",
+        "en": "Invalid item",
       },
       "symbol": {
         "character": "&",

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1284,6 +1284,7 @@ hengband_SOURCES = \
 	system/baseitem/baseitem-definition.cpp system/baseitem/baseitem-definition.h \
 	system/baseitem/baseitem-key.cpp system/baseitem/baseitem-key.h \
 	system/baseitem/baseitem-list.cpp system/baseitem/baseitem-list.h \
+	system/baseitem/baseitem-service.cpp system/baseitem/baseitem-service.h \
 	\
 	system/dungeon/dungeon-data-definition.cpp system/dungeon/dungeon-data-definition.h \
 	system/dungeon/dungeon-definition.cpp system/dungeon/dungeon-definition.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1279,6 +1279,8 @@ hengband_SOURCES = \
 	system/gamevalue.h \
 	\
 	system/baseitem/baseitem-allocation.cpp system/baseitem/baseitem-allocation.h \
+	system/baseitem/baseitem-config.cpp system/baseitem/baseitem-config.h \
+	system/baseitem/baseitem-configs.cpp system/baseitem/baseitem-configs.h \
 	system/baseitem/baseitem-definition.cpp system/baseitem/baseitem-definition.h \
 	system/baseitem/baseitem-key.cpp system/baseitem/baseitem-key.h \
 	system/baseitem/baseitem-list.cpp system/baseitem/baseitem-list.h \

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -165,13 +165,13 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 if (baseitem.flavor == 0) {
                     item_name = baseitem.stripped_name();
                 } else {
-                    ItemEntity dummy(baseitem.idx);
+                    ItemEntity dummy(bi_id);
                     item_name = describe_flavor(player_ptr, dummy, OD_FORCE_FLAVOR);
                 }
 
                 auto_dump_printf(auto_dump_stream, "# %s\n", item_name.data());
                 const auto &config = baseitem_configs.get_config(bi_id);
-                auto_dump_printf(auto_dump_stream, "K:%d:0x%02X/0x%02X\n\n", (int)baseitem.idx, config.get_color(), static_cast<uint8_t>(config.get_character()));
+                auto_dump_printf(auto_dump_stream, "K:%d:0x%02X/0x%02X\n\n", bi_id, config.get_color(), static_cast<uint8_t>(config.get_character()));
                 bi_id++;
             }
 

--- a/src/cmd-visual/cmd-visuals.cpp
+++ b/src/cmd-visual/cmd-visuals.cpp
@@ -13,6 +13,8 @@
 #include "knowledge/knowledge-monsters.h"
 #include "knowledge/lighting-level-table.h"
 #include "main/sound-of-music.h"
+#include "system/baseitem/baseitem-config.h"
+#include "system/baseitem/baseitem-configs.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/item/item-entity.h"
@@ -151,8 +153,11 @@ void do_cmd_visuals(PlayerType *player_ptr)
             }
 
             auto_dump_printf(auto_dump_stream, _("\n# アイテムの[色/文字]の設定\n\n", "\n# Object attr/char definitions\n\n"));
+            const auto &baseitem_configs = BaseitemConfigs::get_instance();
+            short bi_id = 0;
             for (const auto &baseitem : BaseitemList::get_instance()) {
                 if (!baseitem.is_valid()) {
+                    bi_id++;
                     continue;
                 }
 
@@ -165,8 +170,9 @@ void do_cmd_visuals(PlayerType *player_ptr)
                 }
 
                 auto_dump_printf(auto_dump_stream, "# %s\n", item_name.data());
-                const auto &symbol_config = baseitem.symbol_config;
-                auto_dump_printf(auto_dump_stream, "K:%d:0x%02X/0x%02X\n\n", (int)baseitem.idx, symbol_config.color, static_cast<uint8_t>(symbol_config.character));
+                const auto &config = baseitem_configs.get_config(bi_id);
+                auto_dump_printf(auto_dump_stream, "K:%d:0x%02X/0x%02X\n\n", (int)baseitem.idx, config.get_color(), static_cast<uint8_t>(config.get_character()));
+                bi_id++;
             }
 
             close_auto_dump(&auto_dump_stream, mark);
@@ -287,21 +293,22 @@ void do_cmd_visuals(PlayerType *player_ptr)
             static auto choice_msg = _("アイテムの[色/文字]を変更します", "Change object attr/chars");
             static short bi_id = 0;
             prt(format(_("コマンド: %s", "Command: %s"), choice_msg), 15, 0);
-            auto &baseitems = BaseitemList::get_instance();
+            const auto &baseitems = BaseitemList::get_instance();
+            auto &baseitem_configs = BaseitemConfigs::get_instance();
             while (true) {
                 auto &baseitem = baseitems.get_baseitem(bi_id);
                 int c;
-                const auto &symbol_definition = baseitem.symbol_definition;
-                auto &symbol_config = baseitem.symbol_config;
+                const auto &symbol_definition = baseitem.get_symbol();
+                auto &config = baseitem_configs.get_config(bi_id);
                 term_putstr(5, 17, -1, TERM_WHITE,
                     format(
                         _("アイテム = %d, 名前 = %-40.40s", "Object = %d, Name = %-40.40s"), bi_id, (!baseitem.flavor ? baseitem.name : baseitem.flavor_name).data()));
                 term_putstr(10, 19, -1, TERM_WHITE, format(_("初期値  色 / 文字 = %3d / %3d", "Default attr/char = %3d / %3d"), symbol_definition.color, symbol_definition.character));
                 term_putstr(40, 19, -1, TERM_WHITE, empty_symbol);
                 term_queue_bigchar(43, 19, { symbol_definition, {} });
-                term_putstr(10, 20, -1, TERM_WHITE, format(_("現在値  色 / 文字 = %3d / %3d", "Current attr/char = %3d / %3d"), symbol_config.color, symbol_config.character));
+                term_putstr(10, 20, -1, TERM_WHITE, format(_("現在値  色 / 文字 = %3d / %3d", "Current attr/char = %3d / %3d"), config.get_color(), config.get_character()));
                 term_putstr(40, 20, -1, TERM_WHITE, empty_symbol);
-                term_queue_bigchar(43, 20, { symbol_config, {} });
+                term_queue_bigchar(43, 20, { config.get_symbol(), {} });
                 term_putstr(0, 22, -1, TERM_WHITE, _("コマンド (n/N/^N/a/A/^A/c/C/^C/v/V/^V): ", "Command (n/N/^N/a/A/^A/c/C/^C/v/V/^V): "));
 
                 const auto ch = inkey();
@@ -337,22 +344,22 @@ void do_cmd_visuals(PlayerType *player_ptr)
                     break;
                 }
                 case 'a': {
-                    const auto visual_id = input_new_visual_id(ch, symbol_config.color, 256);
+                    const auto visual_id = input_new_visual_id(ch, config.get_color(), 256);
                     if (!visual_id) {
                         break;
                     }
 
-                    baseitem.symbol_config.color = *visual_id;
+                    config.update_color(*visual_id);
                     need_redraw = true;
                     break;
                 }
                 case 'c': {
-                    const auto visual_id = input_new_visual_id(ch, symbol_config.character, 256);
+                    const auto visual_id = input_new_visual_id(ch, config.get_character(), 256);
                     if (!visual_id) {
                         break;
                     }
 
-                    baseitem.symbol_config.character = *visual_id;
+                    config.update_character(*visual_id);
                     need_redraw = true;
                     break;
                 }

--- a/src/core/visuals-reseter.cpp
+++ b/src/core/visuals-reseter.cpp
@@ -1,8 +1,7 @@
 #include "core/visuals-reseter.h"
 #include "game-option/special-options.h"
 #include "io/read-pref-file.h"
-#include "system/baseitem/baseitem-definition.h"
-#include "system/baseitem/baseitem-list.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/monrace/monrace-list.h"
 #include "system/player-type-definition.h"
 #include "system/terrain/terrain-definition.h"
@@ -20,7 +19,7 @@ void reset_visuals(PlayerType *player_ptr)
         }
     }
 
-    BaseitemList::get_instance().reset_all_visuals();
+    BaseitemService::reset_all_visuals();
     MonraceList::get_instance().reset_all_visuals();
     const auto pref_file = use_graphics ? "graf.prf" : "font.prf";
     process_pref_file(player_ptr, pref_file);

--- a/src/info-reader/baseitem-reader.cpp
+++ b/src/info-reader/baseitem-reader.cpp
@@ -65,8 +65,6 @@ int BaseitemReader::read() const
     }
     const short short_id = static_cast<short>(item_id);
     auto &baseitem = baseitems.get_baseitem(short_id);
-    baseitem.idx = short_id;
-
     if (auto err = info_set_string(get_json_value(this->baseitem_data, "name"), baseitem.name, true)) {
         msg_print(_("アイテムの名称読込失敗。ID: '{}'。", "Failed to load item name. ID: '{}'."), error_idx);
         return err;

--- a/src/info-reader/baseitem-reader.cpp
+++ b/src/info-reader/baseitem-reader.cpp
@@ -196,8 +196,8 @@ int BaseitemReader::set_baseitem_symbol(BaseitemDefinition &baseitem) const
     if (color->second > 127) {
         return PARSE_ERROR_GENERIC;
     }
-    baseitem.symbol_definition = DisplaySymbol(color->second, character.front());
 
+    baseitem.init_symbol(DisplaySymbol(color->second, character.front()));
     return PARSE_ERROR_NONE;
 }
 

--- a/src/io/interpret-pref-file.cpp
+++ b/src/io/interpret-pref-file.cpp
@@ -15,6 +15,8 @@
 #include "io/macro-configurations-store.h"
 #include "io/tokenizer.h"
 #include "locale/language-switcher.h"
+#include "system/baseitem/baseitem-config.h"
+#include "system/baseitem/baseitem-configs.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/monrace/monrace-definition.h"
@@ -89,19 +91,19 @@ static bool interpret_k_token(std::string_view buf)
     const auto i = static_cast<short>(std::stoi(tokens[0], nullptr, 0));
     const auto color = static_cast<uint8_t>(std::stoi(tokens[1], nullptr, 0));
     const auto character = static_cast<char>(std::stoi(tokens[2], nullptr, 0));
-    auto &baseitems = BaseitemList::get_instance();
-    if (i >= static_cast<int>(baseitems.size())) {
+    auto &baseitem_configs = BaseitemConfigs::get_instance();
+    if (i >= static_cast<int>(baseitem_configs.size())) {
         return false;
     }
 
     /* Allow TERM_DARK text */
-    auto &baseitem = baseitems.get_baseitem(i);
+    auto &baseitem_config = baseitem_configs.get_config(i);
     if ((color > 0) || (((character & 0x80) == 0) && (character != '\0'))) {
-        baseitem.symbol_config.color = color;
+        baseitem_config.update_color(color);
     }
 
     if (character != '\0') {
-        baseitem.symbol_config.character = character;
+        baseitem_config.update_character(character);
     }
 
     return true;
@@ -233,11 +235,11 @@ static bool interpret_u_token(std::string_view buf)
     for (auto &baseitem : BaseitemList::get_instance()) {
         if (baseitem.is_valid() && (baseitem.bi_key.tval() == tval)) {
             if (color) {
-                baseitem.symbol_definition.color = color;
+                baseitem.init_color(color);
             }
 
             if (character) {
-                baseitem.symbol_definition.character = character;
+                baseitem.init_character(character);
             }
         }
     }

--- a/src/item-info/flavor-initializer.cpp
+++ b/src/item-info/flavor-initializer.cpp
@@ -18,12 +18,13 @@ void initialize_items_flavor()
 {
     auto &system = AngbandSystem::get_instance();
     auto &baseitems = BaseitemList::get_instance();
-    for (auto &baseitem : baseitems) {
+    for (short bi_id = 0; bi_id < static_cast<short>(baseitems.size()); bi_id++) {
+        auto &baseitem = baseitems.get_baseitem(bi_id);
         if (baseitem.flavor_name.empty()) {
             continue;
         }
 
-        baseitem.flavor = baseitem.idx;
+        baseitem.flavor = bi_id;
     }
 
     {

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -19,6 +19,8 @@
 #include "system/artifact/artifact-definition.h"
 #include "system/artifact/artifact-list.h"
 #include "system/artifact/artifact-record.h"
+#include "system/baseitem/baseitem-config.h"
+#include "system/baseitem/baseitem-configs.h"
 #include "system/floor/floor-info.h"
 #include "system/item/item-entity.h"
 #include "system/player-type-definition.h"
@@ -158,28 +160,29 @@ static void display_object_list(int col, int row, int per_page, const std::vecto
 {
     const auto is_wizard = AngbandWorld::get_instance().wizard;
     const auto &baseitems = BaseitemList::get_instance();
+    const auto &baseitem_configs = BaseitemConfigs::get_instance();
     int i;
     for (i = 0; i < per_page && (object_idx[object_top + i] >= 0); i++) {
-        const short bi_id = object_idx[object_top + i];
+        const auto bi_id = object_idx[object_top + i];
         const auto &baseitem = baseitems.get_baseitem(bi_id);
         TERM_COLOR attr = ((baseitem.aware || visual_only) ? TERM_WHITE : TERM_SLATE);
         byte cursor = ((baseitem.aware || visual_only) ? TERM_L_BLUE : TERM_BLUE);
         const auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems.get_baseitem(baseitem.flavor) : baseitem;
+        const auto &flavor_config = !visual_only && baseitem.flavor ? baseitem_configs.get_config(baseitem.flavor) : baseitem_configs.get_config(bi_id);
 
         attr = ((i + object_top == object_cur) ? cursor : attr);
         const auto is_flavor_only = (baseitem.flavor != 0) && (visual_only || !baseitem.aware);
-        const auto o_name = is_flavor_only ? flavor_baseitem.flavor_name : baseitem.stripped_name();
-        c_prt(attr, o_name.data(), row + i, col);
-        const auto &symbol_config = flavor_baseitem.symbol_config;
+        const auto item_name = is_flavor_only ? flavor_baseitem.flavor_name : baseitem.stripped_name();
+        c_prt(attr, item_name.data(), row + i, col);
         if (per_page == 1) {
-            c_prt(attr, format("%02x/%02x", symbol_config.color, symbol_config.character), row + i, (is_wizard || visual_only) ? 64 : 68);
+            c_prt(attr, format("%02x/%02x", flavor_config.get_color(), flavor_config.get_character()), row + i, (is_wizard || visual_only) ? 64 : 68);
         }
 
         if (is_wizard || visual_only) {
             c_prt(attr, format("%d", bi_id), row + i, 70);
         }
 
-        term_queue_bigchar(use_bigtile ? 76 : 77, row + i, { symbol_config, {} });
+        term_queue_bigchar(use_bigtile ? 76 : 77, row + i, { flavor_config.get_symbol(), {} });
     }
 
     for (; i < per_page; i++) {
@@ -241,15 +244,17 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
         object_cnt = 0;
     } else {
         auto &baseitem = baseitems.get_baseitem(direct_k_idx);
-        auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems.get_baseitem(baseitem.flavor) : baseitem;
+        auto &baseitem_configs = BaseitemConfigs::get_instance();
+        auto &flavor_config = !visual_only && baseitem.flavor ? baseitem_configs.get_config(baseitem.flavor) : baseitem_configs.get_config(direct_k_idx);
         object_idx[0] = direct_k_idx;
         object_old = direct_k_idx;
         object_cnt = 1;
         object_idx[1] = -1;
         const auto height = browser_rows - 1;
-        auto &symbol_config = flavor_baseitem.symbol_config;
-        (void)visual_mode_command(
-            'v', &visual_list, height, width, &attr_top, &char_left, &symbol_config.color, &symbol_config.character, need_redraw);
+        auto color = flavor_config.get_color();
+        auto character = flavor_config.get_character();
+        (void)visual_mode_command('v', &visual_list, height, width, &attr_top, &char_left, &color, &character, need_redraw);
+        flavor_config.set_symbol({ color, character });
     }
 
     mode = visual_only ? 0x02 : 0x00;
@@ -334,9 +339,6 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
             display_visual_list(max_length + 3, 7, browser_rows - 1, wid - (max_length + 3), attr_top, char_left);
         }
 
-        auto &baseitem = baseitems.get_baseitem(object_idx[object_cur]);
-        auto &flavor_baseitem = !visual_only && baseitem.flavor ? baseitems.get_baseitem(baseitem.flavor) : baseitem;
-
 #ifdef JP
         prt(format("<方向>%s%s%s, ESC", (!visual_list && !visual_only) ? ", 'r'で詳細を見る" : "", visual_list ? ", ENTERで決定" : ", 'v'でシンボル変更",
                 (symbols_cb.symbol != DisplaySymbol()) ? ", 'c', 'p'でペースト" : ", 'c'でコピー"),
@@ -347,20 +349,25 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
             hgt - 1, 0);
 #endif
 
+        const auto bi_id = object_idx[object_cur];
         if (!visual_only) {
             if (object_cnt) {
-                tracker.set_trackee(object_idx[object_cur]);
+                tracker.set_trackee(bi_id);
             }
 
-            if (object_old != object_idx[object_cur]) {
+            if (object_old != bi_id) {
                 handle_stuff(player_ptr);
-                object_old = object_idx[object_cur];
+                object_old = bi_id;
             }
         }
 
-        auto &symbol_config = flavor_baseitem.symbol_config;
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
+        auto &baseitem_configs = BaseitemConfigs::get_instance();
+        auto &baseitem_config = !visual_only && baseitem.flavor ? baseitem_configs.get_config(baseitem.flavor) : baseitem_configs.get_config(bi_id);
+        auto color = baseitem_config.get_color();
+        auto character = baseitem_config.get_character();
         if (visual_list) {
-            place_visual_list_cursor(max_length + 3, 7, symbol_config.color, symbol_config.character, attr_top, char_left);
+            place_visual_list_cursor(max_length + 3, 7, color, character, attr_top, char_left);
         } else if (!column) {
             term_gotoxy(0, 6 + (grp_cur - grp_top));
         } else {
@@ -369,8 +376,8 @@ void do_cmd_knowledge_objects(PlayerType *player_ptr, bool *need_redraw, bool vi
 
         char ch = inkey();
         const auto height = browser_rows - 1;
-        if (visual_mode_command(
-                ch, &visual_list, height, width, &attr_top, &char_left, &symbol_config.color, &symbol_config.character, need_redraw)) {
+        if (visual_mode_command(ch, &visual_list, height, width, &attr_top, &char_left, &color, &character, need_redraw)) {
+            baseitem_config.set_symbol({ color, character });
             if (direct_k_idx >= 0) {
                 switch (ch) {
                 case '\n':

--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -126,7 +126,9 @@ static short collect_objects(int grp_cur, std::vector<short> &object_idx, BIT_FL
 {
     short object_cnt = 0;
     const auto group_tval = ITEM_KINDS_GROUP[grp_cur];
-    for (const auto &baseitem : BaseitemList::get_instance()) {
+    const auto &baseitems = BaseitemList::get_instance();
+    for (short bi_id = 0; bi_id < static_cast<short>(baseitems.size()); bi_id++) {
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
         if (baseitem.name.empty() || !check_baseitem_chance(mode, baseitem)) {
             continue;
         }
@@ -134,12 +136,12 @@ static short collect_objects(int grp_cur, std::vector<short> &object_idx, BIT_FL
         const auto tval = baseitem.bi_key.tval();
         if (group_tval == ItemKindType::LIFE_BOOK) {
             if (baseitem.bi_key.is_spell_book()) {
-                object_idx[object_cnt++] = baseitem.idx;
+                object_idx[object_cnt++] = bi_id;
             } else {
                 continue;
             }
         } else if (tval == group_tval) {
-            object_idx[object_cnt++] = baseitem.idx;
+            object_idx[object_cnt++] = bi_id;
         } else {
             continue;
         }

--- a/src/main/angband-initializer.cpp
+++ b/src/main/angband-initializer.cpp
@@ -23,6 +23,7 @@
 #include "market/building-initializer.h"
 #include "rumor/rumor-service.h"
 #include "system/angband-system.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/dungeon/quest-list.h"
 #include "system/floor/town-list.h"
 #include "system/monrace/monrace-list.h"
@@ -184,6 +185,7 @@ void init_angband(PlayerType *player_ptr, bool no_term)
 
     init_note(_("[データの初期化中... (アイテム)]", "[Initializing arrays... (objects)]"));
     init_baseitems_info();
+    BaseitemService::initialize_baseitem_configs();
 
     init_note(_("[データの初期化中... (伝説のアイテム)]", "[Initializing arrays... (artifacts)]"));
     init_artifacts_info();

--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -172,7 +172,8 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
     if (item_broken->bi_key.sval() == SV_BROKEN_DAGGER) {
         auto n = 1;
         bi_id = 0;
-        for (const auto &baseitem : baseitems) {
+        for (short tmp_bi_id = 0; tmp_bi_id < static_cast<short>(baseitems.size()); tmp_bi_id++) {
+            const auto &baseitem = baseitems.get_baseitem(tmp_bi_id);
             if (baseitem.bi_key.tval() != ItemKindType::SWORD) {
                 continue;
             }
@@ -187,7 +188,7 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
             }
 
             if (one_in_(n)) {
-                bi_id = baseitem.idx;
+                bi_id = tmp_bi_id;
                 n++;
             }
         }

--- a/src/system/baseitem/baseitem-allocation.cpp
+++ b/src/system/baseitem/baseitem-allocation.cpp
@@ -86,7 +86,8 @@ void BaseitemAllocationTable::initialize()
 
     this->entries = std::vector<BaseitemAllocationEntry>(allocation_size);
     std::array<short, MAX_DEPTH> aux{};
-    for (const auto &baseitem : baseitems) {
+    for (short bi_id = 0; bi_id < static_cast<short>(baseitems.size()); bi_id++) {
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
         for (const auto &[level, chance] : baseitem.alloc_tables) {
             if (chance == 0) {
                 continue;
@@ -96,7 +97,7 @@ void BaseitemAllocationTable::initialize()
             const short p = 100 / chance;
             const auto y = (x > 0) ? num[x - 1] : 0;
             const auto z = y + aux[x];
-            this->entries[z] = BaseitemAllocationEntry(baseitem.idx, x, p, p);
+            this->entries[z] = BaseitemAllocationEntry(bi_id, x, p, p);
             aux[x]++;
         }
     }

--- a/src/system/baseitem/baseitem-config.cpp
+++ b/src/system/baseitem/baseitem-config.cpp
@@ -1,0 +1,46 @@
+#include "system/baseitem/baseitem-config.h"
+
+BaseitemConfig::BaseitemConfig(const DisplaySymbol &ds)
+    : symbol(ds)
+{
+}
+
+bool BaseitemConfig::is_valid() const
+{
+    return (this->symbol.character != '\0') || (this->symbol.color > 0);
+}
+
+DisplaySymbol &BaseitemConfig::get_symbol()
+{
+    return this->symbol;
+}
+
+const DisplaySymbol &BaseitemConfig::get_symbol() const
+{
+    return this->symbol;
+}
+
+char BaseitemConfig::get_character() const
+{
+    return this->symbol.character;
+}
+
+uint8_t BaseitemConfig::get_color() const
+{
+    return this->symbol.color;
+}
+
+void BaseitemConfig::set_symbol(const DisplaySymbol &ds)
+{
+    this->symbol = ds;
+}
+
+void BaseitemConfig::update_character(char character)
+{
+    this->symbol.character = character;
+}
+
+void BaseitemConfig::update_color(uint8_t color)
+{
+    this->symbol.color = color;
+}

--- a/src/system/baseitem/baseitem-config.h
+++ b/src/system/baseitem/baseitem-config.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "view/display-symbol.h"
+
+class BaseitemConfig {
+public:
+    BaseitemConfig(const DisplaySymbol &ds);
+    BaseitemConfig(const BaseitemConfig &) = delete;
+    BaseitemConfig &operator=(const BaseitemConfig &) = delete;
+    BaseitemConfig(BaseitemConfig &&) = default;
+    BaseitemConfig &operator=(BaseitemConfig &&) = delete;
+
+    bool is_valid() const;
+    DisplaySymbol &get_symbol();
+    const DisplaySymbol &get_symbol() const;
+    char get_character() const;
+    uint8_t get_color() const;
+    void set_symbol(const DisplaySymbol &ds);
+    void update_character(char character);
+    void update_color(uint8_t color);
+
+private:
+    DisplaySymbol symbol{};
+};

--- a/src/system/baseitem/baseitem-configs.cpp
+++ b/src/system/baseitem/baseitem-configs.cpp
@@ -1,0 +1,81 @@
+#include "system/baseitem/baseitem-configs.h"
+#include "system/angband-exceptions.h"
+#include "system/baseitem/baseitem-config.h"
+#include "term/z-rand.h"
+#include <fmt/format.h>
+#include <span>
+
+BaseitemConfigs BaseitemConfigs::instance{};
+
+BaseitemConfigs::~BaseitemConfigs() = default;
+
+BaseitemConfigs &BaseitemConfigs::get_instance()
+{
+    return instance;
+}
+
+void BaseitemConfigs::emplace_back(const DisplaySymbol &ds)
+{
+    this->configs.emplace_back(ds);
+}
+
+const BaseitemConfig &BaseitemConfigs::get_config(short bi_id) const
+{
+    this->validate(bi_id);
+    return this->configs.at(bi_id);
+}
+
+BaseitemConfig &BaseitemConfigs::get_config(short bi_id)
+{
+    this->validate(bi_id);
+    return this->configs[bi_id];
+}
+
+/*!
+ * @brief BaseitemConfigをランダムに1つ選ぶ
+ *
+ * 0番はダミーアイテム.
+ * このクラスではベースアイテムの有効無効は分からないので呼び出し元で判定すること.
+ */
+const BaseitemConfig &BaseitemConfigs::pick_one_at_random() const
+{
+    const auto candidates = std::span(this->configs).subspan(1);
+    return rand_choice(candidates);
+}
+
+char BaseitemConfigs::get_character(short bi_id) const
+{
+    if (bi_id == 0) {
+        return '\0';
+    }
+
+    this->validate(bi_id);
+    return this->configs.at(bi_id).get_character();
+}
+
+uint8_t BaseitemConfigs::get_color(short bi_id) const
+{
+    if (bi_id == 0) {
+        return 0;
+    }
+
+    this->validate(bi_id);
+    return this->configs.at(bi_id).get_color();
+}
+
+void BaseitemConfigs::set_config(short bi_id, const DisplaySymbol &ds)
+{
+    if (bi_id == 0) {
+        return;
+    }
+
+    this->validate(bi_id);
+    this->configs[bi_id].set_symbol(ds);
+}
+
+void BaseitemConfigs::validate(short bi_id) const
+{
+    if ((bi_id < 0) || (bi_id >= static_cast<short>(this->size()))) {
+        THROW_EXCEPTION(std::runtime_error, fmt::format("Invalid Baseitem ID: {}", bi_id));
+    }
+}

--- a/src/system/baseitem/baseitem-configs.h
+++ b/src/system/baseitem/baseitem-configs.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "util/abstract-vector-wrapper.h"
+#include <cstdint>
+
+class DisplaySymbol;
+class BaseitemConfig;
+class BaseitemConfigs : public util::AbstractVectorWrapper<BaseitemConfig> {
+public:
+    BaseitemConfigs(const BaseitemConfigs &) = delete;
+    BaseitemConfigs &operator=(BaseitemConfigs &) = delete;
+    BaseitemConfigs(const BaseitemConfigs &&) = delete;
+    BaseitemConfigs &operator=(BaseitemConfigs &&) = delete;
+    ~BaseitemConfigs() override;
+
+    static BaseitemConfigs &get_instance();
+    void emplace_back(const DisplaySymbol &ds);
+
+    const BaseitemConfig &get_config(short bi_id) const;
+    BaseitemConfig &get_config(short bi_id);
+    const BaseitemConfig &pick_one_at_random() const;
+    char get_character(short bi_id) const;
+    uint8_t get_color(short bi_id) const;
+    void set_config(short bi_id, const DisplaySymbol &ds);
+
+private:
+    BaseitemConfigs() = default;
+
+    static BaseitemConfigs instance;
+
+    std::vector<BaseitemConfig> configs;
+
+    void validate(short bi_id) const;
+
+    std::vector<BaseitemConfig> &get_inner_container() override
+    {
+        return this->configs;
+    }
+};

--- a/src/system/baseitem/baseitem-definition.cpp
+++ b/src/system/baseitem/baseitem-definition.cpp
@@ -10,7 +10,6 @@
 BaseitemDefinition::BaseitemDefinition()
     : bi_key(ItemKindType::NONE)
     , symbol_definition(DisplaySymbol(0, '\0'))
-    , symbol_config(DisplaySymbol(0, '\0'))
 {
 }
 
@@ -106,6 +105,26 @@ void BaseitemDefinition::decide_easy_know()
     }
 }
 
+const DisplaySymbol &BaseitemDefinition::get_symbol() const
+{
+    return this->symbol_definition;
+}
+
+void BaseitemDefinition::init_symbol(const DisplaySymbol &ds)
+{
+    this->symbol_definition = ds;
+}
+
+void BaseitemDefinition::init_color(uint8_t color)
+{
+    this->symbol_definition.color = color;
+}
+
+void BaseitemDefinition::init_character(char character)
+{
+    this->symbol_definition.character = character;
+}
+
 /*!
  * @brief 試行状態を変える
  * @param state trueなら試行済、falseなら未試行に変える
@@ -122,9 +141,4 @@ void BaseitemDefinition::mark_trial(bool state)
 void BaseitemDefinition::mark_awareness(bool state)
 {
     this->aware = state;
-}
-
-void BaseitemDefinition::reset_visual()
-{
-    this->symbol_config = this->symbol_definition;
 }

--- a/src/system/baseitem/baseitem-definition.cpp
+++ b/src/system/baseitem/baseitem-definition.cpp
@@ -16,13 +16,13 @@ BaseitemDefinition::BaseitemDefinition()
 /*!
  * @brief 正常なベースアイテムかを判定する
  * @return 正常なベースアイテムか否か
- * @details ID 0は「何か」という異常アイテム
+ * @details ID 0は「異常アイテム」という名前の文字通り異常アイテムであり、個別に弾く
  * その他、ベースアイテムIDは歴史的事情により歯抜けが多数あり、それらは名前が空欄になるようにオブジェクトを生成している
  * @todo v3.1以降で歯抜けを埋めるようにベースアイテムを追加していきたい (詳細未定)
  */
 bool BaseitemDefinition::is_valid() const
 {
-    return !this->name.empty() && (this->name != _("何", "something"));
+    return !this->name.empty() && (this->name != _("異常アイテム", "Invalid item"));
 }
 
 /*!

--- a/src/system/baseitem/baseitem-definition.cpp
+++ b/src/system/baseitem/baseitem-definition.cpp
@@ -22,7 +22,7 @@ BaseitemDefinition::BaseitemDefinition()
  */
 bool BaseitemDefinition::is_valid() const
 {
-    return (this->idx > 0) && !this->name.empty();
+    return !this->name.empty() && (this->name != _("何", "something"));
 }
 
 /*!

--- a/src/system/baseitem/baseitem-definition.h
+++ b/src/system/baseitem/baseitem-definition.h
@@ -25,8 +25,6 @@ public:
     BaseitemDefinition(BaseitemDefinition &&) = default;
     BaseitemDefinition &operator=(BaseitemDefinition &&) = delete;
 
-    short idx{};
-
     std::string name; /*!< ベースアイテム名 */
     std::string text; /*!< 解説テキスト */
     std::string flavor_name; /*!< 未確定名 */

--- a/src/system/baseitem/baseitem-definition.h
+++ b/src/system/baseitem/baseitem-definition.h
@@ -55,7 +55,6 @@ public:
     };
 
     std::array<alloc_table, 4> alloc_tables{}; /*!< ベースアイテムの生成テーブル */
-    DisplaySymbol symbol_definition; //!< 定義上のシンボル (色/文字).
     bool easy_know{}; /*!< ベースアイテムが初期からベース名を判断可能かどうか / This object is always known (if aware) */
     RandomArtActType act_idx{}; /*!< 発動能力のID /  Activative ability index */
 
@@ -64,9 +63,12 @@ public:
     bool order_cost(const BaseitemDefinition &other) const;
     void decide_easy_know();
 
-    /* @todo ここから下はBaseitemDefinitions.txt に依存しないミュータブルなフィールド群なので、将来的に分離予定 */
+    const DisplaySymbol &get_symbol() const;
+    void init_symbol(const DisplaySymbol &ds);
+    void init_color(uint8_t color);
+    void init_character(char character);
 
-    DisplaySymbol symbol_config; //!< ユーザ個別の設定シンボル (色/文字).
+    /* @todo ここから下はBaseitemDefinitions.txt に依存しないミュータブルなフィールド群なので、将来的に分離予定 */
 
     short flavor{}; /*!< 未鑑定名の何番目を当てるか(0は未鑑定名なし) / Special object flavor (or zero) */
     bool aware{}; /*!< ベースアイテムが鑑定済かどうか /  The player is "aware" of the item's effects */
@@ -74,5 +76,7 @@ public:
 
     void mark_trial(bool state);
     void mark_awareness(bool state);
-    void reset_visual();
+
+private:
+    DisplaySymbol symbol_definition; //!< 定義上のシンボル (色/文字).
 };

--- a/src/system/baseitem/baseitem-list.cpp
+++ b/src/system/baseitem/baseitem-list.cpp
@@ -162,10 +162,11 @@ short BaseitemList::exe_lookup(const BaseitemKey &bi_key) const
 const std::map<BaseitemKey, short> &BaseitemList::create_baseitem_keys_cache() const
 {
     static std::map<BaseitemKey, short> cache;
-    for (const auto &baseitem : this->baseitems) {
+    for (short bi_id = 0; bi_id < static_cast<short>(this->baseitems.size()); bi_id++) {
+        const auto &baseitem = this->baseitems.at(bi_id);
         if (baseitem.is_valid()) {
             const auto &bi_key = baseitem.bi_key;
-            cache[bi_key] = baseitem.idx;
+            cache[bi_key] = bi_id;
         }
     }
 

--- a/src/system/baseitem/baseitem-list.cpp
+++ b/src/system/baseitem/baseitem-list.cpp
@@ -33,6 +33,19 @@ BaseitemList &BaseitemList::get_instance()
     return instance;
 }
 
+bool BaseitemList::is_valid(short bi_id) const
+{
+    if (bi_id == 0) {
+        return false;
+    }
+
+    if ((bi_id < 0) || (bi_id >= static_cast<short>(this->baseitems.size()))) {
+        THROW_EXCEPTION(std::logic_error, format(INVALID_BI_ID_FORMAT, bi_id));
+    }
+
+    return this->baseitems.at(bi_id).is_valid();
+}
+
 BaseitemDefinition &BaseitemList::get_baseitem(const short bi_id)
 {
     if ((bi_id < 0) || (bi_id >= static_cast<short>(this->baseitems.size()))) {
@@ -85,13 +98,6 @@ const BaseitemDefinition &BaseitemList::lookup_baseitem(const BaseitemKey &bi_ke
 {
     const auto bi_id = this->lookup_baseitem_id(bi_key);
     return this->baseitems[bi_id];
-}
-
-void BaseitemList::reset_all_visuals()
-{
-    for (auto &baseitem : this->baseitems) {
-        baseitem.reset_visual();
-    }
 }
 
 /*!

--- a/src/system/baseitem/baseitem-list.h
+++ b/src/system/baseitem/baseitem-list.h
@@ -24,6 +24,8 @@ public:
     ~BaseitemList();
 
     static BaseitemList &get_instance();
+
+    bool is_valid(short bi_id) const;
     BaseitemDefinition &get_baseitem(const short bi_id);
     const BaseitemDefinition &get_baseitem(const short bi_id) const;
     const BaseitemDefinition &pick_one_at_random() const;
@@ -31,7 +33,6 @@ public:
     short lookup_baseitem_id(const BaseitemKey &bi_key) const;
     const BaseitemDefinition &lookup_baseitem(const BaseitemKey &bi_key) const;
 
-    void reset_all_visuals();
     void reset_identification_flags();
     void mark_common_items_as_aware();
     void shuffle_flavors();

--- a/src/system/baseitem/baseitem-service.cpp
+++ b/src/system/baseitem/baseitem-service.cpp
@@ -1,0 +1,42 @@
+#include "system/baseitem/baseitem-service.h"
+#include "system/baseitem/baseitem-config.h"
+#include "system/baseitem/baseitem-configs.h"
+#include "system/baseitem/baseitem-definition.h"
+#include "system/baseitem/baseitem-list.h"
+#include "term/z-rand.h"
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/view.hpp>
+
+void BaseitemService::initialize_baseitem_configs()
+{
+    const auto &baseitems = BaseitemList::get_instance();
+    auto &baseitem_configs = BaseitemConfigs::get_instance();
+    const auto range = ranges::views::iota(0) | ranges::views::take(baseitems.size());
+    ranges::for_each(range, [&baseitems, &baseitem_configs](short bi_id) {
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
+        baseitem_configs.emplace_back(baseitem.get_symbol());
+    });
+}
+
+void BaseitemService::reset_all_visuals()
+{
+    const auto &baseitems = BaseitemList::get_instance();
+    auto &baseitem_configs = BaseitemConfigs::get_instance();
+    const auto range = ranges::views::iota(0) | ranges::views::take(baseitems.size());
+    ranges::for_each(range, [&baseitems, &baseitem_configs](short bi_id) {
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
+        baseitem_configs.set_config(bi_id, baseitem.get_symbol());
+    });
+}
+
+const BaseitemConfig &BaseitemService::pick_one_at_random()
+{
+    const auto &baseitems = BaseitemList::get_instance();
+    const auto &baseitem_configs = BaseitemConfigs::get_instance();
+    while (true) {
+        const auto bi_id = randnum1<short>(baseitems.size() - 1); // 0は無効値なので最初から選ばない
+        if (baseitems.is_valid(bi_id)) {
+            return baseitem_configs.get_config(bi_id);
+        }
+    }
+}

--- a/src/system/baseitem/baseitem-service.h
+++ b/src/system/baseitem/baseitem-service.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class BaseitemConfig;
+class BaseitemService {
+public:
+    BaseitemService() = delete;
+
+    static void initialize_baseitem_configs();
+    static void reset_all_visuals();
+    static const BaseitemConfig &pick_one_at_random();
+};

--- a/src/system/item/item-entity.cpp
+++ b/src/system/item/item-entity.cpp
@@ -27,6 +27,8 @@
 #include "system/artifact/artifact-list.h"
 #include "system/artifact/artifact-record.h"
 #include "system/artifact/artifact-service.h"
+#include "system/baseitem/baseitem-config.h"
+#include "system/baseitem/baseitem-configs.h"
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/dungeon/quest-definition.h"
@@ -1627,18 +1629,20 @@ std::string ItemEntity::build_activation_description_dragon_breath() const
  */
 uint8_t ItemEntity::get_color() const
 {
+    const auto &basitem_configs = BaseitemConfigs::get_instance();
     const auto &baseitem = this->get_baseitem();
     const auto flavor = baseitem.flavor;
     if (flavor != 0) {
-        return BaseitemList::get_instance().get_baseitem(flavor).symbol_config.color;
+        return basitem_configs.get_color(flavor);
     }
 
-    const auto &symbol_config = baseitem.symbol_config;
+    const auto &symbol_config = basitem_configs.get_config(this->bi_id);
     auto has_attr = this->is_valid();
     has_attr &= this->is_corpse();
-    has_attr &= symbol_config.color == TERM_DARK;
+    const auto color = symbol_config.get_color();
+    has_attr &= color == TERM_DARK;
     if (!has_attr) {
-        return symbol_config.color;
+        return color;
     }
 
     return this->get_monrace().symbol_config.color;
@@ -1654,7 +1658,8 @@ char ItemEntity::get_character() const
 {
     const auto &baseitem = this->get_baseitem();
     const auto flavor = baseitem.flavor;
-    return flavor ? BaseitemList::get_instance().get_baseitem(flavor).symbol_config.character : baseitem.symbol_config.character;
+    const auto &configs = BaseitemConfigs::get_instance();
+    return flavor > 0 ? configs.get_character(flavor) : configs.get_character(this->bi_id);
 }
 
 /*!

--- a/src/view/display-map.cpp
+++ b/src/view/display-map.cpp
@@ -5,6 +5,8 @@
 #include "game-option/map-screen-options.h"
 #include "game-option/special-options.h"
 #include "player/player-status.h"
+#include "system/baseitem/baseitem-config.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/enums/terrain/terrain-tag.h"
 #include "system/floor/floor-info.h"
 #include "system/grid-type-definition.h"
@@ -39,8 +41,7 @@ const std::string image_monsters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR
 DisplaySymbol image_object()
 {
     if (use_graphics) {
-        const auto &baseitem = BaseitemList::get_instance().pick_one_at_random();
-        return baseitem.symbol_config;
+        return BaseitemService::pick_one_at_random().get_symbol();
     }
 
     const auto color = randnum1<uint8_t>(15);

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -136,12 +136,14 @@ SpoilerOutputResultType spoil_obj_desc()
     ofs << format("%-37s%8s%7s%5s %40s%9s\n", "Description", "Dam/AC", "Wgt", "Lev", "Chance", "Cost");
     ofs << format("%-37s%8s%7s%5s %40s%9s\n", "-------------------------------------", "------", "---", "---", "----------------", "----");
 
+    const auto &baseitems = BaseitemList::get_instance();
     for (const auto &[tval_list, name] : group_item_list) {
         std::vector<short> whats;
         for (auto tval : tval_list) {
-            for (const auto &baseitem : BaseitemList::get_instance()) {
+            for (short bi_id = 0; bi_id < static_cast<short>(baseitems.size()); bi_id++) {
+                const auto &baseitem = baseitems.get_baseitem(bi_id);
                 if ((baseitem.bi_key.tval() == tval) && baseitem.gen_flags.has_not(ItemGenerationTraitType::INSTA_ART)) {
-                    whats.push_back(baseitem.idx);
+                    whats.push_back(bi_id);
                 }
             }
         }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -1002,25 +1002,27 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     std::vector<EgoType> ego_ids;
     if (exam_base) {
         auto max_len = 0;
-        for (const auto &baseitem : BaseitemList::get_instance()) {
+        const auto &baseitems = BaseitemList::get_instance();
+        for (short bi_id = 0; bi_id < static_cast<short>(baseitems.size()); bi_id++) {
+            const auto &baseitem = baseitems.get_baseitem(bi_id);
             if (!baseitem.is_valid()) {
                 continue;
             }
 
-            ItemEntity item(baseitem.idx);
+            ItemEntity item(bi_id);
 #ifdef JP
             const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
 #else
             const auto item_name = str_tolower(describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE)));
 #endif
             if (cheat_xtra) {
-                msg_format("Matching object No.%d %s", baseitem.idx, item_name.data());
+                msg_format("Matching object No.%d %s", bi_id, item_name.data());
             }
 
             const int len = item_name.length();
             if (std::string(pray_chars).find(item_name) != std::string::npos) {
                 if (len > max_len) {
-                    baseitem_ids.push_back(baseitem.idx);
+                    baseitem_ids.push_back(bi_id);
                     max_len = len;
                 }
             }

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -1022,8 +1022,12 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
             const int len = item_name.length();
             if (std::string(pray_chars).find(item_name) != std::string::npos) {
                 if (len > max_len) {
-                    baseitem_ids.push_back(bi_id);
+                    baseitem_ids.clear();
                     max_len = len;
+                }
+
+                if (len == max_len) {
+                    baseitem_ids.push_back(bi_id);
                 }
             }
         }

--- a/src/wizard/wizard-special-process.cpp
+++ b/src/wizard/wizard-special-process.cpp
@@ -112,18 +112,19 @@ static tl::optional<tval_desc> wiz_select_tval()
 static tl::optional<short> wiz_select_sval(const tval_desc &td)
 {
     std::vector<short> bi_ids;
-    for (const auto &baseitem : BaseitemList::get_instance()) {
+    const auto &baseitems = BaseitemList::get_instance();
+    for (short bi_id = 0; bi_id < static_cast<short>(baseitems.size()); bi_id++) {
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
         if (!baseitem.is_valid() || baseitem.bi_key.tval() != td.tval) {
             continue;
         }
 
-        bi_ids.push_back(baseitem.idx);
+        bi_ids.push_back(bi_id);
     }
 
     const auto prompt = format(_("%s群の具体的なアイテムを選んで下さい", "What Kind of %s? "), td.desc);
 
     CandidateSelector cs(prompt, 15);
-    const auto &baseitems = BaseitemList::get_instance();
     const auto choice = cs.select(bi_ids,
         [&baseitems](short bi_id) { return baseitems.get_baseitem(bi_id).stripped_name(); });
     return (choice != bi_ids.end()) ? tl::make_optional(*choice) : tl::nullopt;
@@ -522,9 +523,11 @@ void wiz_jump_to_dungeon(PlayerType *player_ptr)
  */
 void wiz_learn_items_all(PlayerType *player_ptr)
 {
-    for (const auto &baseitem : BaseitemList::get_instance()) {
+    const auto &baseitems = BaseitemList::get_instance();
+    for (short bi_id = 0; bi_id < static_cast<short>(baseitems.size()); bi_id++) {
+        const auto &baseitem = baseitems.get_baseitem(bi_id);
         if (baseitem.is_valid() && baseitem.level <= command_arg) {
-            ItemEntity item(baseitem.idx);
+            ItemEntity item(bi_id);
             object_aware(player_ptr, item);
         }
     }


### PR DESCRIPTION
適当なダンジョンに飛んで同一のアイコンが表示されることをチェックしました
ご確認下さい

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 無効なアイテムIDの表示名を改善

* **その他の改善**
  * アイテム表示設定の管理構造を改善し、システムの安定性と一貫性を向上
<!-- end of auto-generated comment: release notes by coderabbit.ai -->