### PR TITLE
[Refactor] MessageReaderのクラス化

### DIFF
--- a/src/info-reader/message-reader.cpp
+++ b/src/info-reader/message-reader.cpp
@@ -14,6 +14,25 @@
 #include "view/display-messages.h"
 #include <string>
 
+MessageReader::MessageReader(const nlohmann::json &message_data)
+    : message_data(message_data)
+{
+}
+
+/*!
+ * @brief モンスターメッセージ情報(JSON Object)のパース関数
+ * @return エラーコード
+ */
+int MessageReader::read() const
+{
+    if (auto err = this->set_mon_message()) {
+        msg_format(_("モンスターメッセージ読込失敗。", "Failed to load monster message."));
+        return err;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
 /*!
  * @brief JSON Objectからid群をセットする
  * @param id_list_data id群情報の格納されたJSON Object
@@ -41,16 +60,16 @@ static errr set_id_list(const nlohmann::json &id_list_data, std::vector<int> &id
 
 /*!
  * @brief JSON Objectからモンスターのメッセージをセットする
- * @param message_data メッセージ情報の格納されたJSON Object
  * @return エラーコード
  */
-static errr set_mon_message(const nlohmann::json &group_data)
+int MessageReader::set_mon_message() const
 {
+    const auto &group_data = this->message_data;
     const auto message_iter = group_data.find("message");
     if (message_iter == group_data.end() || !message_iter->is_array()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
-    const auto &message_data = message_iter.value();
+    const auto &message_array = message_iter.value();
     auto id_list = std::vector<int>();
 
     const auto id_list_iter = group_data.find("id_list");
@@ -62,21 +81,22 @@ static errr set_mon_message(const nlohmann::json &group_data)
             return id_err;
         }
     } else {
-        if (!group_data["name"].is_string()) {
+        const auto &name_obj = get_json_value(group_data, "name");
+        if (!name_obj.is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        const auto group_name = group_data["name"].get<std::string>();
+        const auto group_name = name_obj.get<std::string>();
         if (group_name != "DEFAULT") {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
     }
 
-    if (!message_data.is_array()) {
+    if (!message_array.is_array()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    for (const auto &message : message_data) {
+    for (const auto &message : message_array) {
         const auto action_iter = message.find("action");
         if (action_iter == message.end() || !action_iter->is_string()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -157,23 +177,5 @@ static errr set_mon_message(const nlohmann::json &group_data)
             }
         }
     }
-    return PARSE_ERROR_NONE;
-}
-
-/*!
- * @brief モンスターメッセージ情報(JSON Object)のパース関数
- * @param mon_data モンスターメッセージの格納されたJSON Object
- * @param head ヘッダ構造体
- * @return エラーコード
- */
-int parse_monster_messages_info(nlohmann::json &message_data)
-{
-    errr err;
-    err = set_mon_message(message_data);
-    if (err) {
-        msg_format(_("モンスターメッセージ読込失敗。", "Failed to load monster message."));
-        return err;
-    }
-
     return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/message-reader.h
+++ b/src/info-reader/message-reader.h
@@ -2,4 +2,19 @@
 
 #include <nlohmann/json.hpp>
 
-int parse_monster_messages_info(nlohmann::json &element);
+class MessageReader {
+public:
+    explicit MessageReader(const nlohmann::json &message_data);
+    MessageReader(nlohmann::json &&) = delete;
+    MessageReader(const MessageReader &) = delete;
+    MessageReader(MessageReader &&) = delete;
+    MessageReader &operator=(const MessageReader &) = delete;
+    MessageReader &operator=(MessageReader &&) = delete;
+
+    int read() const;
+
+private:
+    int set_mon_message() const;
+
+    const nlohmann::json &message_data;
+};

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -245,7 +245,10 @@ void init_monrace_definitions()
  */
 void init_monster_message_definitions()
 {
-    init_json("MonsterMessages.jsonc", "groups", DefinitionHashDataType::MONSTER_MESSAGES, MonraceMessageList::get_instance(), parse_monster_messages_info);
+    auto parser = [](nlohmann::json &message_data) {
+        return MessageReader(message_data).read();
+    };
+    init_json("MonsterMessages.jsonc", "groups", DefinitionHashDataType::MONSTER_MESSAGES, MonraceMessageList::get_instance(), parser);
 }
 
 /*!


### PR DESCRIPTION
## 概要
モンスターメッセージ定義(`MonsterMessages.jsonc`)のパース処理を、フリー関数 `parse_monster_messages_info` から `MessageReader` クラスへ移行しました。先行する `BaseitemReader` / `ArtifactReader` 等と同じ設計に揃えています。

## 変更点
- `parse_monster_messages_info(nlohmann::json&)` を `MessageReader::read() const` に置き換え
- `set_mon_message` を `const` メンバ関数化し、保持する `const nlohmann::json& message_data` を参照
- 唯一の生 `operator[]`(`group_data["name"]`)を `get_json_value()` 経由に統一
  - `id_list`・`name` をともに欠く不正データに対し、`const` 参照への `operator[]` がキー欠如時に起こす未定義動作も併せて解消されます(#5471 の message 該当箇所)
- `init_monster_message_definitions()` を Reader オブジェクト経由の呼び出しに変更
- 汎用ヘルパ `set_id_list` は static フリー関数のまま維持

## 検証
- ビルド(Debug|Win32)成功
- 既存の `MonsterMessages.jsonc` で挙動が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * メッセージ定義の読み込み処理を整理し、初期化時の安定性を向上しました。
  * 一部のJSON入力チェックを見直し、想定外のデータでもより安全に処理できるようになりました。
* **Refactor**
  * メッセージ読み込みの実装をクラスベースに統合し、処理の流れをシンプルにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->