### PR TITLE
[Refactor] SpellReaderのクラス化

### DIFF
--- a/src/info-reader/spell-reader.cpp
+++ b/src/info-reader/spell-reader.cpp
@@ -7,19 +7,46 @@
 #include "util/string-processor.h"
 #include "view/display-messages.h"
 
+SpellReader::SpellReader(const nlohmann::json &realm_data, SpellInfoList &spell_info_list)
+    : realm_data(realm_data)
+    , spell_info_list(spell_info_list)
+{
+}
+
+/*!
+ * @brief 呪文情報(SpellDefinitions)のパース関数
+ * @return エラーコード
+ */
+int SpellReader::read() const
+{
+    error_idx++; //!< @note 呪文領域は数値IDを持たないため、エラー表示用に要素の順序を用いる
+
+    RealmType realm_id;
+    if (auto err = this->set_realm(realm_id)) {
+        msg_format(_("領域名読込失敗。ID: '%d'。", "Failed to load realm name. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    if (auto err = this->set_book_data(realm_id)) {
+        msg_format(_("呪文詳細読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
+        return err;
+    }
+
+    return PARSE_ERROR_NONE;
+}
+
 /*!
  * @brief JSON Objectから呪文領域IDを取得する
- * @param spell_data 情報の格納されたJSON Object
  * @param realm 呪文領域
  * @return エラーコード
  */
-static errr set_realm(const nlohmann::json &spell_data, RealmType &realm)
+int SpellReader::set_realm(RealmType &realm) const
 {
-    if (spell_data.is_null()) {
+    if (this->realm_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
-    const auto &realmname_obj = spell_data["name"];
+    const auto &realmname_obj = get_json_value(this->realm_data, "name");
     if (!realmname_obj.is_string()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
@@ -35,91 +62,66 @@ static errr set_realm(const nlohmann::json &spell_data, RealmType &realm)
 /*!
  * @brief JSON Objectから各呪文の詳細を取得する
  * @param spell_data 情報の格納されたJSON Object
- * @param spell_info_list 呪文情報リスト
  * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_spell_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
+int SpellReader::set_spell_data(const nlohmann::json &spell_data, RealmType realm) const
 {
     if (spell_data.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
     int spell_id;
-    if (auto err = info_set_integer(spell_data["spell_id"], spell_id, true, Range(0, 31))) {
+    if (auto err = info_set_integer(get_json_value(spell_data, "spell_id"), spell_id, true, Range(0, 31))) {
         msg_format(_("呪文ID読込失敗。ID: '%d'。", "Failed to load spell ID. ID: '%d'."), error_idx);
         return err;
     }
     auto info = SpellInfo();
     info.idx = static_cast<short>(spell_id);
 
-    const auto &tag_obj = spell_data["spell_tag"];
+    const auto &tag_obj = get_json_value(spell_data, "spell_tag");
     if (!tag_obj.is_string()) {
         msg_format(_("呪文タグ読込失敗。ID: '%d'。", "Failed to load spell tag. ID: '%d'."), error_idx);
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
     info.tag = tag_obj.get<std::string>();
 
-    if (auto err = info_set_string(spell_data["name"], info.name, true)) {
+    if (auto err = info_set_string(get_json_value(spell_data, "name"), info.name, true)) {
         msg_format(_("呪文名読込失敗。ID: '%d'。", "Failed to load spell name. ID: '%d'."), error_idx);
         return err;
     }
-    if (auto err = info_set_string(spell_data["description"], info.description, true)) {
+    if (auto err = info_set_string(get_json_value(spell_data, "description"), info.description, true)) {
         msg_format(_("呪文説明読込失敗。ID: '%d'。", "Failed to load spell description. ID: '%d'."), error_idx);
         return err;
     }
-    spell_info_list.set_spell_info(realm, spell_id, std::move(info));
+    this->spell_info_list.set_spell_info(realm, spell_id, std::move(info));
 
     return PARSE_ERROR_NONE;
 }
 
 /*!
  * @brief JSON Objectから各呪文の詳細を呪文書単位で取得する
- * @param spell_data 情報の格納されたJSON Object
- * @param spell_info_list 呪文情報リスト
  * @param realm 領域ID
  * @return エラーコード
  */
-static errr set_book_data(const nlohmann::json &spell_data, SpellInfoList &spell_info_list, RealmType realm)
+int SpellReader::set_book_data(RealmType realm) const
 {
-    auto &book_obj = spell_data["books"];
+    const auto &book_obj = get_json_value(this->realm_data, "books");
     if (book_obj.is_null()) {
         return PARSE_ERROR_TOO_FEW_ARGUMENTS;
     }
 
     for (const auto &book : book_obj) {
-        const auto &spells_obj = book["spells"];
+        const auto &spells_obj = get_json_value(book, "spells");
         if (spells_obj.is_null()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
         for (const auto &spell : spells_obj) {
-            if (auto err = set_spell_data(spell, spell_info_list, realm)) {
+            if (auto err = this->set_spell_data(spell, realm)) {
                 return err;
             }
         }
     }
-    return PARSE_ERROR_NONE;
-}
-
-/*!
- * @brief 職業魔法情報(ClassMagicDefinitions)のパース関数
- * @param buf テキスト列
- * @param spell_info_list パースした結果を格納する領域
- * @return エラーコード
- */
-errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list)
-{
-    RealmType realm_id;
-    if (auto err = set_realm(spell_data, realm_id)) {
-        msg_format(_("領域名読込失敗。ID: '%d'。", "Failed to load realm name. ID: '%d'."), error_idx);
-        return err;
-    }
-
-    if (auto err = set_book_data(spell_data, spell_info_list, realm_id)) {
-        msg_format(_("呪文詳細読込失敗。ID: '%d'。", "Failed to load spell data. ID: '%d'."), error_idx);
-        return err;
-    }
-
     return PARSE_ERROR_NONE;
 }

--- a/src/info-reader/spell-reader.h
+++ b/src/info-reader/spell-reader.h
@@ -1,8 +1,26 @@
 #pragma once
 
-#include "system/angband.h"
 #include <nlohmann/json.hpp>
 
+enum class RealmType;
 class SpellInfoList;
 
-errr parse_spell_info(nlohmann::json &spell_data, SpellInfoList &spell_info_list);
+class SpellReader {
+public:
+    SpellReader(const nlohmann::json &realm_data, SpellInfoList &spell_info_list);
+    SpellReader(nlohmann::json &&, SpellInfoList &) = delete;
+    SpellReader(const SpellReader &) = delete;
+    SpellReader(SpellReader &&) = delete;
+    SpellReader &operator=(const SpellReader &) = delete;
+    SpellReader &operator=(SpellReader &&) = delete;
+
+    int read() const;
+
+private:
+    int set_realm(RealmType &realm) const;
+    int set_spell_data(const nlohmann::json &spell_data, RealmType realm) const;
+    int set_book_data(RealmType realm) const;
+
+    const nlohmann::json &realm_data;
+    SpellInfoList &spell_info_list;
+};

--- a/src/main/info-initializer.cpp
+++ b/src/main/info-initializer.cpp
@@ -256,7 +256,7 @@ void init_spell_info()
     auto &spell_info_list = SpellInfoList::get_instance();
     spell_info_list.initialize();
     auto parser = [&spell_info_list](nlohmann::json &spell_data) {
-        return parse_spell_info(spell_data, spell_info_list);
+        return SpellReader(spell_data, spell_info_list).read();
     };
     init_json("SpellDefinitions.jsonc", "realms", DefinitionHashDataType::SPELLS, spell_info_list, parser);
 }


### PR DESCRIPTION
## 概要
呪文定義(`SpellDefinitions.jsonc`)のパース処理を、フリー関数 `parse_spell_info` から `SpellReader` クラスへ移行しました。先行する `BaseitemReader` / `ArtifactReader` 等と同じ設計に揃えています。

## 変更点
- `parse_spell_info(nlohmann::json&, SpellInfoList&)` を `SpellReader::read() const` に置き換え
- 本 reader のみ外部リストを必要とするため、`SpellReader` は `const nlohmann::json& realm_data` と `SpellInfoList& spell_info_list` の2つをメンバとして保持
- `set_realm` / `set_spell_data` / `set_book_data` を `const` メンバ関数化
- 全 JSON キーアクセスを `get_json_value()` 経由に統一
  - 非object・欠落キーの不正データに対し、`const` 参照への `operator[]` が起こす例外送出/未定義動作も併せて解消されます(#5471 の spell 該当箇所)
- `init_spell_info()` を Reader オブジェクト経由の呼び出しに変更(ラムダで `SpellInfoList` をキャプチャ)

## 検証
- ビルド(Debug|Win32)成功
- 既存の `SpellDefinitions.jsonc` で挙動が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **機能改善**
  * 呪文定義の読み込み処理が新しい読み取りAPIに置き換わり、JSONの解析と登録の流れがより一貫しました。
  * レルムごとに関連する呪文詳細を順に取得・登録する仕組みに更新しました。
* **変更**
  * 呪文読み込みの公開インターフェイスを、関数ベースからクラスベースへ整理しました。
  * 読み込み時のエラー検出と中断挙動を、読み取り処理内で統一しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->