### PR TITLE
[Fix] フロア連結性チェックが生成成功時に判定されず孤立領域が再生成されない不具合を修正

### DIFF
--- a/src/floor/floor-generator.cpp
+++ b/src/floor/floor-generator.cpp
@@ -506,7 +506,7 @@ void generate_floor(PlayerType *player_ptr)
         // 狂戦士でのプレイに支障をきたしうるので再生成する。
         // 地上、荒野マップ、クエストでは連結性判定は行わない。
         // TODO: 本来はダンジョン生成アルゴリズム自身で連結性を保証するのが理想ではある。
-        const auto check_conn = why && floor.is_underground() && !floor.is_in_quest();
+        const auto check_conn = !why && floor.is_underground() && !floor.is_in_quest();
         if (check_conn && !floor_is_connected(floor, is_permanent_blocker)) {
             // 一定回数試しても連結にならないなら諦める。
             if (num >= 1000) {


### PR DESCRIPTION
## 概要

issue #5483 の修正。`generate_floor()` のフロア連結性チェック（永久壁で分断された孤立領域があれば再生成する処理）が、条件の極性反転により**生成成功時に判定されず、実質的に機能していなかった**不具合を修正する。

## 問題

`why` は `tl::optional<std::string>` で **値あり = 生成失敗** を表す。連結性チェックの条件が `check_conn = why && ...` となっていたため、

- チェックは**すでに別要因で生成に失敗しているフロアにしか実行されない**。
- 生成に成功した（`why` が空の）フロアは、永久壁で分断された孤立領域を含んでいても直後の `if (!why) break;` で受理され、**再生成されない**。
- `num >= 1000` の打ち切り安全弁も意味を持たない。

結果として、コメントに記載された本来の目的（孤立領域があれば再生成する／狂戦士でのプレイに支障をきたしうる懸念の回避）が果たされていなかった。

## 原因

初版 `a5c05a26c5`（2021-03-06）では成否フラグ `okay`（true = 成功）を用い、**生成成功時**に連結性を判定していた（正しい挙動）。`b33fd938a5`（#4057, 2024-11-10）のリファクタで成否表現を `okay` → `why` に置換した際、極性が逆であること（`okay && ...` は `!why && ...` と等価）が見落とされ、そのまま差し替えられて条件が反転した。

## 修正

```diff
-const auto check_conn = why && floor.is_underground() && !floor.is_in_quest();
+const auto check_conn = !why && floor.is_underground() && !floor.is_in_quest();
```

## 動作

- 生成成功（`why` 空）・地下・非クエストのときに連結性を判定する。
- 孤立領域があれば `why` をセットして再生成。`num >= 1000` で打ち切り（従来からの安全弁が機能するようになる）。
- 連結なフロアは `floor_is_connected()` が true を返し、これまで通り即受理される。

## 確認

- Debug | Win32 でビルド成功（コンパイルエラーなし）。
- `!why` が旧 `okay == true`、`is_underground()` が `dun_level > 0`、`!is_in_quest()` が `inside_quest == 0` にそれぞれ等価であることを確認。
- codex review クリーン（回帰なし）。

Closes #5483


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 地下フロアでクエスト中ではない場合の連結性チェックの実行条件を調整し、フロア生成の判定タイミングが正しくなるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->