### PR TITLE
[Fix] 騎乗モンスターへのカオス効果テレポートを修正

### DIFF
--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -304,10 +304,11 @@ void decide_monster_attack_effect(PlayerType *player_ptr, mam_type *mam_ptr)
 
         if (!has_resist) {
             if (one_in_(2)) {
-                msg_format(_(("%s^はどこかへ消えていった！"), ("%s^ disappears!")), mam_ptr->t_name);
                 if (mam_ptr->t_ptr->is_riding()) {
+                    msg_format(_("%s^はテレポートした！", "%s^ teleports away!"), mam_ptr->t_name);
                     teleport_player_away(mam_ptr->m_idx, player_ptr, 50, false);
                 } else {
+                    msg_format(_("%s^はどこかへ消えていった！", "%s^ disappears!"), mam_ptr->t_name);
                     teleport_away(player_ptr, mam_ptr->t_idx, 50, TELEPORT_PASSIVE);
                 }
             } else {

--- a/src/melee/melee-switcher.cpp
+++ b/src/melee/melee-switcher.cpp
@@ -305,7 +305,11 @@ void decide_monster_attack_effect(PlayerType *player_ptr, mam_type *mam_ptr)
         if (!has_resist) {
             if (one_in_(2)) {
                 msg_format(_(("%s^はどこかへ消えていった！"), ("%s^ disappears!")), mam_ptr->t_name);
-                teleport_away(player_ptr, mam_ptr->t_idx, 50, TELEPORT_PASSIVE);
+                if (mam_ptr->t_ptr->is_riding()) {
+                    teleport_player_away(mam_ptr->m_idx, player_ptr, 50, false);
+                } else {
+                    teleport_away(player_ptr, mam_ptr->t_idx, 50, TELEPORT_PASSIVE);
+                }
             } else {
                 if (polymorph_monster(player_ptr, mam_ptr->t_ptr->fy, mam_ptr->t_ptr->fx)) {
                     msg_format(_("%s^は変化した！", "%s^ changes!"), mam_ptr->t_name);


### PR DESCRIPTION
## 概要

Fixes #5489

モンスター同士のカオス打撃で騎乗モンスターにテレポート・アウェイが発生した場合、騎乗モンスターだけが移動し、プレイヤーの内部状態には騎乗情報と速度補正が残っていました。

対象が騎乗モンスターの場合は、通常のモンスター用 `teleport_away()` ではなくプレイヤー用 `teleport_player_away()` を呼び、プレイヤーと騎乗モンスターを一緒に移動させます。通常モンスターに対する処理は変更しません。

## 原因

カオス打撃のモンスター対モンスター処理では、対象が騎乗中かを判定せず、常にモンスター単体を移動する `teleport_away()` を呼んでいました。このため、マップ上の騎乗モンスターの位置とプレイヤーの騎乗状態が不整合になっていました。

## テレポート・アウェイ関連仕様の確認

- 通常モンスターへのテレポート・アウェイは対象モンスターだけを移動する。
- 乗馬中プレイヤーへの魔法テレポート・アウェイは、プレイヤーと騎乗モンスターを一緒に移動し、騎乗状態を維持する。
- 魔法テレポート・アウェイが騎乗モンスターを対象にした場合も、プレイヤー用処理へ分岐して両者を一緒に移動する。
- 乗馬中プレイヤーがカオス打撃のテレポート効果を受けた場合も、プレイヤーと騎乗モンスターが一緒に移動する。
- ブレスや投射魔法のカオス属性処理には、プレイヤーをテレポートさせる効果はない。

今回の修正は、騎乗モンスターを対象としたカオス打撃についても上記の既存仕様に揃えるものです。カオス耐性の判定は従来どおり対象の騎乗モンスターに対して行い、プレイヤー側の移動には既存の反テレポート判定が適用されます。

## 影響

- 騎乗モンスターだけが飛ばされて騎乗状態と表示が不整合になる問題を解消する。
- 騎乗状態と乗馬による速度補正は正しく維持される。
- 通常モンスターへのカオス効果の挙動は変わらない。

## 確認

- Visual Studio Debug 構成のビルド成功（警告 0、エラー 0）
- `git diff --check` 成功


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 騎乗中のモンスターがカオス属性の打撃効果で消えた際、消失時のテレポート処理と表示メッセージが正しく切り替わるよう改善しました。
  * 騎乗していない場合は、従来どおりの消失挙動・メッセージを維持しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->