### PR TITLE
[Chore] 外部ライブラリ由来の警告を抑制する

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1468,7 +1468,7 @@ EXTRA_DIST = \
 	gcc-wrap
 
 DEFAULT_INCLUDES = \
-	-I. -I$(srcdir) -I$(srcdir)/external-lib/include
+	-I. -I$(srcdir) -isystem $(srcdir)/external-lib/include
 
 CPPFLAGS += $(XFT_CFLAGS) $(libcurl_CFLAGS)
 LIBS += $(XFT_LIBS) $(libcurl_LIBS)
@@ -1481,7 +1481,7 @@ endif
 
 if USE_NKF
 CXXCOMPILE_WRAPPER = $(srcdir)/gcc-wrap
-DEFAULT_INCLUDES += -I$(top_builddir)/src -I$(top_builddir)/src/external-lib/include
+DEFAULT_INCLUDES += -I$(top_builddir)/src -isystem $(top_builddir)/src/external-lib/include
 if COMPILER_IS_CLANG
 AM_CXXFLAGS += -Wno-invalid-source-encoding
 endif


### PR DESCRIPTION
警告レベルを厳しく設定しているため、外部ライブラリのヘッダを由来とした警告が出ることがある。CIのビルドチェックは警告をエラー扱いするため、これによりビルドチェックを通らないなどの問題が発生する。
gcc/clangはシステムヘッダを特別扱いしており警告が出ないようになるが、`-isystem` でインクルードパスを指定することによりそのパスのヘッダはシステムヘッダ扱いとなる。
外部ライブラリのヘッダの設置パス `src/external-lib/include` を`-isystem` で指定することでシステムヘッダ扱いとし、警告を抑制する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 外部ライブラリのヘッダーをシステムヘッダーとして扱うようビルド設定を更新し、コンパイル時の警告表示を抑制しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->