### PR TITLE
[Fix] 装備がない時の表示がヌル文字になっていたのを元に戻した

### DIFF
--- a/src/knowledge/knowledge-items.cpp
+++ b/src/knowledge/knowledge-items.cpp
@@ -21,6 +21,7 @@
 #include "system/artifact/artifact-record.h"
 #include "system/baseitem/baseitem-config.h"
 #include "system/baseitem/baseitem-configs.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/floor/floor-info.h"
 #include "system/item/item-entity.h"
 #include "system/player-type-definition.h"
@@ -163,6 +164,7 @@ static void display_object_list(int col, int row, int per_page, const std::vecto
     const auto is_wizard = AngbandWorld::get_instance().wizard;
     const auto &baseitems = BaseitemList::get_instance();
     const auto &baseitem_configs = BaseitemConfigs::get_instance();
+    const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     int i;
     for (i = 0; i < per_page && (object_idx[object_top + i] >= 0); i++) {
         const auto bi_id = object_idx[object_top + i];
@@ -184,7 +186,8 @@ static void display_object_list(int col, int row, int per_page, const std::vecto
             c_prt(attr, format("%d", bi_id), row + i, 70);
         }
 
-        term_queue_bigchar(use_bigtile ? 76 : 77, row + i, { flavor_config.get_symbol(), {} });
+        const auto ds = flavor_baseitem.is_valid() ? flavor_config.get_symbol() : empty_symbol;
+        term_queue_bigchar(use_bigtile ? 76 : 77, row + i, { ds, {} });
     }
 
     for (; i < per_page; i++) {

--- a/src/system/baseitem/baseitem-service.cpp
+++ b/src/system/baseitem/baseitem-service.cpp
@@ -4,6 +4,7 @@
 #include "system/baseitem/baseitem-definition.h"
 #include "system/baseitem/baseitem-list.h"
 #include "term/z-rand.h"
+#include "view/display-symbol.h"
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view.hpp>
 
@@ -39,4 +40,10 @@ const BaseitemConfig &BaseitemService::pick_one_at_random()
             return baseitem_configs.get_config(bi_id);
         }
     }
+}
+
+const DisplaySymbol &BaseitemService::get_dummy_symbol()
+{
+    static const auto ds = BaseitemConfigs::get_instance().get_config(0).get_symbol();
+    return ds;
 }

--- a/src/system/baseitem/baseitem-service.h
+++ b/src/system/baseitem/baseitem-service.h
@@ -1,5 +1,6 @@
 #pragma once
 
+class DisplaySymbol;
 class BaseitemConfig;
 class BaseitemService {
 public:
@@ -8,4 +9,5 @@ public:
     static void initialize_baseitem_configs();
     static void reset_all_visuals();
     static const BaseitemConfig &pick_one_at_random();
+    static const DisplaySymbol &get_dummy_symbol();
 };

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -24,6 +24,7 @@
 #include "player/player-status-table.h"
 #include "player/player-status.h"
 #include "spell/spells-execution.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/enums/monrace/monrace-id.h"
 #include "system/enums/terrain/terrain-tag.h"
 #include "system/floor/floor-info.h"
@@ -307,6 +308,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
     }
 
     const auto &[wid, hgt] = term_get_size();
+    const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     byte attr = TERM_WHITE;
     for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
         int cur_row = i - INVEN_MAIN_HAND;
@@ -344,7 +346,8 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
         }
 
         if (show_item_graph) {
-            term_queue_bigchar(cur_col, cur_row, { item.get_symbol(), {} });
+            const auto ds = item.is_valid() ? item.get_symbol() : empty_symbol;
+            term_queue_bigchar(cur_col, cur_row, { ds, {} });
             if (use_bigtile) {
                 cur_col++;
             }

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -11,6 +11,7 @@
 #include "object/item-use-flags.h"
 #include "object/object-info.h"
 #include "player/player-status-flags.h"
+#include "system/baseitem/baseitem-service.h"
 #include "system/item/item-entity.h"
 #include "system/player-type-definition.h"
 #include "term/gameterm.h"
@@ -87,6 +88,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
 
     col = (len > wid - _(6, 4)) ? 0 : (wid - len - 1);
     const auto equip_label = prepare_label_string(player_ptr, USE_EQUIP, item_tester);
+    const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     for (j = 0; j < k; j++) {
         i = out_index[j];
         const auto &item = *player_ptr->inventory[i];
@@ -108,7 +110,8 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
         put_str(head, j + 1, col);
         int cur_col = col + 3;
         if (show_item_graph) {
-            term_queue_bigchar(cur_col, j + 1, { item.get_symbol(), {} });
+            const auto ds = item.is_valid() ? item.get_symbol() : empty_symbol;
+            term_queue_bigchar(cur_col, j + 1, { ds, {} });
             if (use_bigtile) {
                 cur_col++;
             }


### PR DESCRIPTION
表示側でのシンボルを変更しました
ご確認下さい

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- ## バグ修正
  - 装備の未選択／無効状態で表示される記号を改善しました。無効なフレーバー参照や無効なアイテムでも、描画キューに渡す記号を適切な空（ダミー）シンボルに切り替え、表示の不整合や違和感を防ぎます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->