### PR TITLE
English: clarify rejected spell selection message

### DIFF
--- a/src/cmd-action/cmd-spell.cpp
+++ b/src/cmd-action/cmd-spell.cpp
@@ -487,7 +487,7 @@ static int get_spell(PlayerType *player_ptr, SPELL_IDX *sn, std::string_view pro
 #ifdef JP
             msg_format("その%sを%sことはできません。", spell_category.data(), prompt_verb.data());
 #else
-            msg_format("You may not %s that %s.", prompt.data(), spell_category.data());
+            msg_format("You may not %s that %s.", prompt_verb.data(), spell_category.data());
 #endif
 
             continue;


### PR DESCRIPTION
Resolves https://github.com/hengband/hengband/issues/5495 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 使用できない呪文を選択した際のメッセージで、実際の操作内容に合った動詞が表示されるよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->