### PR TITLE
[Refactor] アイテムスロット範囲をEnumRangeで処理する

### DIFF
--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -162,8 +162,8 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         (void)lite_area(player_ptr, Dice::roll(2, (lvl / 2)), (lvl / 10) + 1);
         return true;
     case PlayerMutationType::DET_CURSE:
-        for (const auto i : INVEN_ALL_SLOTS) {
-            auto *o_ptr = player_ptr->inventory[i].get();
+        for (const auto i_idx : INVEN_ALL_SLOTS) {
+            auto *o_ptr = player_ptr->inventory[i_idx].get();
             if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
                 continue;
             }

--- a/src/action/mutation-execution.cpp
+++ b/src/action/mutation-execution.cpp
@@ -162,7 +162,7 @@ bool exe_mutation_power(PlayerType *player_ptr, PlayerMutationType power)
         (void)lite_area(player_ptr, Dice::roll(2, (lvl / 2)), (lvl / 10) + 1);
         return true;
     case PlayerMutationType::DET_CURSE:
-        for (int i = 0; i < INVEN_TOTAL; i++) {
+        for (const auto i : INVEN_ALL_SLOTS) {
             auto *o_ptr = player_ptr->inventory[i].get();
             if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
                 continue;

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -362,7 +362,7 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
         return true;
     }
 
-    for (int j = 0; j < INVEN_PACK; j++) {
+    for (const auto j : INVEN_PACK_SLOTS) {
         /*
          * 'Collecting' means the item must be absorbed
          * into an inventory slot.

--- a/src/autopick/autopick-matcher.cpp
+++ b/src/autopick/autopick-matcher.cpp
@@ -362,13 +362,13 @@ bool is_autopick_match(PlayerType *player_ptr, const ItemEntity *o_ptr, const au
         return true;
     }
 
-    for (const auto j : INVEN_PACK_SLOTS) {
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
         /*
          * 'Collecting' means the item must be absorbed
          * into an inventory slot.
          * But an item can not be absorbed into itself!
          */
-        if ((player_ptr->inventory[j].get() != o_ptr) && player_ptr->inventory[j]->is_similar(*o_ptr)) {
+        if ((player_ptr->inventory[i_idx].get() != o_ptr) && player_ptr->inventory[i_idx]->is_similar(*o_ptr)) {
             return true;
         }
     }

--- a/src/autopick/autopick.cpp
+++ b/src/autopick/autopick.cpp
@@ -33,6 +33,7 @@
 #include "term/screen-processor.h"
 #include "view/display-messages.h"
 #include "window/display-sub-windows.h"
+#include <range/v3/view.hpp>
 #include <sstream>
 
 /*!
@@ -64,7 +65,7 @@ static void autopick_delayed_alter_aux(PlayerType *player_ptr, INVENTORY_IDX i_i
  */
 void autopick_delayed_alter(PlayerType *player_ptr)
 {
-    for (INVENTORY_IDX i_idx = INVEN_TOTAL - 1; i_idx >= 0; i_idx--) {
+    for (const auto i_idx : INVEN_ALL_SLOTS | ranges::views::reverse) {
         autopick_delayed_alter_aux(player_ptr, i_idx);
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -57,7 +57,7 @@ void player_wipe_without_name(PlayerType *player_ptr)
     QuestList::get_instance().reset_all();
     player_ptr->inven_cnt = 0;
     player_ptr->equip_cnt = 0;
-    for (int i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         player_ptr->inventory[i]->wipe();
     }
 

--- a/src/birth/game-play-initializer.cpp
+++ b/src/birth/game-play-initializer.cpp
@@ -57,8 +57,8 @@ void player_wipe_without_name(PlayerType *player_ptr)
     QuestList::get_instance().reset_all();
     player_ptr->inven_cnt = 0;
     player_ptr->equip_cnt = 0;
-    for (const auto i : INVEN_ALL_SLOTS) {
-        player_ptr->inventory[i]->wipe();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        player_ptr->inventory[i_idx]->wipe();
     }
 
     ArtifactRecords::get_instance().reset_all_without_knowledge();

--- a/src/birth/inventory-initializer.cpp
+++ b/src/birth/inventory-initializer.cpp
@@ -26,6 +26,7 @@
 #include "sv-definition/sv-weapon-types.h"
 #include "system/baseitem/baseitem-list.h"
 #include "system/item/item-entity.h"
+#include <range/v3/view.hpp>
 #include <tuple>
 
 /*!
@@ -33,7 +34,7 @@
  */
 void wield_all(PlayerType *player_ptr)
 {
-    for (INVENTORY_IDX i_idx = INVEN_PACK - 1; i_idx >= 0; i_idx--) {
+    for (const auto i_idx : INVEN_PACK_SLOTS | ranges::views::reverse) {
         const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -304,7 +304,7 @@ void do_cmd_bash(PlayerType *player_ptr)
  */
 static bool get_spike(PlayerType *player_ptr, INVENTORY_IDX *ip)
 {
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/cmd-action/cmd-open-close.cpp
+++ b/src/cmd-action/cmd-open-close.cpp
@@ -304,14 +304,14 @@ void do_cmd_bash(PlayerType *player_ptr)
  */
 static bool get_spike(PlayerType *player_ptr, INVENTORY_IDX *ip)
 {
-    for (const auto i : INVEN_PACK_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         if (o_ptr->bi_key.tval() == ItemKindType::SPIKE) {
-            *ip = i;
+            *ip = i_idx;
             return true;
         }
     }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -278,8 +278,8 @@ static void preserve_info(PlayerType *player_ptr)
         delete_monster_idx(player_ptr, i);
     }
 
-    for (const auto i : INVEN_PACK_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/floor/floor-leaver.cpp
+++ b/src/floor/floor-leaver.cpp
@@ -278,7 +278,7 @@ static void preserve_info(PlayerType *player_ptr)
         delete_monster_idx(player_ptr, i);
     }
 
-    for (short i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -213,8 +213,8 @@ void regenerate_monsters(PlayerType *player_ptr)
 void regenerate_captured_monsters(PlayerType *player_ptr)
 {
     bool heal = false;
-    for (const auto i : INVEN_ALL_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/hpmp/hp-mp-regenerator.cpp
+++ b/src/hpmp/hp-mp-regenerator.cpp
@@ -213,7 +213,7 @@ void regenerate_monsters(PlayerType *player_ptr)
 void regenerate_captured_monsters(PlayerType *player_ptr)
 {
     bool heal = false;
-    for (int i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -176,8 +176,8 @@ static void test_inventory_floor(PlayerType *player_ptr, FloorItemSelection *fis
         return;
     }
 
-    for (const auto i : INVEN_PACK_SLOTS) {
-        if (item_tester.okay(player_ptr->inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        if (item_tester.okay(player_ptr->inventory[i_idx].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_inven++;
         }
     }
@@ -199,9 +199,9 @@ static void test_equipment_floor(PlayerType *player_ptr, FloorItemSelection *fis
         return;
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        if (player_ptr->select_ring_slot ? is_ring_slot(i)
-                                         : item_tester.okay(player_ptr->inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        if (player_ptr->select_ring_slot ? is_ring_slot(i_idx)
+                                         : item_tester.okay(player_ptr->inventory[i_idx].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_equip++;
         }
     }

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -114,7 +114,8 @@ static std::pair<tl::optional<short>, char> get_floor_item_tag_inventory(PlayerT
  */
 static std::pair<tl::optional<short>, char> check_floor_item_tag_inventory(PlayerType *player_ptr, FloorItemSelection &fis, short i_idx, char prev_tag, const ItemTester &item_tester)
 {
-    if ((!fis.inven || (i_idx < 0) || (i_idx >= INVEN_PACK)) && (!fis.equip || (i_idx < INVEN_MAIN_HAND) || (i_idx >= INVEN_TOTAL))) {
+    const auto slot = i2enum<inventory_slot_type>(i_idx);
+    if ((!fis.inven || !INVEN_PACK_SLOTS.contains(slot)) && (!fis.equip || !INVEN_WIELDING_SLOTS.contains(slot))) {
         return { tl::nullopt, prev_tag };
     }
 

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -198,7 +198,7 @@ static void test_equipment_floor(PlayerType *player_ptr, FloorItemSelection *fis
         return;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         if (player_ptr->select_ring_slot ? is_ring_slot(i)
                                          : item_tester.okay(player_ptr->inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_equip++;

--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -175,7 +175,7 @@ static void test_inventory_floor(PlayerType *player_ptr, FloorItemSelection *fis
         return;
     }
 
-    for (int i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         if (item_tester.okay(player_ptr->inventory[i].get()) || (fis_ptr->mode & USE_FULL)) {
             fis_ptr->max_inven++;
         }

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -169,15 +169,15 @@ ItemEntity *choose_cursed_obj_name(PlayerType *player_ptr, CurseTraitType flag)
         return nullptr;
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (o_ptr->curse_flags.has(flag)) {
-            choices[number] = i;
+            choices[number] = i_idx;
             number++;
             continue;
         }
 
-        choise_cursed_item(flag, o_ptr, choices, &number, i);
+        choise_cursed_item(flag, o_ptr, choices, &number, i_idx);
     }
 
     return player_ptr->inventory[choices[randint0(number)]].get();
@@ -194,8 +194,8 @@ static void curse_teleport(PlayerType *player_ptr)
     }
 
     int i_keep = 0, count = 0;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -212,7 +212,7 @@ static void curse_teleport(PlayerType *player_ptr)
 
         count++;
         if (one_in_(count)) {
-            i_keep = i;
+            i_keep = i_idx;
         }
     }
 

--- a/src/inventory/inventory-curse.cpp
+++ b/src/inventory/inventory-curse.cpp
@@ -169,7 +169,7 @@ ItemEntity *choose_cursed_obj_name(PlayerType *player_ptr, CurseTraitType flag)
         return nullptr;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (o_ptr->curse_flags.has(flag)) {
             choices[number] = i;
@@ -194,7 +194,7 @@ static void curse_teleport(PlayerType *player_ptr)
     }
 
     int i_keep = 0, count = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -33,7 +33,7 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
     }
 
     /* Scan through the slots backwards */
-    for (short i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;

--- a/src/inventory/inventory-damage.cpp
+++ b/src/inventory/inventory-damage.cpp
@@ -33,8 +33,8 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
     }
 
     /* Scan through the slots backwards */
-    for (const auto i : INVEN_PACK_SLOTS) {
-        auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -65,9 +65,9 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
 
         msg_format(_("%s(%c)が%s壊れてしまった！", "%sour %s (%c) %s destroyed!"),
 #ifdef JP
-            item_name.data(), index_to_label(i), ((item.number > 1) ? ((amt == item.number) ? "全部" : (amt > 1 ? "何個か" : "一個")) : ""));
+            item_name.data(), index_to_label(i_idx), ((item.number > 1) ? ((amt == item.number) ? "全部" : (amt > 1 ? "何個か" : "一個")) : ""));
 #else
-            ((item.number > 1) ? ((amt == item.number) ? "All of y" : (amt > 1 ? "Some of y" : "One of y")) : "Y"), item_name.data(), index_to_label(i),
+            ((item.number > 1) ? ((amt == item.number) ? "All of y" : (amt > 1 ? "Some of y" : "One of y")) : "Y"), item_name.data(), index_to_label(i_idx),
             ((amt > 1) ? "were" : "was"));
 #endif
 
@@ -92,7 +92,7 @@ void inventory_damage(PlayerType *player_ptr, const ObjectBreaker &breaker, int 
         reduce_charges(&item, amt);
 
         /* Destroy "amt" items */
-        inven_item_increase(player_ptr, i, -amt);
-        inven_item_optimize(player_ptr, i);
+        inven_item_increase(player_ptr, i_idx, -amt);
+        inven_item_optimize(player_ptr, i_idx);
     }
 }

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -276,18 +276,18 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::PLAYER,
     };
-    for (const auto j : INVEN_PACK_SLOTS) {
-        j_ptr = player_ptr->inventory[j].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        j_ptr = player_ptr->inventory[i_idx].get();
         if (!j_ptr->is_valid()) {
             continue;
         }
 
-        n = enum2i(j);
+        n = enum2i(i_idx);
         if (j_ptr->is_similar(*o_ptr)) {
             j_ptr->absorb(*o_ptr);
             rfu.set_flag(StatusRecalculatingFlag::BONUS);
             rfu.set_flags(flags_swrf);
-            return enum2i(j);
+            return enum2i(i_idx);
         }
     }
 
@@ -343,8 +343,8 @@ bool check_store_item_to_inventory(PlayerType *player_ptr, const ItemEntity *o_p
         return true;
     }
 
-    for (const auto j : INVEN_PACK_SLOTS) {
-        auto *j_ptr = player_ptr->inventory[j].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto *j_ptr = player_ptr->inventory[i_idx].get();
         if (!j_ptr->is_valid()) {
             continue;
         }

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -17,6 +17,7 @@
 #include "view/display-messages.h"
 #include "view/object-describer.h"
 #include <algorithm>
+#include <range/v3/algorithm.hpp>
 
 void vary_item(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBER num)
 {
@@ -266,7 +267,7 @@ void reorder_pack(PlayerType *player_ptr)
  */
 int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
 {
-    INVENTORY_IDX i, j;
+    INVENTORY_IDX i;
     INVENTORY_IDX n = -1;
 
     ItemEntity *j_ptr;
@@ -275,18 +276,18 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
         SubWindowRedrawingFlag::INVENTORY,
         SubWindowRedrawingFlag::PLAYER,
     };
-    for (j = 0; j < INVEN_PACK; j++) {
+    for (const auto j : INVEN_PACK_SLOTS) {
         j_ptr = player_ptr->inventory[j].get();
         if (!j_ptr->is_valid()) {
             continue;
         }
 
-        n = j;
+        n = enum2i(j);
         if (j_ptr->is_similar(*o_ptr)) {
             j_ptr->absorb(*o_ptr);
             rfu.set_flag(StatusRecalculatingFlag::BONUS);
             rfu.set_flags(flags_swrf);
-            return j;
+            return enum2i(j);
         }
     }
 
@@ -294,6 +295,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
         return -1;
     }
 
+    INVENTORY_IDX j;
     for (j = 0; j <= INVEN_PACK; j++) {
         j_ptr = player_ptr->inventory[j].get();
         if (!j_ptr->is_valid()) {
@@ -303,13 +305,10 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
 
     i = j;
     if (i < INVEN_PACK && n >= 0) {
-        for (j = 0; j < INVEN_PACK; j++) {
-            if (object_sort_comp(player_ptr, *o_ptr, *player_ptr->inventory[j])) {
-                break;
-            }
-        }
-
-        i = j;
+        const auto sort_it = ranges::find_if(INVEN_PACK_SLOTS, [&](const auto s) {
+            return object_sort_comp(player_ptr, *o_ptr, *player_ptr->inventory[s]);
+        });
+        i = enum2i(sort_it != INVEN_PACK_SLOTS.end() ? *sort_it : INVEN_PACK);
         auto begin = player_ptr->inventory.begin();
         std::rotate(begin + i, begin + n + 1, begin + n + 2);
     }
@@ -344,7 +343,7 @@ bool check_store_item_to_inventory(PlayerType *player_ptr, const ItemEntity *o_p
         return true;
     }
 
-    for (int j = 0; j < INVEN_PACK; j++) {
+    for (const auto j : INVEN_PACK_SLOTS) {
         auto *j_ptr = player_ptr->inventory[j].get();
         if (!j_ptr->is_valid()) {
             continue;

--- a/src/inventory/inventory-slot-types.h
+++ b/src/inventory/inventory-slot-types.h
@@ -22,5 +22,14 @@ enum inventory_slot_type : short {
     INVEN_FORCE = 1111, /*!< inventory_list slot for selecting force (hard-coded). */
 };
 
+/*!
+ * 所持品スロットの範囲
+ * @note 0-22番を使用。INVEN_PACK(23番)のスロットは特殊な用途で使用される
+ */
+constexpr auto INVEN_PACK_SLOTS = EnumRange(static_cast<inventory_slot_type>(0), INVEN_PACK);
+
 /** 装備スロットの範囲  */
 constexpr auto INVEN_WIELDING_SLOTS = EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_FEET);
+
+/** 所持品と装備を合わせた全スロットの範囲  */
+constexpr auto INVEN_ALL_SLOTS = EnumRange(static_cast<inventory_slot_type>(0), INVEN_TOTAL);

--- a/src/inventory/inventory-slot-types.h
+++ b/src/inventory/inventory-slot-types.h
@@ -31,5 +31,8 @@ constexpr auto INVEN_PACK_SLOTS = EnumRange(static_cast<inventory_slot_type>(0),
 /** 装備スロットの範囲  */
 constexpr auto INVEN_WIELDING_SLOTS = EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_FEET);
 
+/** 装備スロットのうち、武器(近接・遠隔)スロットの範囲 */
+constexpr auto INVEN_WEAPON_SLOTS = EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW);
+
 /** 所持品と装備を合わせた全スロットの範囲  */
 constexpr auto INVEN_ALL_SLOTS = EnumRange(static_cast<inventory_slot_type>(0), INVEN_TOTAL);

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -65,13 +65,13 @@ tl::optional<short> get_tag_floor(const FloorType &floor, char tag, const std::v
     return floor_item_indice;
 }
 
-static tl::optional<std::pair<short, short>> get_inventory_range(BIT_FLAGS mode)
+static tl::optional<EnumRange<inventory_slot_type>> get_inventory_range(BIT_FLAGS mode)
 {
     switch (mode) {
     case USE_EQUIP:
-        return std::make_pair(INVEN_MAIN_HAND, INVEN_TOTAL);
+        return INVEN_WIELDING_SLOTS.to_enum_range();
     case USE_INVEN:
-        return std::make_pair(static_cast<short>(0), INVEN_PACK);
+        return INVEN_PACK_SLOTS;
     default:
         return tl::nullopt;
     }
@@ -99,9 +99,8 @@ tl::optional<short> get_tag(PlayerType *player_ptr, char tag, BIT_FLAGS mode, co
         return tl::nullopt;
     }
 
-    const auto &[start, end] = *range;
     tl::optional<short> i_idx;
-    for (auto i = start; i < end; i++) {
+    for (const auto i : *range) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;
@@ -136,7 +135,7 @@ tl::optional<short> get_tag(PlayerType *player_ptr, char tag, BIT_FLAGS mode, co
  */
 bool get_item_okay(PlayerType *player_ptr, OBJECT_IDX i, const ItemTester &item_tester)
 {
-    if ((i < 0) || (i >= INVEN_TOTAL)) {
+    if (!INVEN_ALL_SLOTS.contains(i2enum<inventory_slot_type>(i))) {
         return false;
     }
 
@@ -194,7 +193,7 @@ INVENTORY_IDX label_to_equipment(PlayerType *player_ptr, int c)
 {
     INVENTORY_IDX i = (INVENTORY_IDX)(islower(c) ? A2I(c) : -1) + INVEN_MAIN_HAND;
 
-    if ((i < INVEN_MAIN_HAND) || (i >= INVEN_TOTAL)) {
+    if (!INVEN_WIELDING_SLOTS.contains(i2enum<inventory_slot_type>(i))) {
         return -1;
     }
 
@@ -221,7 +220,7 @@ INVENTORY_IDX label_to_inventory(PlayerType *player_ptr, int c)
 {
     INVENTORY_IDX i = (INVENTORY_IDX)(islower(c) ? A2I(c) : -1);
 
-    if ((i < 0) || (i > INVEN_PACK) || !player_ptr->inventory[i]->is_valid()) {
+    if (!INVEN_PACK_SLOTS.contains(i2enum<inventory_slot_type>(i)) || !player_ptr->inventory[i]->is_valid()) {
         return -1;
     }
 

--- a/src/inventory/inventory-util.cpp
+++ b/src/inventory/inventory-util.cpp
@@ -99,9 +99,9 @@ tl::optional<short> get_tag(PlayerType *player_ptr, char tag, BIT_FLAGS mode, co
         return tl::nullopt;
     }
 
-    tl::optional<short> i_idx;
-    for (const auto i : *range) {
-        const auto &item = *player_ptr->inventory[i];
+    tl::optional<short> result;
+    for (const auto i_idx : *range) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;
         }
@@ -113,18 +113,18 @@ tl::optional<short> get_tag(PlayerType *player_ptr, char tag, BIT_FLAGS mode, co
         auto sv = extract_suffix(*item.inscription, '@');
         while (sv) {
             if ((sv->length() > 2) && (sv->at(1) == command_cmd) && (sv->at(2) == tag)) {
-                return i;
+                return i_idx;
             }
 
-            if (!i_idx && is_numeric(tag) && (sv->length() > 1) && (sv->at(1) == tag)) {
-                i_idx = i;
+            if (!result && is_numeric(tag) && (sv->length() > 1) && (sv->at(1) == tag)) {
+                result = i_idx;
             }
 
             sv = extract_suffix(sv->substr(1), '@');
         }
     }
 
-    return i_idx;
+    return result;
 }
 
 /*!

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -49,8 +49,8 @@
  */
 bool can_get_item(PlayerType *player_ptr, const ItemTester &item_tester)
 {
-    for (const auto j : INVEN_ALL_SLOTS) {
-        if (item_tester.okay(player_ptr->inventory[j].get())) {
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        if (item_tester.okay(player_ptr->inventory[i_idx].get())) {
             return true;
         }
     }

--- a/src/inventory/player-inventory.cpp
+++ b/src/inventory/player-inventory.cpp
@@ -49,7 +49,7 @@
  */
 bool can_get_item(PlayerType *player_ptr, const ItemTester &item_tester)
 {
-    for (int j = 0; j < INVEN_TOTAL; j++) {
+    for (const auto j : INVEN_ALL_SLOTS) {
         if (item_tester.okay(player_ptr->inventory[j].get())) {
             return true;
         }

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -80,7 +80,7 @@ void recharge_magic_items(PlayerType *player_ptr)
      * one per turn. -LM-
      */
     changed = false;
-    for (int i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -53,8 +53,8 @@ static void recharged_notice(PlayerType *player_ptr, const ItemEntity &item)
 void recharge_magic_items(PlayerType *player_ptr)
 {
     bool changed = false;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -80,8 +80,8 @@ void recharge_magic_items(PlayerType *player_ptr)
      * one per turn. -LM-
      */
     changed = false;
-    for (const auto i : INVEN_PACK_SLOTS) {
-        auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/inventory/recharge-processor.cpp
+++ b/src/inventory/recharge-processor.cpp
@@ -52,10 +52,8 @@ static void recharged_notice(PlayerType *player_ptr, const ItemEntity &item)
  */
 void recharge_magic_items(PlayerType *player_ptr)
 {
-    int i;
-    bool changed;
-
-    for (changed = false, i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    bool changed = false;
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
@@ -81,7 +79,8 @@ void recharge_magic_items(PlayerType *player_ptr)
      * and each charging rod in a stack decreases the stack's timeout by
      * one per turn. -LM-
      */
-    for (changed = false, i = 0; i < INVEN_PACK; i++) {
+    changed = false;
+    for (int i = 0; i < INVEN_PACK; i++) {
         auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -511,7 +511,7 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
     }
 
     fmt::println(fff, _("  [キャラクタの持ち物]\n", "  [Character Inventory]\n"));
-    for (auto i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         if (!player_ptr->inventory[i]->is_valid()) {
             break;
         }

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -496,7 +496,7 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
 {
     if (player_ptr->equip_cnt) {
         fmt::println(fff, _("  [キャラクタの装備]\n", "  [Character Equipment]\n"));
-        for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        for (const auto i : INVEN_WIELDING_SLOTS) {
             auto item_name = describe_flavor(player_ptr, *player_ptr->inventory[i], 0);
             auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr));
             is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr));

--- a/src/io-dump/character-dump.cpp
+++ b/src/io-dump/character-dump.cpp
@@ -496,28 +496,28 @@ static void dump_aux_equipment_inventory(PlayerType *player_ptr, FILE *fff)
 {
     if (player_ptr->equip_cnt) {
         fmt::println(fff, _("  [キャラクタの装備]\n", "  [Character Equipment]\n"));
-        for (const auto i : INVEN_WIELDING_SLOTS) {
-            auto item_name = describe_flavor(player_ptr, *player_ptr->inventory[i], 0);
-            auto is_two_handed = ((i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr));
-            is_two_handed |= ((i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr));
+        for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+            auto item_name = describe_flavor(player_ptr, *player_ptr->inventory[i_idx], 0);
+            auto is_two_handed = ((i_idx == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr));
+            is_two_handed |= ((i_idx == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr));
             if (is_two_handed && has_two_handed_weapons(player_ptr)) {
                 item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             }
 
-            fmt::println(fff, "{}) {}", index_to_label(i), item_name);
+            fmt::println(fff, "{}) {}", index_to_label(i_idx), item_name);
         }
 
         fmt::println(fff, "\n");
     }
 
     fmt::println(fff, _("  [キャラクタの持ち物]\n", "  [Character Inventory]\n"));
-    for (const auto i : INVEN_PACK_SLOTS) {
-        if (!player_ptr->inventory[i]->is_valid()) {
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        if (!player_ptr->inventory[i_idx]->is_valid()) {
             break;
         }
 
-        const auto item_name = describe_flavor(player_ptr, *player_ptr->inventory[i], 0);
-        fmt::println(fff, "{}) {}", index_to_label(i), item_name);
+        const auto item_name = describe_flavor(player_ptr, *player_ptr->inventory[i_idx], 0);
+        fmt::println(fff, "{}) {}", index_to_label(i_idx), item_name);
     }
 
     fmt::println(fff, "\n");

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -81,7 +81,7 @@ void spoil_random_artifact(PlayerType *player_ptr)
     const auto &outpost = TownList::get_instance().get_town(1);
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
-            for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+            for (const auto i : INVEN_WIELDING_SLOTS) {
                 auto &item = *player_ptr->inventory[i];
                 spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -86,7 +86,7 @@ void spoil_random_artifact(PlayerType *player_ptr)
                 spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }
 
-            for (int i = 0; i < INVEN_PACK; i++) {
+            for (const auto i : INVEN_PACK_SLOTS) {
                 auto &item = *player_ptr->inventory[i];
                 spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }

--- a/src/io-dump/random-art-info-dumper.cpp
+++ b/src/io-dump/random-art-info-dumper.cpp
@@ -81,13 +81,13 @@ void spoil_random_artifact(PlayerType *player_ptr)
     const auto &outpost = TownList::get_instance().get_town(1);
     for (const auto &[tval_list, name] : group_artifact_list) {
         for (auto tval : tval_list) {
-            for (const auto i : INVEN_WIELDING_SLOTS) {
-                auto &item = *player_ptr->inventory[i];
+            for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+                auto &item = *player_ptr->inventory[i_idx];
                 spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }
 
-            for (const auto i : INVEN_PACK_SLOTS) {
-                auto &item = *player_ptr->inventory[i];
+            for (const auto i_idx : INVEN_PACK_SLOTS) {
+                auto &item = *player_ptr->inventory[i_idx];
                 spoil_random_artifact_aux(player_ptr, item, tval, ofs);
             }
 

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -305,8 +305,8 @@ int InputKeyRequestor::get_caret_command() const
 void InputKeyRequestor::sweep_confirmation_equipments()
 {
     auto caret_command = this->get_caret_command();
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto &item = *this->player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto &item = *this->player_ptr->inventory[i_idx];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;
         }

--- a/src/io/input-key-requester.cpp
+++ b/src/io/input-key-requester.cpp
@@ -305,7 +305,7 @@ int InputKeyRequestor::get_caret_command() const
 void InputKeyRequestor::sweep_confirmation_equipments()
 {
     auto caret_command = this->get_caret_command();
-    for (auto i = enum2i(INVEN_MAIN_HAND); i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto &item = *this->player_ptr->inventory[i];
         if (!item.is_valid() || !item.is_inscribed()) {
             continue;

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -171,8 +171,8 @@ static void pad_and_print_header(int label_number, FILE *fff)
 static int show_wearing_equipment_resistances(PlayerType *player_ptr, ItemKindType tval, int label_number_initial, FILE *fff)
 {
     auto label_number = label_number_initial;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.has_knowledge(tval)) {
             continue;
         }
@@ -195,8 +195,8 @@ static int show_wearing_equipment_resistances(PlayerType *player_ptr, ItemKindTy
 static int show_holding_equipment_resistances(PlayerType *player_ptr, ItemKindType tval, int label_number_initial, FILE *fff)
 {
     auto label_number = label_number_initial;
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.has_knowledge(tval)) {
             continue;
         }

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -195,7 +195,7 @@ static int show_wearing_equipment_resistances(PlayerType *player_ptr, ItemKindTy
 static int show_holding_equipment_resistances(PlayerType *player_ptr, ItemKindType tval, int label_number_initial, FILE *fff)
 {
     auto label_number = label_number_initial;
-    for (short i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.has_knowledge(tval)) {
             continue;

--- a/src/knowledge/knowledge-inventory.cpp
+++ b/src/knowledge/knowledge-inventory.cpp
@@ -171,7 +171,7 @@ static void pad_and_print_header(int label_number, FILE *fff)
 static int show_wearing_equipment_resistances(PlayerType *player_ptr, ItemKindType tval, int label_number_initial, FILE *fff)
 {
     auto label_number = label_number_initial;
-    for (short i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.has_knowledge(tval)) {
             continue;

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -96,8 +96,8 @@ auto collect_known_fixed_artifacts_old(PlayerType *player_ptr)
         }
     }
 
-    for (const auto i : INVEN_ALL_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }

--- a/src/load/load.cpp
+++ b/src/load/load.cpp
@@ -96,7 +96,7 @@ auto collect_known_fixed_artifacts_old(PlayerType *player_ptr)
         }
     }
 
-    for (auto i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -30,6 +30,7 @@
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <algorithm>
+#include <range/v3/view.hpp>
 
 /*!
  * @brief 賞金首の引き換え処理 / Get prize
@@ -65,7 +66,7 @@ bool exchange_cash(PlayerType *player_ptr)
         vary_item(player_ptr, i, -item.number);
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.is_corpse()) {
             continue;
@@ -88,7 +89,7 @@ bool exchange_cash(PlayerType *player_ptr)
         vary_item(player_ptr, i, -item.number);
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) {
             continue;
@@ -112,7 +113,7 @@ bool exchange_cash(PlayerType *player_ptr)
     }
 
     auto &world = AngbandWorld::get_instance();
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         const auto &monrace = world.get_today_bounty();
         if (!item.is_corpse() || (item.get_monrace().name != monrace.name)) {
@@ -132,7 +133,7 @@ bool exchange_cash(PlayerType *player_ptr)
         vary_item(player_ptr, i, -item.number);
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         const auto &monrace = world.get_today_bounty();
         if ((item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) || (item.get_monrace().name != monrace.name)) {
@@ -157,7 +158,7 @@ bool exchange_cash(PlayerType *player_ptr)
             continue;
         }
 
-        for (INVENTORY_IDX i = INVEN_PACK - 1; i >= 0; i--) {
+        for (const auto i : INVEN_PACK_SLOTS | ranges::views::reverse) {
             auto &item = *player_ptr->inventory[i];
             if ((item.bi_key.tval() != ItemKindType::MONSTER_REMAINS) || (item.get_monrace().idx != monrace_id)) {
                 continue;

--- a/src/market/bounty.cpp
+++ b/src/market/bounty.cpp
@@ -66,8 +66,8 @@ bool exchange_cash(PlayerType *player_ptr)
         vary_item(player_ptr, i, -item.number);
     }
 
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_corpse()) {
             continue;
         }
@@ -86,11 +86,11 @@ bool exchange_cash(PlayerType *player_ptr)
         msg_format(fmt_reward, reward_money);
         player_ptr->au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item.number);
+        vary_item(player_ptr, i_idx, -item.number);
     }
 
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) {
             continue;
         }
@@ -109,12 +109,12 @@ bool exchange_cash(PlayerType *player_ptr)
         msg_format(fmt_reward, reward_money);
         player_ptr->au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item.number);
+        vary_item(player_ptr, i_idx, -item.number);
     }
 
     auto &world = AngbandWorld::get_instance();
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         const auto &monrace = world.get_today_bounty();
         if (!item.is_corpse() || (item.get_monrace().name != monrace.name)) {
             continue;
@@ -130,11 +130,11 @@ bool exchange_cash(PlayerType *player_ptr)
         msg_format(fmt_reward, reward_money);
         player_ptr->au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item.number);
+        vary_item(player_ptr, i_idx, -item.number);
     }
 
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         const auto &monrace = world.get_today_bounty();
         if ((item.bi_key != BaseitemKey(ItemKindType::MONSTER_REMAINS, SV_SKELETON)) || (item.get_monrace().name != monrace.name)) {
             continue;
@@ -150,7 +150,7 @@ bool exchange_cash(PlayerType *player_ptr)
         msg_format(fmt_reward, reward_money);
         player_ptr->au += reward_money;
         rfu.set_flag(MainWindowRedrawingFlag::GOLD);
-        vary_item(player_ptr, i, -item.number);
+        vary_item(player_ptr, i_idx, -item.number);
     }
 
     for (auto &[monrace_id, is_achieved] : world.bounties) {
@@ -158,8 +158,8 @@ bool exchange_cash(PlayerType *player_ptr)
             continue;
         }
 
-        for (const auto i : INVEN_PACK_SLOTS | ranges::views::reverse) {
-            auto &item = *player_ptr->inventory[i];
+        for (const auto i_idx : INVEN_PACK_SLOTS | ranges::views::reverse) {
+            auto &item = *player_ptr->inventory[i_idx];
             if ((item.bi_key.tval() != ItemKindType::MONSTER_REMAINS) || (item.get_monrace().idx != monrace_id)) {
                 continue;
             }
@@ -170,7 +170,7 @@ bool exchange_cash(PlayerType *player_ptr)
                 continue;
             }
 
-            vary_item(player_ptr, i, -item.number);
+            vary_item(player_ptr, i_idx, -item.number);
             chg_virtue(player_ptr, Virtue::JUSTICE, 5);
             is_achieved = true;
 

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -175,8 +175,8 @@ void building_recharge_all(PlayerType *player_ptr)
 
     auto price = 0;
     auto total_cost = 0;
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.can_recharge()) {
             continue;
         }
@@ -227,15 +227,15 @@ void building_recharge_all(PlayerType *player_ptr)
         return;
     }
 
-    for (const auto i : INVEN_PACK_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->can_recharge()) {
             continue;
         }
 
         if (!o_ptr->is_known()) {
             identify_item(player_ptr, o_ptr);
-            autopick_alter_item(player_ptr, i, false);
+            autopick_alter_item(player_ptr, i_idx, false);
         }
 
         const auto base_pval = o_ptr->get_baseitem_pval();

--- a/src/market/building-recharger.cpp
+++ b/src/market/building-recharger.cpp
@@ -175,7 +175,7 @@ void building_recharge_all(PlayerType *player_ptr)
 
     auto price = 0;
     auto total_cost = 0;
-    for (short i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.can_recharge()) {
             continue;
@@ -227,7 +227,7 @@ void building_recharge_all(PlayerType *player_ptr)
         return;
     }
 
-    for (short i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->can_recharge()) {
             continue;

--- a/src/mind/mind-ninja.cpp
+++ b/src/mind/mind-ninja.cpp
@@ -9,6 +9,7 @@
 #include "floor/floor-util.h"
 #include "game-option/disturbance-options.h"
 #include "grid/grid.h"
+#include "inventory/inventory-slot-types.h"
 #include "main/sound-definitions-table.h"
 #include "main/sound-of-music.h"
 #include "mind/mind-mirror-master.h"
@@ -50,6 +51,7 @@
 #include "target/target-getter.h"
 #include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
+#include <range/v3/algorithm.hpp>
 
 /*!
  * @brief 変わり身処理
@@ -414,15 +416,11 @@ bool cast_ninja_spell(PlayerType *player_ptr, MindNinjaType spell)
         return rush_attack(player_ptr, nullptr);
     case MindNinjaType::SYURIKEN_SPREADING: {
         for (int i = 0; i < 8; i++) {
-            OBJECT_IDX slot;
+            const auto it = ranges::find_if(INVEN_PACK_SLOTS, [&](const auto s) {
+                return player_ptr->inventory[s]->bi_key.tval() == ItemKindType::SPIKE;
+            });
 
-            for (slot = 0; slot < INVEN_PACK; slot++) {
-                if (player_ptr->inventory[slot]->bi_key.tval() == ItemKindType::SPIKE) {
-                    break;
-                }
-            }
-
-            if (slot == INVEN_PACK) {
+            if (it == INVEN_PACK_SLOTS.end()) {
                 if (!i) {
                     msg_print(_("くさびを持っていない。", "You have no Iron Spikes."));
                 } else {
@@ -432,7 +430,7 @@ bool cast_ninja_spell(PlayerType *player_ptr, MindNinjaType spell)
                 return false;
             }
 
-            (void)ThrowCommand(player_ptr).do_cmd_throw(1, false, slot);
+            (void)ThrowCommand(player_ptr).do_cmd_throw(1, false, enum2i(*it));
             PlayerEnergy(player_ptr).set_player_turn_energy(100);
         }
 

--- a/src/monster-attack/monster-attack-switcher.cpp
+++ b/src/monster-attack/monster-attack-switcher.cpp
@@ -111,7 +111,7 @@ static void calc_blow_un_power(PlayerType *player_ptr, MonsterAttackPlayer *mona
 
     int max_draining_item = is_magic_mastery ? 5 : 10;
     for (int i = 0; i < max_draining_item; i++) {
-        auto i_idx = randnum0<short>(INVEN_PACK);
+        const auto i_idx = rand_choice(INVEN_PACK_SLOTS);
         monap_ptr->o_ptr = player_ptr->inventory[i_idx].get();
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;

--- a/src/monster-attack/monster-eating.cpp
+++ b/src/monster-attack/monster-eating.cpp
@@ -131,7 +131,7 @@ static void move_item_to_monster(PlayerType *player_ptr, MonsterAttackPlayer *mo
 void process_eat_item(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 {
     for (int i = 0; i < 10; i++) {
-        auto i_idx = randnum0<short>(INVEN_PACK);
+        const auto i_idx = rand_choice(INVEN_PACK_SLOTS);
         monap_ptr->o_ptr = player_ptr->inventory[i_idx].get();
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;
@@ -161,7 +161,7 @@ void process_eat_item(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 void process_eat_food(PlayerType *player_ptr, MonsterAttackPlayer *monap_ptr)
 {
     for (int i = 0; i < 10; i++) {
-        auto i_idx = randnum0<short>(INVEN_PACK);
+        const auto i_idx = rand_choice(INVEN_PACK_SLOTS);
         monap_ptr->o_ptr = player_ptr->inventory[i_idx].get();
         if (!monap_ptr->o_ptr->is_valid()) {
             continue;

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -38,8 +38,8 @@ bool item_tester_hook_use(PlayerType *player_ptr, const ItemEntity *o_ptr)
             return false;
         }
 
-        for (const auto i : INVEN_WIELDING_SLOTS) {
-            if ((player_ptr->inventory[i].get() == o_ptr) && o_ptr->get_flags().has(TR_ACTIVATE)) {
+        for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+            if ((player_ptr->inventory[i_idx].get() == o_ptr) && o_ptr->get_flags().has(TR_ACTIVATE)) {
                 return true;
             }
         }

--- a/src/object-hook/hook-magic.cpp
+++ b/src/object-hook/hook-magic.cpp
@@ -38,7 +38,7 @@ bool item_tester_hook_use(PlayerType *player_ptr, const ItemEntity *o_ptr)
             return false;
         }
 
-        for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+        for (const auto i : INVEN_WIELDING_SLOTS) {
             if ((player_ptr->inventory[i].get() == o_ptr) && o_ptr->get_flags().has(TR_ACTIVATE)) {
                 return true;
             }

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -34,10 +34,10 @@ std::shared_ptr<ItemEntity> choose_warning_item(PlayerType *player_ptr)
     }
 
     std::vector<int> candidates;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        const auto &item = player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = player_ptr->inventory[i_idx];
         if (item->get_flags().has(TR_WARNING)) {
-            candidates.push_back(i);
+            candidates.push_back(i_idx);
         }
     }
 

--- a/src/object/warning.cpp
+++ b/src/object/warning.cpp
@@ -4,6 +4,7 @@
 #include "flavor/flavor-describer.h"
 #include "flavor/object-flavor-types.h"
 #include "game-option/input-options.h"
+#include "inventory/inventory-slot-types.h"
 #include "monster-attack/monster-attack-table.h"
 #include "mspell/mspell-damage-calculator.h"
 #include "player-base/player-race.h"
@@ -33,7 +34,7 @@ std::shared_ptr<ItemEntity> choose_warning_item(PlayerType *player_ptr)
     }
 
     std::vector<int> candidates;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         const auto &item = player_ptr->inventory[i];
         if (item->get_flags().has(TR_WARNING)) {
             candidates.push_back(i);

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -278,7 +278,7 @@ void sense_inventory1(PlayerType *player_ptr)
         heavy = true;
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
 
         if (!o_ptr->is_valid()) {
@@ -406,7 +406,7 @@ void sense_inventory2(PlayerType *player_ptr)
         break;
     }
 
-    for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         bool okay = false;
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {

--- a/src/perception/simple-perception.cpp
+++ b/src/perception/simple-perception.cpp
@@ -278,8 +278,8 @@ void sense_inventory1(PlayerType *player_ptr)
         heavy = true;
     }
 
-    for (const auto i : INVEN_ALL_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
 
         if (!o_ptr->is_valid()) {
             continue;
@@ -315,7 +315,7 @@ void sense_inventory1(PlayerType *player_ptr)
             continue;
         }
 
-        if ((i < INVEN_MAIN_HAND) && (0 != randint0(5))) {
+        if ((i_idx < INVEN_MAIN_HAND) && (0 != randint0(5))) {
             continue;
         }
 
@@ -323,7 +323,7 @@ void sense_inventory1(PlayerType *player_ptr)
             heavy = true;
         }
 
-        sense_inventory_aux(player_ptr, i, heavy);
+        sense_inventory_aux(player_ptr, i_idx, heavy);
     }
 }
 
@@ -406,9 +406,9 @@ void sense_inventory2(PlayerType *player_ptr)
         break;
     }
 
-    for (const auto i : INVEN_ALL_SLOTS) {
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
         bool okay = false;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -430,11 +430,11 @@ void sense_inventory2(PlayerType *player_ptr)
             continue;
         }
 
-        if ((i < INVEN_MAIN_HAND) && (0 != randint0(5))) {
+        if ((i_idx < INVEN_MAIN_HAND) && (0 != randint0(5))) {
             continue;
         }
 
-        sense_inventory_aux(player_ptr, i, true);
+        sense_inventory_aux(player_ptr, i_idx, true);
     }
 }
 

--- a/src/player-info/base-status-info.cpp
+++ b/src/player-info/base-status-info.cpp
@@ -8,7 +8,7 @@
 
 void set_equipment_influence(PlayerType *player_ptr, self_info_type *self_ptr)
 {
-    for (int k = INVEN_MAIN_HAND; k < INVEN_TOTAL; k++) {
+    for (const auto k : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = player_ptr->inventory[k].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/player-info/base-status-info.cpp
+++ b/src/player-info/base-status-info.cpp
@@ -8,8 +8,8 @@
 
 void set_equipment_influence(PlayerType *player_ptr, self_info_type *self_ptr)
 {
-    for (const auto k : INVEN_WIELDING_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[k].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -210,7 +210,7 @@ void PlayerStatusBase::set_locals()
 BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -218,7 +218,7 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 
         const auto o_flags = o_ptr->get_flags();
         if (o_flags.has(check_flag)) {
-            set_bits(flags, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(flags, convert_inventory_slot_type_to_flag_cause(i));
         }
     }
 
@@ -233,7 +233,7 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = this->player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -242,7 +242,7 @@ BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
         const auto o_flags = o_ptr->get_flags();
         if (o_flags.has(check_flag)) {
             if (o_ptr->pval < 0) {
-                set_bits(flags, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+                set_bits(flags, convert_inventory_slot_type_to_flag_cause(i));
             }
         }
     }
@@ -258,7 +258,7 @@ int16_t PlayerStatusBase::equipments_bonus()
 {
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     int16_t bonus = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         const auto *o_ptr = player_ptr->inventory[i].get();
         const auto o_flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {

--- a/src/player-status/player-status-base.cpp
+++ b/src/player-status/player-status-base.cpp
@@ -210,15 +210,15 @@ void PlayerStatusBase::set_locals()
 BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         const auto o_flags = o_ptr->get_flags();
         if (o_flags.has(check_flag)) {
-            set_bits(flags, convert_inventory_slot_type_to_flag_cause(i));
+            set_bits(flags, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
 
@@ -233,8 +233,8 @@ BIT_FLAGS PlayerStatusBase::equipments_flags(tr_type check_flag)
 BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
 {
     BIT_FLAGS flags = 0;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto *o_ptr = this->player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = this->player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -242,7 +242,7 @@ BIT_FLAGS PlayerStatusBase::equipments_bad_flags(tr_type check_flag)
         const auto o_flags = o_ptr->get_flags();
         if (o_flags.has(check_flag)) {
             if (o_ptr->pval < 0) {
-                set_bits(flags, convert_inventory_slot_type_to_flag_cause(i));
+                set_bits(flags, convert_inventory_slot_type_to_flag_cause(i_idx));
             }
         }
     }
@@ -258,8 +258,8 @@ int16_t PlayerStatusBase::equipments_bonus()
 {
     this->set_locals(); /* 計算前に値のセット。派生クラスの値がセットされる。*/
     int16_t bonus = 0;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        const auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto *o_ptr = player_ptr->inventory[i_idx].get();
         const auto o_flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -720,7 +720,7 @@ void check_no_flowed(PlayerType *player_ptr)
         return;
     }
 
-    for (int i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &bi_key = player_ptr->inventory[i]->bi_key;
         if (bi_key == BaseitemKey(ItemKindType::NATURE_BOOK, 2)) {
             has_sw = true;

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -118,8 +118,8 @@ BIT_FLAGS check_equipment_flags(PlayerType *player_ptr, tr_type tr_flag)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -127,7 +127,7 @@ BIT_FLAGS check_equipment_flags(PlayerType *player_ptr, tr_type tr_flag)
         const auto flags = o_ptr->get_flags();
 
         if (flags.has(tr_flag)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
     return result;
@@ -720,8 +720,8 @@ void check_no_flowed(PlayerType *player_ptr)
         return;
     }
 
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &bi_key = player_ptr->inventory[i]->bi_key;
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &bi_key = player_ptr->inventory[i_idx]->bi_key;
         if (bi_key == BaseitemKey(ItemKindType::NATURE_BOOK, 2)) {
             has_sw = true;
         }
@@ -789,8 +789,8 @@ BIT_FLAGS has_warning(PlayerType *player_ptr)
     BIT_FLAGS result = 0L;
     ItemEntity *o_ptr;
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -799,7 +799,7 @@ BIT_FLAGS has_warning(PlayerType *player_ptr)
 
         if (flags.has(TR_WARNING)) {
             if (!o_ptr->is_inscribed() || !angband_strchr(o_ptr->inscription->data(), '$')) {
-                set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
+                set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
             }
         }
     }
@@ -1056,8 +1056,8 @@ void update_curses(PlayerType *player_ptr)
         player_ptr->cursed.set(CurseTraitType::AGGRAVATE);
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1166,17 +1166,17 @@ void update_extra_blows(PlayerType *player_ptr)
     const melee_type melee_type = player_melee_type(player_ptr);
     const bool two_handed = (melee_type == MELEE_TYPE_WEAPON_TWOHAND || melee_type == MELEE_TYPE_BAREHAND_TWO);
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         const auto flags = o_ptr->get_flags();
         if (flags.has(TR_BLOWS)) {
-            if ((i == INVEN_MAIN_HAND || i == INVEN_MAIN_RING) && !two_handed) {
+            if ((i_idx == INVEN_MAIN_HAND || i_idx == INVEN_MAIN_RING) && !two_handed) {
                 player_ptr->extra_blows[0] += o_ptr->pval;
-            } else if ((i == INVEN_SUB_HAND || i == INVEN_SUB_RING) && !two_handed) {
+            } else if ((i_idx == INVEN_SUB_HAND || i_idx == INVEN_SUB_RING) && !two_handed) {
                 player_ptr->extra_blows[1] += o_ptr->pval;
             } else {
                 player_ptr->extra_blows[0] += o_ptr->pval;
@@ -1469,8 +1469,8 @@ BIT_FLAGS has_vuln_curse(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1478,7 +1478,7 @@ BIT_FLAGS has_vuln_curse(PlayerType *player_ptr)
         const auto flags = o_ptr->get_flags();
 
         if (flags.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
 
@@ -1494,8 +1494,8 @@ BIT_FLAGS has_heavy_vuln_curse(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1503,7 +1503,7 @@ BIT_FLAGS has_heavy_vuln_curse(PlayerType *player_ptr)
         const auto flags = o_ptr->get_flags();
 
         if ((flags.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE)) && o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i_idx));
         }
     }
 

--- a/src/player/player-status-flags.cpp
+++ b/src/player/player-status-flags.cpp
@@ -118,7 +118,7 @@ BIT_FLAGS check_equipment_flags(PlayerType *player_ptr, tr_type tr_flag)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -127,7 +127,7 @@ BIT_FLAGS check_equipment_flags(PlayerType *player_ptr, tr_type tr_flag)
         const auto flags = o_ptr->get_flags();
 
         if (flags.has(tr_flag)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
         }
     }
     return result;
@@ -789,7 +789,7 @@ BIT_FLAGS has_warning(PlayerType *player_ptr)
     BIT_FLAGS result = 0L;
     ItemEntity *o_ptr;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -799,7 +799,7 @@ BIT_FLAGS has_warning(PlayerType *player_ptr)
 
         if (flags.has(TR_WARNING)) {
             if (!o_ptr->is_inscribed() || !angband_strchr(o_ptr->inscription->data(), '$')) {
-                set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+                set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
             }
         }
     }
@@ -1056,7 +1056,7 @@ void update_curses(PlayerType *player_ptr)
         player_ptr->cursed.set(CurseTraitType::AGGRAVATE);
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1166,7 +1166,7 @@ void update_extra_blows(PlayerType *player_ptr)
     const melee_type melee_type = player_melee_type(player_ptr);
     const bool two_handed = (melee_type == MELEE_TYPE_WEAPON_TWOHAND || melee_type == MELEE_TYPE_BAREHAND_TWO);
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1469,7 +1469,7 @@ BIT_FLAGS has_vuln_curse(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1478,7 +1478,7 @@ BIT_FLAGS has_vuln_curse(PlayerType *player_ptr)
         const auto flags = o_ptr->get_flags();
 
         if (flags.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
         }
     }
 
@@ -1494,7 +1494,7 @@ BIT_FLAGS has_heavy_vuln_curse(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
     BIT_FLAGS result = 0L;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1503,7 +1503,7 @@ BIT_FLAGS has_heavy_vuln_curse(PlayerType *player_ptr)
         const auto flags = o_ptr->get_flags();
 
         if ((flags.has(TR_VUL_CURSE) || o_ptr->curse_flags.has(CurseTraitType::VUL_CURSE)) && o_ptr->curse_flags.has(CurseTraitType::HEAVY_CURSE)) {
-            set_bits(result, convert_inventory_slot_type_to_flag_cause(i2enum<inventory_slot_type>(i)));
+            set_bits(result, convert_inventory_slot_type_to_flag_cause(i));
         }
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -19,6 +19,7 @@
 #include "game-option/birth-options.h"
 #include "grid/grid.h"
 #include "inventory/inventory-object.h"
+#include "inventory/inventory-slot-types.h"
 #include "io/input-key-acceptor.h"
 #include "io/write-diary.h"
 #include "main/sound-definitions-table.h"
@@ -949,7 +950,7 @@ short calc_num_fire(PlayerType *player_ptr, const ItemEntity *o_ptr)
 {
     int extra_shots = 0;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *q_ptr;
         q_ptr = player_ptr->inventory[i].get();
         if (!q_ptr->is_valid()) {
@@ -1069,7 +1070,7 @@ static ACTION_SKILL_POWER calc_device_ability(PlayerType *player_ptr)
     pow = tmp_rp_ptr->r_dev + player_class.c_dev + player_personality.a_dev;
     pow += ((player_class.x_dev * player_ptr->lev / 10) + (ap_ptr->a_dev * player_ptr->lev / 50));
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
@@ -1197,7 +1198,7 @@ static ACTION_SKILL_POWER calc_search(PlayerType *player_ptr)
     pow = tmp_rp_ptr->r_srh + player_class.c_srh + player_personality.a_srh;
     pow += (player_class.x_srh * player_ptr->lev / 10);
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
@@ -1246,7 +1247,7 @@ static ACTION_SKILL_POWER calc_search_freq(PlayerType *player_ptr)
     pow = tmp_rp_ptr->r_fos + player_class.c_fos + player_personality.a_fos;
     pow += (player_class.x_fos * player_ptr->lev / 10);
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
@@ -1382,7 +1383,7 @@ static ACTION_SKILL_POWER calc_skill_dig(PlayerType *player_ptr)
         pow += (100 + player_ptr->lev * 8);
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1600,7 +1601,7 @@ static int16_t calc_to_magic_chance(PlayerType *player_ptr)
         chance += 5;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
@@ -1625,7 +1626,7 @@ static ARMOUR_CLASS calc_base_ac(PlayerType *player_ptr)
         return 0;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
@@ -1683,7 +1684,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
         ac -= 50;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         const auto *o_ptr = player_ptr->inventory[i].get();
         const auto flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {
@@ -2077,7 +2078,7 @@ static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_
         }
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         int bonus_to_d = 0;
         o_ptr = player_ptr->inventory[i].get();
         const auto has_melee = has_melee_weapon(player_ptr, i);
@@ -2317,7 +2318,7 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
     }
 
     /* Bonuses from inventory */
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
 
         /* Ignore empty hands, handed weapons, bows and capture balls */
@@ -2458,7 +2459,7 @@ static int16_t calc_to_hit_bow(PlayerType *player_ptr, bool is_real_value)
     }
 
     // 武器以外の装備による修正
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         int bonus_to_h;
         o_ptr = player_ptr->inventory[i].get();
         const auto has_melee = has_melee_weapon(player_ptr, i);
@@ -2494,7 +2495,7 @@ static int16_t calc_to_damage_misc(PlayerType *player_ptr)
 
     int16_t to_dam = 0;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
@@ -2524,7 +2525,7 @@ static int16_t calc_to_hit_misc(PlayerType *player_ptr)
 
     int16_t to_hit = 0;
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -187,7 +187,7 @@ static bool is_heavy_shoot(PlayerType *player_ptr, const ItemEntity *o_ptr)
 int calc_inventory_weight(PlayerType *player_ptr)
 {
     auto weight = 0;
-    for (int i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2693,7 +2693,7 @@ void update_creature(PlayerType *player_ptr)
  */
 bool player_has_no_spellbooks(PlayerType *player_ptr)
 {
-    for (int i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto *o_ptr = player_ptr->inventory[i].get();
         if (o_ptr->is_valid() && check_book_realm(player_ptr, o_ptr->bi_key)) {
             return false;

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -187,8 +187,8 @@ static bool is_heavy_shoot(PlayerType *player_ptr, const ItemEntity *o_ptr)
 int calc_inventory_weight(PlayerType *player_ptr)
 {
     auto weight = 0;
-    for (const auto i : INVEN_ALL_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
@@ -950,14 +950,14 @@ short calc_num_fire(PlayerType *player_ptr, const ItemEntity *o_ptr)
 {
     int extra_shots = 0;
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *q_ptr;
-        q_ptr = player_ptr->inventory[i].get();
+        q_ptr = player_ptr->inventory[i_idx].get();
         if (!q_ptr->is_valid()) {
             continue;
         }
 
-        if (i == INVEN_BOW) {
+        if (i_idx == INVEN_BOW) {
             continue;
         }
 
@@ -1070,9 +1070,9 @@ static ACTION_SKILL_POWER calc_device_ability(PlayerType *player_ptr)
     pow = tmp_rp_ptr->r_dev + player_class.c_dev + player_personality.a_dev;
     pow += ((player_class.x_dev * player_ptr->lev / 10) + (ap_ptr->a_dev * player_ptr->lev / 50));
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1198,9 +1198,9 @@ static ACTION_SKILL_POWER calc_search(PlayerType *player_ptr)
     pow = tmp_rp_ptr->r_srh + player_class.c_srh + player_personality.a_srh;
     pow += (player_class.x_srh * player_ptr->lev / 10);
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1247,9 +1247,9 @@ static ACTION_SKILL_POWER calc_search_freq(PlayerType *player_ptr)
     pow = tmp_rp_ptr->r_fos + player_class.c_fos + player_personality.a_fos;
     pow += (player_class.x_fos * player_ptr->lev / 10);
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1383,8 +1383,8 @@ static ACTION_SKILL_POWER calc_skill_dig(PlayerType *player_ptr)
         pow += (100 + player_ptr->lev * 8);
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1601,9 +1601,9 @@ static int16_t calc_to_magic_chance(PlayerType *player_ptr)
         chance += 5;
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1626,9 +1626,9 @@ static ARMOUR_CLASS calc_base_ac(PlayerType *player_ptr)
         return 0;
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -1684,8 +1684,8 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
         ac -= 50;
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        const auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto *o_ptr = player_ptr->inventory[i_idx].get();
         const auto flags = o_ptr->get_flags();
         if (!o_ptr->is_valid()) {
             continue;
@@ -1706,7 +1706,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
             }
         }
 
-        if ((i == INVEN_SUB_HAND) && flags.has(TR_SUPPORTIVE)) {
+        if ((i_idx == INVEN_SUB_HAND) && flags.has(TR_SUPPORTIVE)) {
             ac += 5;
         }
     }
@@ -2078,15 +2078,15 @@ static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_
         }
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         int bonus_to_d = 0;
-        o_ptr = player_ptr->inventory[i].get();
-        const auto has_melee = has_melee_weapon(player_ptr, i);
+        o_ptr = player_ptr->inventory[i_idx].get();
+        const auto has_melee = has_melee_weapon(player_ptr, i_idx);
         if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
             continue;
         }
 
-        if (((i == INVEN_MAIN_HAND) && has_melee) || ((i == INVEN_SUB_HAND) && has_melee) || (i == INVEN_BOW)) {
+        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
             continue;
         }
 
@@ -2111,30 +2111,30 @@ static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_
 
         case MELEE_TYPE_BAREHAND_MAIN:
         case MELEE_TYPE_WEAPON_MAIN:
-            if ((calc_hand == PLAYER_HAND_MAIN) && (i != INVEN_SUB_RING)) {
+            if ((calc_hand == PLAYER_HAND_MAIN) && (i_idx != INVEN_SUB_RING)) {
                 damage += (int16_t)bonus_to_d;
             }
             break;
 
         case MELEE_TYPE_BAREHAND_SUB:
         case MELEE_TYPE_WEAPON_SUB:
-            if ((calc_hand == PLAYER_HAND_SUB) && (i != INVEN_MAIN_RING)) {
+            if ((calc_hand == PLAYER_HAND_SUB) && (i_idx != INVEN_MAIN_RING)) {
                 damage += (int16_t)bonus_to_d;
             }
             break;
 
         case MELEE_TYPE_WEAPON_DOUBLE:
             if (calc_hand == PLAYER_HAND_MAIN) {
-                if (i == INVEN_MAIN_RING) {
+                if (i_idx == INVEN_MAIN_RING) {
                     damage += (int16_t)bonus_to_d;
-                } else if (i != INVEN_SUB_RING) {
+                } else if (i_idx != INVEN_SUB_RING) {
                     damage += (bonus_to_d > 0) ? (bonus_to_d + 1) / 2 : bonus_to_d;
                 }
             }
             if (calc_hand == PLAYER_HAND_SUB) {
-                if (i == INVEN_SUB_RING) {
+                if (i_idx == INVEN_SUB_RING) {
                     damage += (int16_t)bonus_to_d;
-                } else if (i != INVEN_MAIN_RING) {
+                } else if (i_idx != INVEN_MAIN_RING) {
                     damage += (bonus_to_d > 0) ? bonus_to_d / 2 : bonus_to_d;
                 }
             }
@@ -2318,16 +2318,16 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
     }
 
     /* Bonuses from inventory */
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
 
         /* Ignore empty hands, handed weapons, bows and capture balls */
-        const auto has_melee = has_melee_weapon(player_ptr, i);
+        const auto has_melee = has_melee_weapon(player_ptr, i_idx);
         if (!o_ptr->is_valid() || o_ptr->bi_key.tval() == ItemKindType::CAPTURE) {
             continue;
         }
 
-        if (((i == INVEN_MAIN_HAND) && has_melee) || ((i == INVEN_SUB_HAND) && has_melee) || (i == INVEN_BOW)) {
+        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
             continue;
         }
 
@@ -2355,30 +2355,30 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
 
         case MELEE_TYPE_BAREHAND_MAIN:
         case MELEE_TYPE_WEAPON_MAIN:
-            if ((calc_hand == PLAYER_HAND_MAIN) && (i != INVEN_SUB_RING)) {
+            if ((calc_hand == PLAYER_HAND_MAIN) && (i_idx != INVEN_SUB_RING)) {
                 hit += (int16_t)bonus_to_h;
             }
             break;
 
         case MELEE_TYPE_BAREHAND_SUB:
         case MELEE_TYPE_WEAPON_SUB:
-            if ((calc_hand == PLAYER_HAND_SUB) && (i != INVEN_MAIN_RING)) {
+            if ((calc_hand == PLAYER_HAND_SUB) && (i_idx != INVEN_MAIN_RING)) {
                 hit += (int16_t)bonus_to_h;
             }
             break;
 
         case MELEE_TYPE_WEAPON_DOUBLE:
             if (calc_hand == PLAYER_HAND_MAIN) {
-                if (i == INVEN_MAIN_RING) {
+                if (i_idx == INVEN_MAIN_RING) {
                     hit += (int16_t)bonus_to_h;
-                } else if (i != INVEN_SUB_RING) {
+                } else if (i_idx != INVEN_SUB_RING) {
                     hit += (bonus_to_h > 0) ? (bonus_to_h + 1) / 2 : bonus_to_h;
                 }
             }
             if (calc_hand == PLAYER_HAND_SUB) {
-                if (i == INVEN_SUB_RING) {
+                if (i_idx == INVEN_SUB_RING) {
                     hit += (int16_t)bonus_to_h;
-                } else if (i != INVEN_MAIN_RING) {
+                } else if (i_idx != INVEN_MAIN_RING) {
                     hit += (bonus_to_h > 0) ? bonus_to_h / 2 : bonus_to_h;
                 }
             }
@@ -2459,15 +2459,15 @@ static int16_t calc_to_hit_bow(PlayerType *player_ptr, bool is_real_value)
     }
 
     // 武器以外の装備による修正
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         int bonus_to_h;
-        o_ptr = player_ptr->inventory[i].get();
-        const auto has_melee = has_melee_weapon(player_ptr, i);
+        o_ptr = player_ptr->inventory[i_idx].get();
+        const auto has_melee = has_melee_weapon(player_ptr, i_idx);
         if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
             continue;
         }
 
-        if (((i == INVEN_MAIN_HAND) && has_melee) || ((i == INVEN_SUB_HAND) && has_melee) || (i == INVEN_BOW)) {
+        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
             continue;
         }
 
@@ -2495,8 +2495,8 @@ static int16_t calc_to_damage_misc(PlayerType *player_ptr)
 
     int16_t to_dam = 0;
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -2525,8 +2525,8 @@ static int16_t calc_to_hit_misc(PlayerType *player_ptr)
 
     int16_t to_hit = 0;
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
@@ -2693,8 +2693,8 @@ void update_creature(PlayerType *player_ptr)
  */
 bool player_has_no_spellbooks(PlayerType *player_ptr)
 {
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (o_ptr->is_valid() && check_book_realm(player_ptr, o_ptr->bi_key)) {
             return false;
         }

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -238,7 +238,7 @@ void print_tomb(PlayerType *player_ptr)
 static void inventory_aware(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
-    for (int i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/player/process-death.cpp
+++ b/src/player/process-death.cpp
@@ -238,8 +238,8 @@ void print_tomb(PlayerType *player_ptr)
 static void inventory_aware(PlayerType *player_ptr)
 {
     ItemEntity *o_ptr;
-    for (const auto i : INVEN_ALL_SLOTS) {
-        o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -82,9 +82,9 @@ void known_obj_immunity(PlayerType *player_ptr, TrFlags &flags)
 {
     flags.clear();
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/player/race-resistances.cpp
+++ b/src/player/race-resistances.cpp
@@ -82,7 +82,7 @@ void known_obj_immunity(PlayerType *player_ptr, TrFlags &flags)
 {
     flags.clear();
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
         o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -63,7 +63,7 @@ void calc_android_exp(PlayerType *player_ptr)
         return;
     }
 
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         uint32_t value, exp;
         DEPTH level = std::max(o_ptr->get_baseitem_level() - 8, 1);

--- a/src/racial/racial-android.cpp
+++ b/src/racial/racial-android.cpp
@@ -63,12 +63,12 @@ void calc_android_exp(PlayerType *player_ptr)
         return;
     }
 
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         uint32_t value, exp;
         DEPTH level = std::max(o_ptr->get_baseitem_level() - 8, 1);
 
-        if ((i == INVEN_MAIN_RING) || (i == INVEN_SUB_RING) || (i == INVEN_NECK) || (i == INVEN_LITE)) {
+        if ((i_idx == INVEN_MAIN_RING) || (i_idx == INVEN_SUB_RING) || (i_idx == INVEN_NECK) || (i_idx == INVEN_LITE)) {
             continue;
         }
         if (!o_ptr->is_valid()) {
@@ -154,12 +154,12 @@ void calc_android_exp(PlayerType *player_ptr)
                 exp += (value - 100000L) / 4 * level;
             }
         }
-        if ((((i == INVEN_MAIN_HAND) || (i == INVEN_SUB_HAND)) && (has_melee_weapon(player_ptr, i))) || (i == INVEN_BOW)) {
+        if ((((i_idx == INVEN_MAIN_HAND) || (i_idx == INVEN_SUB_HAND)) && (has_melee_weapon(player_ptr, i_idx))) || (i_idx == INVEN_BOW)) {
             total_exp += exp / 48;
         } else {
             total_exp += exp / 16;
         }
-        if (i == INVEN_BODY) {
+        if (i_idx == INVEN_BODY) {
             total_exp += exp / 32;
         }
     }

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -182,7 +182,7 @@ static bool wr_savefile_new(PlayerType *player_ptr)
         wr_byte(static_cast<byte>(spell_id));
     }
 
-    for (int i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;

--- a/src/save/save.cpp
+++ b/src/save/save.cpp
@@ -182,13 +182,13 @@ static bool wr_savefile_new(PlayerType *player_ptr)
         wr_byte(static_cast<byte>(spell_id));
     }
 
-    for (const auto i : INVEN_ALL_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
 
-        wr_u16b((uint16_t)i);
+        wr_u16b((uint16_t)i_idx);
         wr_item(item);
     }
 

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -70,8 +70,8 @@ void torch_lost_fuel(ItemEntity *o_ptr)
 void update_lite_radius(PlayerType *player_ptr)
 {
     player_ptr->cur_lite = 0;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        const auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }

--- a/src/specific-object/torch.cpp
+++ b/src/specific-object/torch.cpp
@@ -70,7 +70,7 @@ void torch_lost_fuel(ItemEntity *o_ptr)
 void update_lite_radius(PlayerType *player_ptr)
 {
     player_ptr->cur_lite = 0;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         const auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/spell-kind/spells-curse-removal.cpp
+++ b/src/spell-kind/spells-curse-removal.cpp
@@ -19,8 +19,8 @@ static int exe_curse_removal(PlayerType *player_ptr, int all)
 {
     auto count = 0;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
             continue;
         }

--- a/src/spell-kind/spells-curse-removal.cpp
+++ b/src/spell-kind/spells-curse-removal.cpp
@@ -19,7 +19,7 @@ static int exe_curse_removal(PlayerType *player_ptr, int all)
 {
     auto count = 0;
     auto &rfu = RedrawingFlagsUpdater::get_instance();
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid() || !o_ptr->is_cursed()) {
             continue;

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -38,7 +38,7 @@
  */
 void identify_pack(PlayerType *player_ptr)
 {
-    for (INVENTORY_IDX i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/spell-kind/spells-perception.cpp
+++ b/src/spell-kind/spells-perception.cpp
@@ -38,14 +38,14 @@
  */
 void identify_pack(PlayerType *player_ptr)
 {
-    for (const auto i : INVEN_ALL_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
 
         identify_item(player_ptr, o_ptr);
-        autopick_alter_item(player_ptr, i, false);
+        autopick_alter_item(player_ptr, i_idx, false);
     }
 }
 

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -533,11 +533,8 @@ void teleport_away_followable(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if (player_ptr->muta.has(PlayerMutationType::VTELEPORT) || PlayerClass(player_ptr).equals(PlayerClassType::IMITATOR)) {
         follow = true;
     } else {
-        ItemEntity *o_ptr;
-        INVENTORY_IDX i;
-
-        for (i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
-            o_ptr = player_ptr->inventory[i].get();
+        for (const auto i : INVEN_WIELDING_SLOTS) {
+            const auto *o_ptr = player_ptr->inventory[i].get();
             if (o_ptr->is_valid() && !o_ptr->is_cursed() && o_ptr->get_flags().has(TR_TELEPORT)) {
                 follow = true;
                 break;

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -533,8 +533,8 @@ void teleport_away_followable(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if (player_ptr->muta.has(PlayerMutationType::VTELEPORT) || PlayerClass(player_ptr).equals(PlayerClassType::IMITATOR)) {
         follow = true;
     } else {
-        for (const auto i : INVEN_WIELDING_SLOTS) {
-            const auto *o_ptr = player_ptr->inventory[i].get();
+        for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+            const auto *o_ptr = player_ptr->inventory[i_idx].get();
             if (o_ptr->is_valid() && !o_ptr->is_cursed() && o_ptr->get_flags().has(TR_TELEPORT)) {
                 follow = true;
                 break;

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -302,8 +302,8 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity &item)
  */
 void brand_bolts(PlayerType *player_ptr)
 {
-    for (const auto i : INVEN_PACK_SLOTS) {
-        auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto &item = *player_ptr->inventory[i_idx];
         if (item.bi_key.tval() != ItemKindType::BOLT) {
             continue;
         }

--- a/src/spell/spells-object.cpp
+++ b/src/spell/spells-object.cpp
@@ -302,7 +302,7 @@ bool curse_weapon_object(PlayerType *player_ptr, bool force, ItemEntity &item)
  */
 void brand_bolts(PlayerType *player_ptr)
 {
-    for (auto i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         auto &item = *player_ptr->inventory[i];
         if (item.bi_key.tval() != ItemKindType::BOLT) {
             continue;

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -303,8 +303,8 @@ bool lose_all_info(PlayerType *player_ptr)
 {
     chg_virtue(player_ptr, Virtue::KNOWLEDGE, -5);
     chg_virtue(player_ptr, Virtue::ENLIGHTEN, -5);
-    for (const auto i : INVEN_ALL_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid() || o_ptr->is_fully_known()) {
             continue;
         }

--- a/src/status/base-status.cpp
+++ b/src/status/base-status.cpp
@@ -303,7 +303,7 @@ bool lose_all_info(PlayerType *player_ptr)
 {
     chg_virtue(player_ptr, Virtue::KNOWLEDGE, -5);
     chg_virtue(player_ptr, Virtue::ENLIGHTEN, -5);
-    for (int i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid() || o_ptr->is_fully_known()) {
             continue;

--- a/src/util/enum-range.h
+++ b/src/util/enum-range.h
@@ -20,9 +20,9 @@ public:
     class iterator {
     public:
         // std::iterator_traits に対応するための定義
-        using difference_type = int;
+        using difference_type = ptrdiff_t;
         using value_type = EnumType;
-        using iterator_concept = std::input_iterator_tag;
+        using iterator_concept = std::bidirectional_iterator_tag;
 
         constexpr iterator() noexcept = default;
 
@@ -66,6 +66,29 @@ public:
         {
             auto old = *this;
             ++*this;
+            return old;
+        }
+
+        /*!
+         * @brief イテレータを前置デクリメントする
+         *
+         * @return *this の参照
+         */
+        constexpr iterator &operator--() noexcept
+        {
+            --index;
+            return *this;
+        }
+
+        /*!
+         * @brief イテレータを後置デクリメントする
+         *
+         * @return インクリメント前のイテレータのコピー
+         */
+        constexpr iterator operator--(int) noexcept
+        {
+            auto old = *this;
+            --*this;
             return old;
         }
 

--- a/src/util/enum-range.h
+++ b/src/util/enum-range.h
@@ -238,6 +238,16 @@ public:
         return range.size();
     }
 
+    /*!
+     * @brief 閉区間の範囲を半開区間の EnumRange に変換する
+     *
+     * @return 同じ範囲を表す EnumRange<EnumType>
+     */
+    constexpr EnumRange<EnumType> to_enum_range() const noexcept
+    {
+        return range;
+    }
+
 private:
     EnumRange<EnumType> range;
 };

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -105,8 +105,8 @@ static std::array<tr_type, 6> lite_flags = {
 static void process_cursed_equipment_characteristics(PlayerType *player_ptr, uint16_t mode, char_stat &char_stat)
 {
     const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
-    for (const auto i : range) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : range) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         auto is_known = o_ptr->is_known();
         auto is_sensed = is_known || o_ptr->has_identification_flag(IdentificationFlag::SENSE);
         auto flags = o_ptr->get_flags_known();
@@ -154,8 +154,8 @@ static void process_cursed_equipment_characteristics(PlayerType *player_ptr, uin
 static void process_light_equipment_characteristics(PlayerType *player_ptr, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
     const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
-    for (const auto i : range) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : range) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();
 
         auto b = false;
@@ -209,8 +209,8 @@ static void process_light_equipment_characteristics(PlayerType *player_ptr, all_
 static void process_inventory_characteristic(PlayerType *player_ptr, tr_type flag, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
     const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
-    for (const auto i : range) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : range) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();
 
         auto f_imm = flag_to_greater_flag.find(flag);

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -104,7 +104,7 @@ static std::array<tr_type, 6> lite_flags = {
  */
 static void process_cursed_equipment_characteristics(PlayerType *player_ptr, uint16_t mode, char_stat &char_stat)
 {
-    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
     for (const auto i_idx : range) {
         auto *o_ptr = player_ptr->inventory[i_idx].get();
         auto is_known = o_ptr->is_known();
@@ -153,7 +153,7 @@ static void process_cursed_equipment_characteristics(PlayerType *player_ptr, uin
  */
 static void process_light_equipment_characteristics(PlayerType *player_ptr, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
-    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
     for (const auto i_idx : range) {
         auto *o_ptr = player_ptr->inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();
@@ -208,7 +208,7 @@ static void process_light_equipment_characteristics(PlayerType *player_ptr, all_
  */
 static void process_inventory_characteristic(PlayerType *player_ptr, tr_type flag, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
-    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
     for (const auto i_idx : range) {
         auto *o_ptr = player_ptr->inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();

--- a/src/view/display-characteristic.cpp
+++ b/src/view/display-characteristic.cpp
@@ -104,8 +104,8 @@ static std::array<tr_type, 6> lite_flags = {
  */
 static void process_cursed_equipment_characteristics(PlayerType *player_ptr, uint16_t mode, char_stat &char_stat)
 {
-    int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
+    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    for (const auto i : range) {
         auto *o_ptr = player_ptr->inventory[i].get();
         auto is_known = o_ptr->is_known();
         auto is_sensed = is_known || o_ptr->has_identification_flag(IdentificationFlag::SENSE);
@@ -153,8 +153,8 @@ static void process_cursed_equipment_characteristics(PlayerType *player_ptr, uin
  */
 static void process_light_equipment_characteristics(PlayerType *player_ptr, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
-    int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
+    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    for (const auto i : range) {
         auto *o_ptr = player_ptr->inventory[i].get();
         auto flags = o_ptr->get_flags_known();
 
@@ -208,8 +208,8 @@ static void process_light_equipment_characteristics(PlayerType *player_ptr, all_
  */
 static void process_inventory_characteristic(PlayerType *player_ptr, tr_type flag, all_player_flags *f, uint16_t mode, char_stat &char_stat)
 {
-    int max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
+    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    for (const auto i : range) {
         auto *o_ptr = player_ptr->inventory[i].get();
         auto flags = o_ptr->get_flags_known();
 

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -36,13 +36,13 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     auto col = command_gap;
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
-    for (const auto i : INVEN_PACK_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
         if (!item.is_valid()) {
             continue;
         }
 
-        z = enum2i(i) + 1;
+        z = enum2i(i_idx) + 1;
     }
 
     COMMAND_CODE i;
@@ -140,12 +140,12 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
     }
 
     const auto &[wid, hgt] = term_get_size();
-    for (const auto i : INVEN_PACK_SLOTS) {
-        auto o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_PACK_SLOTS) {
+        auto o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
-        z = enum2i(i) + 1;
+        z = enum2i(i_idx) + 1;
     }
 
     for (auto i = 0; i < z; i++) {

--- a/src/view/display-inventory.cpp
+++ b/src/view/display-inventory.cpp
@@ -28,7 +28,6 @@
  */
 COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
-    COMMAND_CODE i;
     int k, l, z = 0;
     COMMAND_CODE out_index[23]{};
     TERM_COLOR out_color[23]{};
@@ -37,15 +36,16 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     auto col = command_gap;
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
-    for (i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         if (!item.is_valid()) {
             continue;
         }
 
-        z = i + 1;
+        z = enum2i(i) + 1;
     }
 
+    COMMAND_CODE i;
     const auto inven_label = prepare_label_string(player_ptr, USE_INVEN, item_tester);
     for (k = 0, i = 0; i < z; i++) {
         auto &item = *player_ptr->inventory[i];
@@ -133,22 +133,22 @@ COMMAND_CODE show_inventory(PlayerType *player_ptr, int target_item, BIT_FLAGS m
  */
 void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
 {
-    int i, z = 0;
+    int z = 0;
     TERM_COLOR attr = TERM_WHITE;
     if (!player_ptr || player_ptr->inventory.empty()) {
         return;
     }
 
     const auto &[wid, hgt] = term_get_size();
-    for (i = 0; i < INVEN_PACK; i++) {
+    for (const auto i : INVEN_PACK_SLOTS) {
         auto o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;
         }
-        z = i + 1;
+        z = enum2i(i) + 1;
     }
 
-    for (i = 0; i < z; i++) {
+    for (auto i = 0; i < z; i++) {
         if (i >= hgt) {
             break;
         }
@@ -190,7 +190,7 @@ void display_inventory(PlayerType *player_ptr, const ItemTester &item_tester)
         }
     }
 
-    for (i = z; i < hgt; i++) {
+    for (auto i = z; i < hgt; i++) {
         term_erase(0, i);
     }
 }

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -207,7 +207,7 @@ static DisplaySymbol compensate_stat_by_weapon(uint8_t color, ItemEntity *o_ptr,
  */
 static void display_equipments_compensation(PlayerType *player_ptr, int row, int *col)
 {
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
         o_ptr = player_ptr->inventory[i].get();
         auto flags = o_ptr->get_flags_known();

--- a/src/view/display-player-stat-info.cpp
+++ b/src/view/display-player-stat-info.cpp
@@ -207,9 +207,9 @@ static DisplaySymbol compensate_stat_by_weapon(uint8_t color, ItemEntity *o_ptr,
  */
 static void display_equipments_compensation(PlayerType *player_ptr, int row, int *col)
 {
-    for (const auto i : INVEN_WIELDING_SLOTS) {
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         ItemEntity *o_ptr;
-        o_ptr = player_ptr->inventory[i].get();
+        o_ptr = player_ptr->inventory[i_idx].get();
         auto flags = o_ptr->get_flags_known();
         for (int stat = 0; stat < A_MAX; stat++) {
             DisplaySymbol symbol(TERM_SLATE, '.');

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -334,14 +334,14 @@ tl::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
 void display_player_equippy(PlayerType *player_ptr, TERM_LEN y, TERM_LEN x, BIT_FLAGS16 mode)
 {
     const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
-    for (const auto i : range) {
-        const auto &item = *player_ptr->inventory[i];
+    for (const auto i_idx : range) {
+        const auto &item = *player_ptr->inventory[i_idx];
         auto symbol = item.get_symbol();
         if (!equippy_chars || !item.is_valid()) {
             symbol.color = TERM_DARK;
             symbol.character = ' ';
         }
 
-        term_putch(x + i - INVEN_MAIN_HAND, y, symbol);
+        term_putch(x + i_idx - INVEN_MAIN_HAND, y, symbol);
     }
 }

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -333,7 +333,7 @@ tl::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
  */
 void display_player_equippy(PlayerType *player_ptr, TERM_LEN y, TERM_LEN x, BIT_FLAGS16 mode)
 {
-    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    const auto range = (mode & DP_WP) ? INVEN_WEAPON_SLOTS : INVEN_WIELDING_SLOTS;
     for (const auto i_idx : range) {
         const auto &item = *player_ptr->inventory[i_idx];
         auto symbol = item.get_symbol();

--- a/src/view/display-player.cpp
+++ b/src/view/display-player.cpp
@@ -333,8 +333,8 @@ tl::optional<int> display_player(PlayerType *player_ptr, const int tmp_mode)
  */
 void display_player_equippy(PlayerType *player_ptr, TERM_LEN y, TERM_LEN x, BIT_FLAGS16 mode)
 {
-    const auto max_i = (mode & DP_WP) ? INVEN_BOW + 1 : INVEN_TOTAL;
-    for (int i = INVEN_MAIN_HAND; i < max_i; i++) {
+    const auto range = (mode & DP_WP) ? EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_BOW) : INVEN_WIELDING_SLOTS;
+    for (const auto i : range) {
         const auto &item = *player_ptr->inventory[i];
         auto symbol = item.get_symbol();
         if (!equippy_chars || !item.is_valid()) {

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -311,18 +311,18 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
     const auto &[wid, hgt] = term_get_size();
     const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     byte attr = TERM_WHITE;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        int cur_row = i - INVEN_MAIN_HAND;
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        int cur_row = i_idx - INVEN_MAIN_HAND;
         if (cur_row >= hgt) {
             break;
         }
 
-        const auto &item = *player_ptr->inventory[i];
-        auto do_disp = player_ptr->select_ring_slot ? is_ring_slot(i) : item_tester.okay(&item);
+        const auto &item = *player_ptr->inventory[i_idx];
+        auto do_disp = player_ptr->select_ring_slot ? is_ring_slot(i_idx) : item_tester.okay(&item);
         std::string tmp_val = "   ";
 
         if (do_disp) {
-            tmp_val[0] = index_to_label(i);
+            tmp_val[0] = index_to_label(i_idx);
             tmp_val[1] = ')';
         }
 
@@ -331,8 +331,8 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
         term_putstr(0, cur_row, cur_col, TERM_WHITE, tmp_val);
 
         std::string item_name;
-        auto is_two_handed = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr);
-        is_two_handed |= (i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr);
+        auto is_two_handed = (i_idx == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr);
+        is_two_handed |= (i_idx == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr);
         if (is_two_handed && has_two_handed_weapons(player_ptr)) {
             item_name = _("(武器を両手持ち)", "(wielding with two-hands)");
             attr = TERM_WHITE;
@@ -365,7 +365,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
 
         if (show_labels) {
             term_putstr(wid - 20, cur_row, -1, TERM_WHITE, " <-- ");
-            prt(mention_use(player_ptr, i), cur_row, wid - 15);
+            prt(mention_use(player_ptr, i_idx), cur_row, wid - 15);
         }
     }
 

--- a/src/window/display-sub-windows.cpp
+++ b/src/window/display-sub-windows.cpp
@@ -4,6 +4,7 @@
 #include "game-option/special-options.h"
 #include "game-option/text-display-options.h"
 #include "inventory/inventory-describer.h"
+#include "inventory/inventory-slot-types.h"
 #include "inventory/inventory-util.h"
 #include "locale/japanese.h"
 #include "main/sound-of-music.h"
@@ -310,7 +311,7 @@ static void display_equipment(PlayerType *player_ptr, const ItemTester &item_tes
     const auto &[wid, hgt] = term_get_size();
     const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     byte attr = TERM_WHITE;
-    for (int i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         int cur_row = i - INVEN_MAIN_HAND;
         if (cur_row >= hgt) {
             break;

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -41,11 +41,11 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
     k = 0;
-    for (const auto i : INVEN_WIELDING_SLOTS) {
-        const auto &item = *player_ptr->inventory[i];
-        auto only_slot = !(player_ptr->select_ring_slot ? is_ring_slot(i) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
-        auto is_any_hand = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr);
-        is_any_hand |= (i == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr);
+    for (const auto i_idx : INVEN_WIELDING_SLOTS) {
+        const auto &item = *player_ptr->inventory[i_idx];
+        auto only_slot = !(player_ptr->select_ring_slot ? is_ring_slot(i_idx) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
+        auto is_any_hand = (i_idx == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr);
+        is_any_hand |= (i_idx == INVEN_SUB_HAND) && can_attack_with_main_hand(player_ptr);
         auto is_two_handed = is_any_hand && has_two_handed_weapons(player_ptr);
         only_slot &= !is_two_handed || any_bits(mode, IGNORE_BOTHHAND_SLOT);
         if (only_slot) {
@@ -61,7 +61,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
             out_color[k] = tval_to_attr[enum2i(item.bi_key.tval()) % 128];
         }
 
-        out_index[k] = i;
+        out_index[k] = i_idx;
         if (item.timeout) {
             out_color[k] = TERM_L_DARK;
         }

--- a/src/window/main-window-equipments.cpp
+++ b/src/window/main-window-equipments.cpp
@@ -32,7 +32,6 @@
  */
 COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS mode, const ItemTester &item_tester)
 {
-    COMMAND_CODE i;
     int j, k, l;
     COMMAND_CODE out_index[23]{};
     TERM_COLOR out_color[23]{};
@@ -41,7 +40,8 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     auto col = command_gap;
     const auto &[wid, hgt] = term_get_size();
     auto len = wid - col - 1;
-    for (k = 0, i = INVEN_MAIN_HAND; i < INVEN_TOTAL; i++) {
+    k = 0;
+    for (const auto i : INVEN_WIELDING_SLOTS) {
         const auto &item = *player_ptr->inventory[i];
         auto only_slot = !(player_ptr->select_ring_slot ? is_ring_slot(i) : (item_tester.okay(&item) || any_bits(mode, USE_FULL)));
         auto is_any_hand = (i == INVEN_MAIN_HAND) && can_attack_with_sub_hand(player_ptr);
@@ -90,7 +90,7 @@ COMMAND_CODE show_equipment(PlayerType *player_ptr, int target_item, BIT_FLAGS m
     const auto equip_label = prepare_label_string(player_ptr, USE_EQUIP, item_tester);
     const auto &empty_symbol = BaseitemService::get_dummy_symbol();
     for (j = 0; j < k; j++) {
-        i = out_index[j];
+        const auto i = out_index[j];
         const auto &item = *player_ptr->inventory[i];
         prt("", j + 1, col ? col - 2 : col);
         std::string head;

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -36,6 +36,7 @@
 #include "wizard/wizard-spells.h"
 #include "wizard/wizard-spoiler.h"
 #include <algorithm>
+#include <range/v3/view.hpp>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -255,7 +256,7 @@ bool exe_cmd_debug(PlayerType *player_ptr, char cmd)
         gain_exp(player_ptr, command_arg ? command_arg : (player_ptr->exp + 1));
         return true;
     case 'X':
-        for (INVENTORY_IDX i = INVEN_TOTAL - 1; i >= 0; i--) {
+        for (const auto i : INVEN_ALL_SLOTS | ranges::views::reverse) {
             if (player_ptr->inventory[i]->is_valid()) {
                 drop_from_inventory(player_ptr, i, 999);
             }

--- a/src/wizard/cmd-wizard.cpp
+++ b/src/wizard/cmd-wizard.cpp
@@ -256,9 +256,9 @@ bool exe_cmd_debug(PlayerType *player_ptr, char cmd)
         gain_exp(player_ptr, command_arg ? command_arg : (player_ptr->exp + 1));
         return true;
     case 'X':
-        for (const auto i : INVEN_ALL_SLOTS | ranges::views::reverse) {
-            if (player_ptr->inventory[i]->is_valid()) {
-                drop_from_inventory(player_ptr, i, 999);
+        for (const auto i_idx : INVEN_ALL_SLOTS | ranges::views::reverse) {
+            if (player_ptr->inventory[i_idx]->is_valid()) {
+                drop_from_inventory(player_ptr, i_idx, 999);
             }
         }
 

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -270,7 +270,7 @@ void wiz_modify_item_activation(PlayerType *player_ptr)
  */
 void wiz_identify_full_inventory(PlayerType *player_ptr)
 {
-    for (int i = 0; i < INVEN_TOTAL; i++) {
+    for (const auto i : INVEN_ALL_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i].get();
         if (!o_ptr->is_valid()) {
             continue;

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -270,8 +270,8 @@ void wiz_modify_item_activation(PlayerType *player_ptr)
  */
 void wiz_identify_full_inventory(PlayerType *player_ptr)
 {
-    for (const auto i : INVEN_ALL_SLOTS) {
-        auto *o_ptr = player_ptr->inventory[i].get();
+    for (const auto i_idx : INVEN_ALL_SLOTS) {
+        auto *o_ptr = player_ptr->inventory[i_idx].get();
         if (!o_ptr->is_valid()) {
             continue;
         }


### PR DESCRIPTION
アイテムスロット範囲を定義したEnumRange型の定数を追加し、従来のアイテムスロット範囲のforループを範囲for文に置き換えることを中心にしたリファクタリングを行い、可読性を向上する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 所持品・装備品の対象スロットを定義済みの集合で統一し、表示・鑑定・自動拾い・再充填・呪い/解呪・保存/復元などの挙動を整合させました。
* **改善**
  * 所持品/装備の表示順や対象範囲が更新されます。
* **その他**
  * スロット列挙の取り扱いを整理し、関連処理の一貫性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->