### PR TITLE
[Fix] 不正値で実行時不具合を起こすデータをJSON Schemaで弾く

### DIFF
--- a/schema/DungeonDefinitions.schema.json
+++ b/schema/DungeonDefinitions.schema.json
@@ -218,7 +218,8 @@
         },
         "rate": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 32767
         }
       }
     },
@@ -244,7 +245,8 @@
         },
         "rate": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 32767
         }
       }
     },

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -232,9 +232,9 @@
                     "blows": {
                         "type": "array",
                         "description": "物理攻撃",
+                        "maxItems": 4,
                         "items": {
                             "type": "object",
-                            "maxItems": 4,
                             "additionalProperties": false,
                             "required": [
                                 "method",
@@ -554,7 +554,7 @@
                             "probability": {
                                 "type": "string",
                                 "description": "能力使用確率",
-                                "pattern": "1_IN_[1-9][0-9]*"
+                                "pattern": "^1_IN_([1-9][0-9]?|100)$"
                             },
                             "shoot": {
                                 "type": "string",


### PR DESCRIPTION
## 概要
CI で強制されている JSON Schema validation（`lib/edit` ↔ `schema`）を厳格化し、**reader 側に到達すると実行時不具合（メモリ破壊・ゼロ除算・桁あふれ・例外）を起こす値を、データ読込前に schema validation で排除**します。

Issue #5471 / #5468 のうち、既存の schema 制約では弾けず**到達可能**だった分に対応します。

## 変更点
- **MonraceDefinitions: `skill.probability` の分母を 1〜100 に制限**（`^1_IN_([1-9][0-9]?|100)$`）
  - 旧 `1_IN_[1-9][0-9]*` は `1_IN_256` 等を許容し、`set_mon_skills` で `byte` への narrowing により分母が 0 になり `100 / denominator` がゼロ除算となっていました。併せて巨大値（`std::stoi` の `out_of_range`）も排除されます。
- **MonraceDefinitions: `blows` の `maxItems: 4` を配列レベルへ移動**
  - 旧定義では `maxItems` が `items` サブスキーマ（各要素オブジェクト）の中にあり、配列専用キーワードである `maxItems` がオブジェクトに対して **no-op** となっていました。そのため打撃5個以上のデータが schema を通過し、`set_mon_blows` で `MonsterBlow blows[MAX_NUM_BLOWS=4]` への範囲外書き込み(UB/メモリ破壊)が起き得ました（reader のガードは `blow_num > 5`）。`maxItems:4` を配列本体に効かせて排除します。
- **DungeonDefinitions: `tile.rate` に `maximum: 32767`(=SHRT_MAX) を追加**
  - `parse_terrain_probability` の `get<short>()` で SHRT_MAX 超過時に桁あふれ（weight 破損）が起きていました。

## このアプローチの理由
本リポジトリは PR ごとに `validate_json.py`（pyjson5 + jsonschema）で `lib/edit/*.jsonc` を schema 検証しており、**schema が不正データの防御層**になっています。上記は schema 制約が緩い／誤配置だったため不正値が通過していたもので、schema を正すことでコード変更なしに不具合を排除しました。

## 検証
- 既存 `lib/edit/*.jsonc` を網羅確認: `skill.probability` は `1_IN_1`〜`1_IN_15`（13種）、全1408 monster の最大 blow 数は **4**、`tile.rate` は 5〜100（62値）。いずれも新制約内で、shipped データは引き続き valid（CI 破壊なし）。
- 正規表現の挙動確認: `1_IN_1`〜`1_IN_100` は valid、`1_IN_0` / `1_IN_256` / `1_IN_101` / 巨大値は invalid。
- 最終的な schema 検証は CI(JSON Schema Validation)に委ねます。

## 補足: 既に schema で防御済みのため対応不要な finding
- **#5467**(空文字 `.front()`): `character` の1文字パターンで空文字を排除
- **#5469**(`is_string` 欠如): `method`/`effect`/`flags`/`skill.list`/`action` はすべて `type:string`(+enum)
- **#5471 magic `info[]` 範囲外書込**: `realms[].name` の enum が魔法領域(LIFE〜CRUSADE)のみで技芸領域を含まない
- **#5471 baseitem/artifact の `std::stoi`**: `activate` が enum(フラグ名のみ・数値文字列不可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 一部の定義スキーマで、値の上限チェックが追加され、想定外に大きい数値が受け入れられないようになりました。
  * モンスター定義の配列件数制限が正しく適用されるようになり、入力検証の精度が改善されました。
  * スキル確率の書式チェックがより厳密になり、無効な値を検出しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->