### PR TITLE
[Refactor] CAVE_ICKY を CAVE_NO_TELEPORT_DEST にリネーム

### DIFF
--- a/src/dungeon/quest-monster-placer.cpp
+++ b/src/dungeon/quest-monster-placer.cpp
@@ -63,7 +63,7 @@ bool place_quest_monsters(PlayerType *player_ptr)
                         continue;
                     }
 
-                    if (grid.is_icky()) {
+                    if (grid.is_no_teleport_dest()) {
                         continue;
                     } else {
                         break;

--- a/src/floor/floor-streams.cpp
+++ b/src/floor/floor-streams.cpp
@@ -140,7 +140,7 @@ static void recursive_river(FloorType &floor, const Pos2D &pos_start, const Pos2
                     }
 
                     /* Hack -- don't teleport here */
-                    grid.info |= CAVE_ICKY;
+                    grid.info |= CAVE_NO_TELEPORT_DEST;
                 }
             }
 
@@ -380,7 +380,7 @@ void place_trees(PlayerType *player_ptr, const Pos2D &pos)
             }
 
             auto &grid = floor.get_grid(pos_neighbor);
-            if (any_bits(grid.info, CAVE_ICKY) || !grid.o_idx_list.empty()) {
+            if (any_bits(grid.info, CAVE_NO_TELEPORT_DEST) || !grid.o_idx_list.empty()) {
                 continue;
             }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -197,7 +197,7 @@ tl::optional<Pos2D> new_player_spot(PlayerType *player_ptr)
         }
 
         /* Refuse to start on anti-teleport grids */
-        if (grid.is_icky()) {
+        if (grid.is_no_teleport_dest()) {
             continue;
         }
 
@@ -566,7 +566,7 @@ void lite_spot(PlayerType *player_ptr, const Pos2D &pos)
  * and should be illuminated by "lite room" and "darkness" spells.
  *
  *
- * A grid may be marked as "CAVE_ICKY" which means it is part of a "vault",
+ * A grid may be marked as "CAVE_NO_TELEPORT_DEST" which means it is part of a "vault",
  * and should be unavailable for "teleportation" destinations.
  *
  *
@@ -891,7 +891,7 @@ bool cave_player_teleportable_bold(PlayerType *player_ptr, POSITION y, POSITION 
     }
 
     /* No magical teleporting into vaults and such */
-    if (!(mode & TELEPORT_NONMAGICAL) && grid.is_icky()) {
+    if (!(mode & TELEPORT_NONMAGICAL) && grid.is_no_teleport_dest()) {
         return false;
     }
     const auto &floor = *player_ptr->current_floor_ptr;

--- a/src/info-reader/general-parser.h
+++ b/src/info-reader/general-parser.h
@@ -19,7 +19,7 @@ struct dungeon_grid {
     EgoType ego; /* Ego-Item */
     FixedArtifactId artifact; /* Artifact */
     IDX trap; /* Trap */
-    BIT_FLAGS cave_info; /* Flags for CAVE_MARK, CAVE_GLOW, CAVE_ICKY, CAVE_ROOM */
+    BIT_FLAGS cave_info; /* Flags for CAVE_MARK, CAVE_GLOW, CAVE_NO_TELEPORT_DEST, CAVE_ROOM */
     int16_t special; /* Reserved for special terrain info */
     int random; /* Number of the random effect */
 

--- a/src/mind/mind-elementalist.cpp
+++ b/src/mind/mind-elementalist.cpp
@@ -1448,7 +1448,7 @@ static bool door_to_darkness(PlayerType *player_ptr, int distance)
             continue;
         }
 
-        if (!floor.is_empty_at(*p_pos) || floor.get_grid(*p_pos).is_icky()) {
+        if (!floor.is_empty_at(*p_pos) || floor.get_grid(*p_pos).is_no_teleport_dest()) {
             msg_print(_("そこには移動できない。", "Can not teleport to there."));
             continue;
         }

--- a/src/realm/realm-hex.cpp
+++ b/src/realm/realm-hex.cpp
@@ -653,7 +653,7 @@ tl::optional<std::string> do_hex_spell(PlayerType *player_ptr, spell_hex_type sp
 
                 const auto p_pos = player_ptr->get_position();
                 const auto dist = Grid::calc_distance(*pos_target, p_pos);
-                if (!floor.is_empty_at(*pos_target) || (*pos_target == p_pos) || floor.get_grid(*pos_target).is_icky() || (dist > player_ptr->lev + 2)) {
+                if (!floor.is_empty_at(*pos_target) || (*pos_target == p_pos) || floor.get_grid(*pos_target).is_no_teleport_dest() || (dist > player_ptr->lev + 2)) {
                     msg_print(_("そこには移動できない。", "Can not teleport to there."));
                     continue;
                 }

--- a/src/room/cave-filler.cpp
+++ b/src/room/cave-filler.cpp
@@ -92,7 +92,7 @@ void generate_hmap(FloorType &floor, POSITION y0, POSITION x0, POSITION xsiz, PO
     for (POSITION i = 0; i <= xsize; i++) {
         for (POSITION j = 0; j <= ysize; j++) {
             floor.grid_array[(int)(fill_data.ymin + j)][(int)(fill_data.xmin + i)].feat = -1;
-            floor.grid_array[(int)(fill_data.ymin + j)][(int)(fill_data.xmin + i)].info &= ~(CAVE_ICKY);
+            floor.grid_array[(int)(fill_data.ymin + j)][(int)(fill_data.xmin + i)].info &= ~(CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -180,11 +180,11 @@ static bool hack_isnt_wall(PlayerType *player_ptr, POSITION y, POSITION x, int c
     BIT_FLAGS info1, BIT_FLAGS info2, BIT_FLAGS info3)
 {
     auto &floor = *player_ptr->current_floor_ptr;
-    if (floor.grid_array[y][x].info & CAVE_ICKY) {
+    if (floor.grid_array[y][x].info & CAVE_NO_TELEPORT_DEST) {
         return false;
     }
 
-    floor.grid_array[y][x].info |= (CAVE_ICKY);
+    floor.grid_array[y][x].info |= (CAVE_NO_TELEPORT_DEST);
     if (floor.grid_array[y][x].feat <= c1) {
         if (randint1(100) < 75) {
             floor.grid_array[y][x].feat = feat1;
@@ -244,12 +244,12 @@ static void cave_fill(PlayerType *player_ptr, const Pos2D &initial_pos)
             const auto pos_to = pos + d.vec();
             auto &grid = floor.get_grid(pos_to);
             if (!floor.contains(pos_to, FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
-                grid.info |= CAVE_ICKY;
+                grid.info |= CAVE_NO_TELEPORT_DEST;
                 continue;
             }
 
             if ((pos_to.x <= fill_data.xmin) || (pos_to.x >= fill_data.xmax) || (pos_to.y <= fill_data.ymin) || (pos_to.y >= fill_data.ymax)) {
-                grid.info |= CAVE_ICKY;
+                grid.info |= CAVE_NO_TELEPORT_DEST;
                 continue;
             }
 
@@ -285,7 +285,7 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
         for (POSITION x = 0; x <= xsize; ++x) {
             for (POSITION y = 0; y <= ysize; ++y) {
                 place_bold(player_ptr, y0 + y - yhsize, x0 + x - xhsize, GB_EXTRA);
-                floor.grid_array[y0 + y - yhsize][x0 + x - xhsize].info &= ~(CAVE_ICKY | CAVE_ROOM);
+                floor.grid_array[y0 + y - yhsize][x0 + x - xhsize].info &= ~(CAVE_NO_TELEPORT_DEST | CAVE_ROOM);
             }
         }
 
@@ -294,7 +294,7 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
 
     for (int i = 0; i <= xsize; ++i) {
         auto &grid1 = floor.grid_array[y0 - yhsize][i + x0 - xhsize];
-        if (grid1.is_icky() && (room)) {
+        if (grid1.is_no_teleport_dest() && (room)) {
             place_bold(player_ptr, y0 - yhsize, x0 + i - xhsize, GB_OUTER);
             if (light) {
                 floor.grid_array[y0 - yhsize][x0 + i - xhsize].info |= (CAVE_GLOW);
@@ -307,7 +307,7 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
         }
 
         auto &grid2 = floor.grid_array[ysize + y0 - yhsize][i + x0 - xhsize];
-        if (grid2.is_icky() && (room)) {
+        if (grid2.is_no_teleport_dest() && (room)) {
             place_bold(player_ptr, y0 + ysize - yhsize, x0 + i - xhsize, GB_OUTER);
             if (light) {
                 grid2.info |= (CAVE_GLOW);
@@ -319,13 +319,13 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
             place_bold(player_ptr, y0 + ysize - yhsize, x0 + i - xhsize, GB_EXTRA);
         }
 
-        grid1.info &= ~(CAVE_ICKY);
-        grid2.info &= ~(CAVE_ICKY);
+        grid1.info &= ~(CAVE_NO_TELEPORT_DEST);
+        grid2.info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (int i = 1; i < ysize; ++i) {
         auto &grid1 = floor.grid_array[i + y0 - yhsize][x0 - xhsize];
-        if (grid1.is_icky() && room) {
+        if (grid1.is_no_teleport_dest() && room) {
             place_bold(player_ptr, y0 + i - yhsize, x0 - xhsize, GB_OUTER);
             if (light) {
                 grid1.info |= (CAVE_GLOW);
@@ -338,7 +338,7 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
         }
 
         auto &grid2 = floor.grid_array[i + y0 - yhsize][xsize + x0 - xhsize];
-        if (grid2.is_icky() && room) {
+        if (grid2.is_no_teleport_dest() && room) {
             place_bold(player_ptr, y0 + i - yhsize, x0 + xsize - xhsize, GB_OUTER);
             if (light) {
                 grid2.info |= (CAVE_GLOW);
@@ -350,15 +350,15 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
             place_bold(player_ptr, y0 + i - yhsize, x0 + xsize - xhsize, GB_EXTRA);
         }
 
-        grid1.info &= ~(CAVE_ICKY);
-        grid2.info &= ~(CAVE_ICKY);
+        grid1.info &= ~(CAVE_NO_TELEPORT_DEST);
+        grid2.info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (POSITION x = 1; x < xsize; ++x) {
         for (POSITION y = 1; y < ysize; ++y) {
             auto &grid1 = floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
-            if (grid1.is_floor() && grid1.is_icky()) {
-                grid1.info &= ~CAVE_ICKY;
+            if (grid1.is_floor() && grid1.is_no_teleport_dest()) {
+                grid1.info &= ~CAVE_NO_TELEPORT_DEST;
                 if (light) {
                     grid1.info |= (CAVE_GLOW);
                 }
@@ -371,8 +371,8 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
             }
 
             auto &grid2 = floor.grid_array[y0 + y - yhsize][x0 + x - xhsize];
-            if (grid2.is_outer() && grid2.is_icky()) {
-                grid2.info &= ~(CAVE_ICKY);
+            if (grid2.is_outer() && grid2.is_no_teleport_dest()) {
+                grid2.info &= ~(CAVE_NO_TELEPORT_DEST);
                 if (light) {
                     grid2.info |= (CAVE_GLOW);
                 }
@@ -388,7 +388,7 @@ bool generate_fracave(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION
             }
 
             place_bold(player_ptr, y0 + y - yhsize, x0 + x - xhsize, GB_EXTRA);
-            grid2.info &= ~(CAVE_ICKY | CAVE_ROOM);
+            grid2.info &= ~(CAVE_NO_TELEPORT_DEST | CAVE_ROOM);
         }
     }
 
@@ -468,7 +468,7 @@ bool generate_lake(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION xs
             for (auto y = 0; y <= ysize; ++y) {
                 const Pos2D pos(y0 + y - yhsize, x0 + x - xhsize);
                 place_bold(player_ptr, pos.y, pos.x, GB_FLOOR);
-                floor.get_grid(pos).info &= ~(CAVE_ICKY);
+                floor.get_grid(pos).info &= ~(CAVE_NO_TELEPORT_DEST);
             }
         }
 
@@ -480,8 +480,8 @@ bool generate_lake(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION xs
         const Pos2DVec vec(ysize, 0);
         place_bold(player_ptr, pos.y, pos.x, GB_EXTRA);
         place_bold(player_ptr, (pos + vec).y, (pos + vec).x, GB_EXTRA);
-        floor.get_grid(pos).info &= ~(CAVE_ICKY);
-        floor.get_grid(pos + vec).info &= ~(CAVE_ICKY);
+        floor.get_grid(pos).info &= ~(CAVE_NO_TELEPORT_DEST);
+        floor.get_grid(pos + vec).info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (auto i = 1; i < ysize; ++i) {
@@ -489,19 +489,19 @@ bool generate_lake(PlayerType *player_ptr, POSITION y0, POSITION x0, POSITION xs
         const Pos2DVec vec(0, xsize);
         place_bold(player_ptr, pos.y, pos.x, GB_EXTRA);
         place_bold(player_ptr, (pos + vec).y, (pos + vec).x, GB_EXTRA);
-        floor.get_grid(pos).info &= ~(CAVE_ICKY);
-        floor.get_grid(pos + vec).info &= ~(CAVE_ICKY);
+        floor.get_grid(pos).info &= ~(CAVE_NO_TELEPORT_DEST);
+        floor.get_grid(pos + vec).info &= ~(CAVE_NO_TELEPORT_DEST);
     }
 
     for (auto x = 1; x < xsize; ++x) {
         for (auto y = 1; y < ysize; ++y) {
             const Pos2D pos(y0 + y - yhsize, x0 + x - xhsize);
             auto &grid = floor.get_grid(pos);
-            if (!grid.is_icky() || grid.is_outer()) {
+            if (!grid.is_no_teleport_dest() || grid.is_outer()) {
                 place_bold(player_ptr, pos.y, pos.x, GB_EXTRA);
             }
 
-            grid.info &= ~(CAVE_ICKY | CAVE_ROOM);
+            grid.info &= ~(CAVE_NO_TELEPORT_DEST | CAVE_ROOM);
             if (floor.has_terrain_characteristics(pos, TerrainCharacteristics::LAVA)) {
                 if (floor.get_dungeon_definition().flags.has_not(DungeonFeatureType::DARKNESS)) {
                     grid.info |= CAVE_GLOW;

--- a/src/room/rooms-builder.cpp
+++ b/src/room/rooms-builder.cpp
@@ -168,16 +168,16 @@ void build_room(PlayerType *player_ptr, POSITION x1, POSITION x2, POSITION y1, P
     auto &floor = *player_ptr->current_floor_ptr;
     for (int i = 0; i <= xsize; i++) {
         place_bold(player_ptr, y1, x1 + i, GB_OUTER_NOPERM);
-        floor.grid_array[y1][x1 + i].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y1][x1 + i].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(player_ptr, y2, x1 + i, GB_OUTER_NOPERM);
-        floor.grid_array[y2][x1 + i].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y2][x1 + i].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
     }
 
     for (int i = 1; i < ysize; i++) {
         place_bold(player_ptr, y1 + i, x1, GB_OUTER_NOPERM);
-        floor.grid_array[y1 + i][x1].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y1 + i][x1].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(player_ptr, y1 + i, x2, GB_OUTER_NOPERM);
-        floor.grid_array[y1 + i][x2].info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.grid_array[y1 + i][x2].info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
     }
 
     for (POSITION x = 1; x < xsize; x++) {
@@ -185,9 +185,9 @@ void build_room(PlayerType *player_ptr, POSITION x1, POSITION x2, POSITION y1, P
             auto &grid = floor.grid_array[y1 + y][x1 + x];
             if (grid.is_extra()) {
                 place_bold(player_ptr, y1 + y, x1 + x, GB_FLOOR);
-                grid.info |= (CAVE_ROOM | CAVE_ICKY);
+                grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
             } else {
-                grid.info |= (CAVE_ROOM | CAVE_ICKY);
+                grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
             }
         }
     }

--- a/src/room/rooms-maze-vault.cpp
+++ b/src/room/rooms-maze-vault.cpp
@@ -113,7 +113,7 @@ void build_maze_vault(PlayerType *player_ptr, const Pos2D &center, const Pos2DVe
             auto &grid = floor.get_grid({ y, x });
             grid.info |= CAVE_ROOM;
             if (is_vault) {
-                grid.info |= CAVE_ICKY;
+                grid.info |= CAVE_NO_TELEPORT_DEST;
             }
             if ((x == x1 - 1) || (x == x2 + 1) || (y == y1 - 1) || (y == y2 + 1)) {
                 place_grid(player_ptr, grid, GB_OUTER);

--- a/src/room/rooms-nest.cpp
+++ b/src/room/rooms-nest.cpp
@@ -91,7 +91,7 @@ void generate_inner_room(PlayerType *player_ptr, const Pos2D &center, Rect2D &re
     });
 
     for (const auto &pos : inner_rectangle) {
-        floor.get_grid(pos).add_info(CAVE_ICKY);
+        floor.get_grid(pos).add_info(CAVE_NO_TELEPORT_DEST);
     }
 
     /* Place a secret door */

--- a/src/room/rooms-pit.cpp
+++ b/src/room/rooms-pit.cpp
@@ -139,7 +139,7 @@ void place_pit_inner(PlayerType *player_ptr, const Pos2D &center)
 
     for (auto y = rectangle.top_left.y; y <= rectangle.bottom_right.y; y++) {
         for (auto x = rectangle.top_left.x; x <= rectangle.bottom_right.x; x++) {
-            floor.get_grid({ y, x }).add_info(CAVE_ICKY);
+            floor.get_grid({ y, x }).add_info(CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -376,22 +376,22 @@ bool build_type13(PlayerType *player_ptr, DungeonData *dd_ptr)
     for (auto x = rectangle.top_left.x + 3; x <= rectangle.bottom_right.x - 3; x++) {
         auto &grid_top = floor.get_grid({ center->y - 2, x });
         place_grid(player_ptr, grid_top, GB_FLOOR);
-        grid_top.add_info(CAVE_ICKY);
+        grid_top.add_info(CAVE_NO_TELEPORT_DEST);
 
         auto &grid_bottom = floor.get_grid({ center->y + 2, x });
         place_grid(player_ptr, grid_bottom, GB_FLOOR);
-        grid_bottom.add_info(CAVE_ICKY);
+        grid_bottom.add_info(CAVE_NO_TELEPORT_DEST);
     }
 
     /* Place the floor area 2 */
     for (auto x = rectangle.top_left.x + 5; x <= rectangle.bottom_right.x - 5; x++) {
         auto &grid_left = floor.get_grid({ center->y - 3, x });
         place_grid(player_ptr, grid_left, GB_FLOOR);
-        grid_left.add_info(CAVE_ICKY);
+        grid_left.add_info(CAVE_NO_TELEPORT_DEST);
 
         auto &grid_right = floor.get_grid({ center->y + 3, x });
         place_grid(player_ptr, grid_right, GB_FLOOR);
-        grid_right.add_info(CAVE_ICKY);
+        grid_right.add_info(CAVE_NO_TELEPORT_DEST);
     }
 
     /* Corridor */

--- a/src/room/rooms-special.cpp
+++ b/src/room/rooms-special.cpp
@@ -116,7 +116,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
         /* Walls around the potion */
         for (const auto &d : Direction::directions_4()) {
             place_inner_perm_glass(player_ptr, floor.get_grid(*center + d.vec() * 2));
-            floor.get_grid(*center + d.vec()).info |= CAVE_ICKY;
+            floor.get_grid(*center + d.vec()).info |= CAVE_NO_TELEPORT_DEST;
         }
 
         /* Glass door */
@@ -129,7 +129,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
 
         /* Place a potion */
         place_object(player_ptr, *center, AM_NO_FIXED_ART, kind_is_potion);
-        floor.get_grid(*center).info |= CAVE_ICKY;
+        floor.get_grid(*center).info |= CAVE_NO_TELEPORT_DEST;
     } break;
 
     case 2: /* 1 lite breather + random object */
@@ -164,7 +164,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
 
         /* Place an object */
         place_object(player_ptr, *center, AM_NO_FIXED_ART);
-        floor.get_grid(*center).info |= CAVE_ICKY;
+        floor.get_grid(*center).info |= CAVE_NO_TELEPORT_DEST;
     } break;
 
     case 3: /* 4 shards breathers + 2 potions */
@@ -206,7 +206,7 @@ bool build_type15(PlayerType *player_ptr, DungeonData *dd_ptr)
 
         for (auto y = center->y - 2; y <= center->y + 2; y++) {
             for (auto x = center->x - 2; x <= center->x + 2; x++) {
-                floor.get_grid({ y, x }).info |= CAVE_ICKY;
+                floor.get_grid({ y, x }).info |= CAVE_NO_TELEPORT_DEST;
             }
         }
     } break;

--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -84,7 +84,7 @@ std::array<Pos2D, NUM_BUBBLES> create_bubbles_center(const Pos2DVec &vec)
 void set_boundaries(PlayerType *player_ptr, const Pos2D &pos)
 {
     place_bold(player_ptr, pos.y, pos.x, GB_OUTER_NOPERM);
-    player_ptr->current_floor_ptr->get_grid(pos).add_info(CAVE_ROOM | CAVE_ICKY);
+    player_ptr->current_floor_ptr->get_grid(pos).add_info(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 }
 }
 
@@ -146,7 +146,7 @@ static void build_bubble_vault(PlayerType *player_ptr, const Pos2D &pos0, const 
             }
 
             /* clean up rest of flags */
-            floor.get_grid({ pos0.y - vec_half.y + y, pos0.x - vec_half.x + x }).add_info(CAVE_ROOM | CAVE_ICKY);
+            floor.get_grid({ pos0.y - vec_half.y + y, pos0.x - vec_half.x + x }).add_info(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -176,7 +176,7 @@ static void build_room_vault(PlayerType *player_ptr, const Pos2D &center, const 
         for (auto y1 = 0; y1 < vec.y; y1++) {
             const Pos2D pos(center.y - vec_half.y + y1, x);
             place_bold(player_ptr, pos.y, pos.x, GB_EXTRA);
-            floor.get_grid(pos).info &= (~CAVE_ICKY);
+            floor.get_grid(pos).info &= (~CAVE_NO_TELEPORT_DEST);
         }
     }
 
@@ -234,10 +234,10 @@ static void build_cave_vault(PlayerType *player_ptr, const Pos2D &center, const 
         done = generate_fracave(player_ptr, center.y, center.x, xsize, ysize, cutoff, light, room);
     }
 
-    /* Set icky flag because is a vault */
+    /* Set no-teleport-dest flag because is a vault */
     const Rect2D area(center, vec_half);
     for (const auto &pos : area) {
-        floor.get_grid(pos).info |= CAVE_ICKY;
+        floor.get_grid(pos).info |= CAVE_NO_TELEPORT_DEST;
     }
 
     /* Fill with monsters and treasure, low difficulty */
@@ -333,7 +333,7 @@ static void build_vault(
             grid.mimic = 0;
 
             /* Part of a vault */
-            grid.info |= (CAVE_ROOM | CAVE_ICKY);
+            grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 
             /* Analyze the grid */
             switch (*t) {
@@ -565,7 +565,7 @@ static void build_target_vault(PlayerType *player_ptr, const Pos2D &center, cons
             const Pos2D pos(y, x);
             auto &grid = floor.get_grid(pos);
             grid.info &= ~(CAVE_ROOM);
-            grid.info |= CAVE_ICKY;
+            grid.info |= CAVE_NO_TELEPORT_DEST;
 
             if (dist2(center.y, center.x, pos.y, pos.x, h1, h2, h3, h4) <= rad - 1) {
                 /* inside- so is floor */
@@ -692,10 +692,10 @@ static void build_elemental_vault(PlayerType *player_ptr, const Pos2D &center, c
         done = generate_lake(player_ptr, center.y, center.x, xsize, ysize, c1, c2, c3, type);
     }
 
-    /* Set icky flag because is a vault */
+    /* Set no-teleport-dest flag because is a vault */
     const Rect2D area(center, vec_half);
     for (const auto &pos : area) {
-        floor.get_grid(pos).info |= CAVE_ICKY;
+        floor.get_grid(pos).info |= CAVE_NO_TELEPORT_DEST;
     }
 
     /* make a few rooms in the vault */
@@ -734,7 +734,7 @@ static void build_mini_c_vault(PlayerType *player_ptr, const Pos2D &center, cons
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(player_ptr, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
@@ -744,7 +744,7 @@ static void build_mini_c_vault(PlayerType *player_ptr, const Pos2D &center, cons
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(player_ptr, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
@@ -754,7 +754,7 @@ static void build_mini_c_vault(PlayerType *player_ptr, const Pos2D &center, cons
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(player_ptr, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
@@ -764,14 +764,14 @@ static void build_mini_c_vault(PlayerType *player_ptr, const Pos2D &center, cons
             break;
         }
 
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         place_bold(player_ptr, pos.y, pos.x, GB_OUTER_NOPERM);
     }
 
     for (auto y = y1 - 1; y <= y2 + 1; y++) {
         for (auto x = x1 - 1; x <= x2 + 1; x++) {
             auto &grid = floor.get_grid({ y, x });
-            grid.info |= (CAVE_ROOM | CAVE_ICKY);
+            grid.info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 
             /* Permanent walls */
             place_grid(player_ptr, grid, GB_INNER_PERM);
@@ -833,7 +833,7 @@ static void build_castle_vault(PlayerType *player_ptr, const Pos2D &center, cons
     /* generate the room */
     auto &floor = *player_ptr->current_floor_ptr;
     for (const auto &pos : area.resized(1)) {
-        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_ICKY);
+        floor.get_grid(pos).info |= (CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         /* Make everything a floor */
         place_bold(player_ptr, pos.y, pos.x, GB_FLOOR);
     }

--- a/src/spell-kind/earthquake.cpp
+++ b/src/spell-kind/earthquake.cpp
@@ -49,7 +49,7 @@ void reset_grid_info(FloorType &floor, std::span<const Pos2D> area)
 {
     for (const auto &pos : area) {
         auto &grid = floor.get_grid(pos);
-        grid.info &= ~(CAVE_ROOM | CAVE_ICKY | CAVE_UNSAFE);
+        grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST | CAVE_UNSAFE);
         grid.info &= ~(CAVE_GLOW | CAVE_MARK | CAVE_KNOWN);
     }
 }

--- a/src/spell-kind/spells-fetcher.cpp
+++ b/src/spell-kind/spells-fetcher.cpp
@@ -55,7 +55,7 @@ void fetch_item(PlayerType *player_ptr, const Direction &dir, WEIGHT wgt, bool r
             return;
         }
 
-        if (grid_ptr->is_icky()) {
+        if (grid_ptr->is_no_teleport_dest()) {
             msg_print(_("アイテムがコントロールを外れて落ちた。", "The item slips from your control."));
             return;
         }

--- a/src/spell-kind/spells-floor.cpp
+++ b/src/spell-kind/spells-floor.cpp
@@ -274,7 +274,7 @@ bool destroy_area(PlayerType *player_ptr, const POSITION y1, const POSITION x1, 
             auto &grid = floor.get_grid(pos);
 
             /* Lose room and vault */
-            grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
+            grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
 
             /* Lose light and knowledge */
             grid.info &= ~(CAVE_MARK | CAVE_GLOW | CAVE_KNOWN);

--- a/src/spell-kind/spells-teleport.cpp
+++ b/src/spell-kind/spells-teleport.cpp
@@ -58,7 +58,7 @@ bool teleport_swap(PlayerType *player_ptr, const Direction &dir)
         return false;
     }
 
-    if ((grid.is_icky()) || (Grid::calc_distance(pos, player_ptr->get_position()) > player_ptr->lev * 3 / 2 + 10)) {
+    if ((grid.is_no_teleport_dest()) || (Grid::calc_distance(pos, player_ptr->get_position()) > player_ptr->lev * 3 / 2 + 10)) {
         msg_print(_("失敗した。", "Failed to swap."));
         return false;
     }
@@ -146,7 +146,7 @@ bool teleport_away(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION dis, tele
                 continue;
             }
             if (!floor.is_in_quest() && !floor.inside_arena) {
-                if (floor.get_grid(m_pos).is_icky()) {
+                if (floor.get_grid(m_pos).is_no_teleport_dest()) {
                     continue;
                 }
             }

--- a/src/spell-realm/spells-chaos.cpp
+++ b/src/spell-realm/spells-chaos.cpp
@@ -95,7 +95,7 @@ static void erase_wall(FloorType &floor, const Pos2D &pos)
 {
     auto &grid = floor.get_grid(pos);
     const auto &terrain = grid.get_terrain(TerrainKind::MIMIC_RAW);
-    grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
+    grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
     if ((grid.mimic == 0) || terrain.flags.has_not(TerrainCharacteristics::CAN_DISINTEGRATE)) {
         return;
     }
@@ -138,7 +138,7 @@ bool vanish_dungeon(PlayerType *player_ptr)
     for (const auto &pos : floor.get_area(FloorBoundary::OUTER_WALL_EXCLUSIVE)) {
         auto &grid = floor.get_grid(pos);
         const auto &terrrain = grid.get_terrain();
-        grid.info &= ~(CAVE_ROOM | CAVE_ICKY);
+        grid.info &= ~(CAVE_ROOM | CAVE_NO_TELEPORT_DEST);
         const auto &monster = floor.m_list[grid.m_idx];
         if (grid.has_monster() && monster.is_asleep()) {
             (void)set_monster_csleep(floor, grid.m_idx, 0);

--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -95,9 +95,9 @@ bool Grid::is_solid() const
     return any_bits(this->info, CAVE_SOLID);
 }
 
-bool Grid::is_icky() const
+bool Grid::is_no_teleport_dest() const
 {
-    return any_bits(this->info, CAVE_ICKY);
+    return any_bits(this->info, CAVE_NO_TELEPORT_DEST);
 }
 
 bool Grid::is_lite() const

--- a/src/system/grid-type-definition.h
+++ b/src/system/grid-type-definition.h
@@ -11,7 +11,7 @@
  */
 #define CAVE_MARK 0x0001 /*!< 現在プレイヤーの記憶に収まっている / memorized feature */
 #define CAVE_GLOW 0x0002 /*!< マス自体が光源を持っている / self-illuminating */
-#define CAVE_ICKY 0x0004 /*!< 生成されたVaultの一部である / part of a vault */
+#define CAVE_NO_TELEPORT_DEST 0x0004 /*!< Vaultの一部でありテレポート等の移動先にできない / part of a vault; forbidden as a teleport destination */
 #define CAVE_ROOM 0x0008 /*!< 生成された部屋の一部である / part of a room */
 #define CAVE_LITE 0x0010 /*!< 現在光に照らされている / lite flag  */
 #define CAVE_VIEW 0x0020 /*!< 現在プレイヤーの視界に収まっている / view flag */
@@ -76,7 +76,7 @@ public:
     bool is_inner() const;
     bool is_outer() const;
     bool is_solid() const;
-    bool is_icky() const;
+    bool is_no_teleport_dest() const;
     bool is_lite() const;
     bool is_redraw() const;
     bool is_view() const;


### PR DESCRIPTION
## 概要

`CAVE_ICKY` (0x0004) はマスが Vault の一部であることを表すフラグですが、実際のゲーム上の効果は「そのマスをテレポート/フェッチ/配置の *移動先* にできない」点のみです（テレポートによる **進入** を禁止しますが、そこからの **退出** は制限しません）。

旧称 `"icky"` はこの意味を伝えず、方向性を含まない「テレポート禁止」とも誤読され得たため、意味を正確に表す名称へ改名します。

## 変更点

- `CAVE_ICKY` → `CAVE_NO_TELEPORT_DEST`（フラグ定義 + 全使用箇所）
- `Grid::is_icky()` → `Grid::is_no_teleport_dest()`（宣言 / 定義 + 全呼び出し箇所）
- フラグ定義コメントおよび `rooms-vault.cpp` の説明コメントを意味に即して更新

## 補足

- **純粋なリネームで挙動は不変**です（20 files, 78 insertions / 78 deletions と対称）。
- 同名異義（装備の `is_icky_wield` 系 / 画面の `character_icky_depth` / 端末の `icky_corner` / モンスター名 "Icky Thing"）は本フラグと無関係のため対象外・不変です。
- ビルド（Debug|Win32）成功、`clang-format` クリーンを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * テレポート先として扱えない地形の判定が整理され、プレイヤー配置、移動、各種テレポート、アイテム取得、地形生成の挙動が一貫して更新されました。
  * 部屋、Vault、巣、穴、迷路、川、木などの生成物で、対象マスの除外条件が見直されました。
  * 地震や破壊系の効果で、テレポート不可状態の解除対象が正しく更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->