### PR TITLE
[Refactor]「横に伸びる」の効果時間をTimedEffects クラスへ移植した

### DIFF
--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -705,6 +705,7 @@
     <ClCompile Include="..\..\src\timed-effect\player-poison.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-protection.cpp" />
     <ClCompile Include="..\..\src\timed-effect\player-stun.cpp" />
+    <ClCompile Include="..\..\src\timed-effect\player-wide-spread.cpp" />
     <ClCompile Include="..\..\src\timed-effect\timed-effects.cpp" />
     <ClCompile Include="..\..\src\tracking\baseitem-tracker.cpp" />
     <ClCompile Include="..\..\src\tracking\health-bar-tracker.cpp" />
@@ -1564,6 +1565,7 @@
     <ClInclude Include="..\..\src\timed-effect\player-poison.h" />
     <ClInclude Include="..\..\src\timed-effect\player-protection.h" />
     <ClInclude Include="..\..\src\timed-effect\player-stun.h" />
+    <ClInclude Include="..\..\src\timed-effect\player-wide-spread.h" />
     <ClInclude Include="..\..\src\timed-effect\timed-effects.h" />
     <ClInclude Include="..\..\src\tracking\baseitem-tracker.h" />
     <ClInclude Include="..\..\src\tracking\health-bar-tracker.h" />

--- a/VisualStudio/Hengband/Hengband.vcxproj.filters
+++ b/VisualStudio/Hengband/Hengband.vcxproj.filters
@@ -2625,6 +2625,9 @@
     <ClCompile Include="..\..\src\system\baseitem\baseitem-records.cpp">
       <Filter>system\baseitem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\timed-effect\player-wide-spread.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\combat\shoot.h">
@@ -5684,6 +5687,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\system\baseitem\baseitem-records.h">
       <Filter>system\baseitem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\timed-effect\player-wide-spread.h">
+      <Filter>timed-effect</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1361,6 +1361,7 @@ hengband_SOURCES = \
 	timed-effect/player-poison.cpp timed-effect/player-poison.h \
 	timed-effect/player-protection.cpp timed-effect/player-protection.h \
 	timed-effect/player-stun.cpp timed-effect/player-stun.h \
+	timed-effect/player-wide-spread.cpp timed-effect/player-wide-spread.h \
 	timed-effect/timed-effects.cpp timed-effect/timed-effects.h \
 	\
 	tracking/baseitem-tracker.cpp tracking/baseitem-tracker.h \

--- a/src/core/magic-effects-timeout-reducer.cpp
+++ b/src/core/magic-effects-timeout-reducer.cpp
@@ -185,8 +185,8 @@ void reduce_magic_effects_timeout(PlayerType *player_ptr)
         (void)set_shield(player_ptr, player_ptr->shield - 1, true);
     }
 
-    if (player_ptr->tsubureru) {
-        (void)set_leveling(player_ptr, player_ptr->tsubureru - 1, true);
+    if (effects->wide_spread().is_wide_spreaded()) {
+        (void)set_leveling(player_ptr, effects->wide_spread().current() - 1, true);
     }
 
     if (player_ptr->magicdef) {

--- a/src/load/player-info-loader.cpp
+++ b/src/load/player-info-loader.cpp
@@ -407,6 +407,7 @@ static void rd_tsuyoshi(PlayerType *player_ptr)
 
 static void set_timed_effects(PlayerType *player_ptr)
 {
+    const auto effects = player_ptr->effects();
     player_ptr->tim_esp = rd_s16b();
     player_ptr->wraith_form = rd_s16b();
     player_ptr->resist_magic = rd_s16b();
@@ -416,7 +417,7 @@ static void set_timed_effects(PlayerType *player_ptr)
     player_ptr->tim_levitation = rd_s16b();
     player_ptr->tim_sh_touki = rd_s16b();
     player_ptr->lightspeed = rd_s16b();
-    player_ptr->tsubureru = rd_s16b();
+    effects->wide_spread().set(rd_s16b());
     if (h_older_than(0, 4, 7)) {
         player_ptr->magicdef = 0;
     } else {

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -1156,7 +1156,7 @@ static ACTION_SKILL_POWER calc_saving_throw(PlayerType *player_ptr)
         pow = 90 + player_ptr->lev;
     }
 
-    if (player_ptr->tsubureru) {
+    if (player_ptr->effects()->wide_spread().is_wide_spreaded()) {
         pow = 10;
     }
 
@@ -1651,6 +1651,8 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
         return 0;
     }
 
+    const auto effects = player_ptr->effects();
+
     ac += ((int)(adj_dex_ta[player_ptr->stat_index[A_DEX]]) - 128);
 
     switch (player_ptr->mimic_form) {
@@ -1801,7 +1803,7 @@ static ARMOUR_CLASS calc_to_ac(PlayerType *player_ptr, bool is_real_value)
 
     if (player_ptr->ult_res || (pc.samurai_stance_is(SamuraiStanceType::MUSOU))) {
         ac += 100;
-    } else if (player_ptr->tsubureru || player_ptr->shield || player_ptr->magicdef) {
+    } else if (effects->wide_spread().is_wide_spreaded() || player_ptr->shield || player_ptr->magicdef) {
         ac += 50;
     }
 

--- a/src/racial/racial-kutar.cpp
+++ b/src/racial/racial-kutar.cpp
@@ -7,6 +7,7 @@
 #include "main/sound-of-music.h"
 #include "system/player-type-definition.h"
 #include "system/redrawing-flags-updater.h"
+#include "timed-effect/timed-effects.h"
 #include "view/display-messages.h"
 
 /*!
@@ -25,24 +26,25 @@ bool set_leveling(PlayerType *player_ptr, TIME_EFFECT v, bool do_dec)
         return false;
     }
 
+    const auto effects = player_ptr->effects();
     if (v) {
-        if (player_ptr->tsubureru && !do_dec) {
-            if (player_ptr->tsubureru > v) {
+        if (effects->wide_spread().is_wide_spreaded() && !do_dec) {
+            if (effects->wide_spread().current() > v) {
                 return false;
             }
-        } else if (!player_ptr->tsubureru) {
+        } else if (!effects->wide_spread().is_wide_spreaded()) {
             msg_print(_("横に伸びた。", "Your body expands horizontally."));
             notice = true;
         }
     } else {
-        if (player_ptr->tsubureru) {
+        if (effects->wide_spread().is_wide_spreaded()) {
             msg_print(_("もう横に伸びていない。", "Your body returns to normal."));
             sound(SoundKind::BUFF_EXPIRE);
             notice = true;
         }
     }
 
-    player_ptr->tsubureru = v;
+    effects->wide_spread().set(v);
     auto &rfu = RedrawingFlagsUpdater::get_instance();
     rfu.set_flag(MainWindowRedrawingFlag::TIMED_EFFECT);
     if (!notice) {

--- a/src/save/player-writer.cpp
+++ b/src/save/player-writer.cpp
@@ -209,7 +209,7 @@ void wr_player(PlayerType *player_ptr)
     wr_s16b(player_ptr->tim_levitation);
     wr_s16b(player_ptr->tim_sh_touki);
     wr_s16b(player_ptr->lightspeed);
-    wr_s16b(player_ptr->tsubureru);
+    wr_s16b(effects->wide_spread().current());
     wr_s16b(player_ptr->magicdef);
     wr_s16b(player_ptr->tim_res_nether);
     wr_s16b(player_ptr->tim_res_lite);

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -115,7 +115,6 @@ public:
     TIME_EFFECT tim_levitation{};
     TIME_EFFECT tim_sh_touki{};
     TIME_EFFECT lightspeed{};
-    TIME_EFFECT tsubureru{};
     TIME_EFFECT magicdef{};
     TIME_EFFECT tim_res_nether{}; /* Timed -- Nether resistance */
     TIME_EFFECT tim_res_lite{}; /* Timed -- Lite resistance */

--- a/src/timed-effect/player-wide-spread.cpp
+++ b/src/timed-effect/player-wide-spread.cpp
@@ -1,0 +1,21 @@
+#include "timed-effect/player-wide-spread.h"
+#include "system/angband-exceptions.h"
+
+short PlayerWideSpread::current() const
+{
+    return this->wide_spread;
+}
+
+bool PlayerWideSpread::is_wide_spreaded() const
+{
+    return this->current() > 0;
+}
+
+void PlayerWideSpread::set(short value)
+{
+    if (value < 0) {
+        THROW_EXCEPTION(std::invalid_argument, "Negative value can't be set in the player's wide-spread parameter!");
+    }
+
+    this->wide_spread = value;
+}

--- a/src/timed-effect/player-wide-spread.h
+++ b/src/timed-effect/player-wide-spread.h
@@ -1,0 +1,17 @@
+#pragma once
+class PlayerWideSpread {
+public:
+    PlayerWideSpread() = default;
+    ~PlayerWideSpread() = default;
+    PlayerWideSpread(const PlayerWideSpread &) = delete;
+    PlayerWideSpread(PlayerWideSpread &&) = delete;
+    PlayerWideSpread &operator=(const PlayerWideSpread &) = delete;
+    PlayerWideSpread &operator=(PlayerWideSpread &&) = delete;
+
+    short current() const;
+    bool is_wide_spreaded() const;
+    void set(short value);
+
+private:
+    short wide_spread = 0;
+};

--- a/src/timed-effect/timed-effects.cpp
+++ b/src/timed-effect/timed-effects.cpp
@@ -115,3 +115,13 @@ const PlayerProtection &TimedEffects::protection() const
 {
     return this->player_protection;
 }
+
+PlayerWideSpread &TimedEffects::wide_spread()
+{
+    return this->player_wide_spread;
+}
+
+const PlayerWideSpread &TimedEffects::wide_spread() const
+{
+    return this->player_wide_spread;
+}

--- a/src/timed-effect/timed-effects.h
+++ b/src/timed-effect/timed-effects.h
@@ -11,6 +11,7 @@
 #include "timed-effect/player-poison.h"
 #include "timed-effect/player-protection.h"
 #include "timed-effect/player-stun.h"
+#include "timed-effect/player-wide-spread.h"
 
 class TimedEffects {
 public:
@@ -43,6 +44,8 @@ public:
     const PlayerPoison &poison() const;
     PlayerProtection &protection();
     const PlayerProtection &protection() const;
+    PlayerWideSpread &wide_spread();
+    const PlayerWideSpread &wide_spread() const;
 
 private:
     PlayerBlindness player_blindness{};
@@ -56,4 +59,5 @@ private:
     PlayerDeceleration player_deceleration{};
     PlayerPoison player_poison{};
     PlayerProtection player_protection{};
+    PlayerWideSpread player_wide_spread{};
 };

--- a/src/window/main-window-stat-poster.cpp
+++ b/src/window/main-window-stat-poster.cpp
@@ -524,7 +524,7 @@ void print_status(PlayerType *player_ptr)
         ADD_BAR_FLAG(BAR_MAGICDEFENSE);
     }
 
-    if (player_ptr->tsubureru) {
+    if (effects->wide_spread().is_wide_spreaded()) {
         ADD_BAR_FLAG(BAR_EXPAND);
     }
 


### PR DESCRIPTION
This PR closes #5506.

概ねAIによる機械的置換
一応テスト済

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **機能改善**
  * 横方向への拡大効果を、時間効果として一元的に管理するよう改善しました。
  * 効果の状態が、防御力・魔法防御力・レベリング効果の減衰に正しく反映されます。
  * 効果の有効状態がステータス表示に正しく反映されます。
  * セーブ・ロード時に効果の状態を引き継げるようになりました。
  * 効果時間の更新、メッセージ表示、効果音の動作を維持しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->