### PR TITLE
[Fix] #5493 床上アイテム選択の無限ループを修正

### DIFF
--- a/src/inventory/floor-item-getter.cpp
+++ b/src/inventory/floor-item-getter.cpp
@@ -664,7 +664,7 @@ tl::optional<short> get_item_floor(PlayerType *player_ptr, std::string_view pmt,
                 break;
             }
 
-            if (grid.o_idx_list.size() < 2) {
+            if (fis.floor_item_index.size() < 2) {
                 break;
             }
 


### PR DESCRIPTION
## 概要

床上アイテムの選択画面で、選択候補が1件しかない場合にスクロール操作を行うと無限ループする可能性がある不具合を修正します。

Fixes #5493

## 原因

スクロール可能かどうかを床上の全アイテム数 (`grid.o_idx_list`) で判定していましたが、その後に参照するのはアイテム種別や認識状態で絞り込まれた候補配列 (`fis.floor_item_index`) でした。

床上には複数のアイテムがある一方、射撃などの選択候補が1件だけの場合、存在しない2番目の候補を範囲外参照し、不定なアイテムIDがリストの先頭に現れるまで回転し続けていました。

## 変更内容

スクロール可否の判定にも、実際に表示・参照している `fis.floor_item_index` の要素数を使用します。

## 影響

候補が1件だけの場合はスクロールせず、2件以上の場合の既存のスクロール動作は維持されます。

## 確認

- `git diff --check`: 成功
- Visual Studio Debug ビルド: コンパイルは警告0で成功。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 床上アイテム選択時、タグやマーキングされたアイテム数に基づいて次のアイテムへ移動できるよう判定を改善しました。
  * 対象アイテムが少ない場合に、不要な選択切り替えを防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->