### PR TITLE
bot: emit CAVE_KNOWN-only ordinary floor tiles to bot consumers

### DIFF
--- a/src/bot/bot-json-output.cpp
+++ b/src/bot/bot-json-output.cpp
@@ -124,11 +124,50 @@ bool is_grid_perceivable(const PlayerType &player, const Pos2D &pos)
     return is_visible || (grid.is_view() && (is_glowing || player.see_nocto != 0));
 }
 
+// is_grid_perceivable() is a faithful mirror of display-map.cpp's map_info(),
+// which decides what the player currently sees drawn on screen (display
+// parity). For ordinary (non-REMEMBER) floor tiles, that gate depends on
+// CAVE_MARK, which is only persisted when the "view_torch_grids" option is
+// on -- off by default. travel-execution.cpp's travel_flow_aux(), which
+// drives the native travel command, instead gates on CAVE_KNOWN, a
+// permanent memory flag set unconditionally in note_spot() once a tile is
+// first perceived, independent of any display option. With the default
+// options, a torch-lit corridor floor tile that is CAVE_KNOWN but never
+// gets CAVE_MARK'd (view_torch_grids is off) is included in nearby_grids
+// while lit, then vanishes from it the instant the player's light moves
+// on -- even though the tile remains one the native travel command (and a
+// human player, via the same travel command) can path through. This
+// predicate closes that gap for bot consumers without touching
+// is_grid_perceivable() itself, so display-parity behaviour (and every
+// existing consumer of "known" as display state) is unchanged.
+//
+// REMEMBER terrain (walls, doors, stairs, stores, rubble -- everything
+// that isn't ordinary floor/dirt/grass/glass-floor/invisible-trap) is
+// deliberately excluded from the CAVE_KNOWN fallback: map_area() (Magic
+// Mapping) sets CAVE_KNOWN unconditionally for every tile in range,
+// including undiscovered bedrock, and is_revealed_wall() elsewhere in this
+// file relies on is_grid_perceivable()'s REMEMBER branch to keep
+// undiscovered secret walls hidden from bot consumers. Falling through to
+// raw CAVE_KNOWN for REMEMBER terrain would leak both of those.
+bool is_grid_known_to_bot(const PlayerType &player, const Pos2D &pos)
+{
+    if (is_grid_perceivable(player, pos)) {
+        return true;
+    }
+
+    const auto &grid = player.current_floor_ptr->get_grid(pos);
+    if (grid.get_terrain(TerrainKind::MIMIC).flags.has(TerrainCharacteristics::REMEMBER)) {
+        return false;
+    }
+
+    return (grid.info & CAVE_KNOWN) != 0;
+}
+
 nlohmann::json make_grid_json(const PlayerType &player, const Pos2D &pos)
 {
     const auto &floor = *player.current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
-    const auto is_known = is_grid_perceivable(player, pos);
+    const auto is_known = is_grid_known_to_bot(player, pos);
     if (!is_known) {
         return {
             { "y", pos.y },
@@ -412,9 +451,12 @@ nlohmann::json make_nearby_grids_json(const PlayerType &player)
     // (so the bot can see the dungeon entrance immediately, like the player),
     // and in the dungeon this lets it navigate to any already-explored feature.
     // Unknown tiles are omitted; the client treats an absent but in-bounds
-    // neighbour as a frontier.
+    // neighbour as a frontier. "Known" here means either currently drawn on
+    // screen (is_grid_perceivable()) or, for ordinary floor terrain, simply
+    // remembered by the game via CAVE_KNOWN even without a display mark --
+    // see is_grid_known_to_bot() above.
     for (const auto &pos : floor.get_area()) {
-        if (!is_grid_perceivable(player, pos)) {
+        if (!is_grid_known_to_bot(player, pos)) {
             continue;
         }
 

--- a/src/bot/bot-json-output.cpp
+++ b/src/bot/bot-json-output.cpp
@@ -155,9 +155,11 @@ bool is_grid_perceivable(const PlayerType &player, const Pos2D &pos)
 // floor is generated, and that placeholder carries no REMEMBER flag (its
 // flags list is empty), so it isn't caught by the check above. wiz_lite()
 // (Clairvoyance) and map_area() (Magic Mapping) both set CAVE_KNOWN
-// unconditionally across the whole floor via note_spot(), so without this
-// check any ungenerated grid still holding that placeholder id after
-// either spell would leak through as known:true.
+// directly (grid.info |= CAVE_KNOWN) for every tile in range, unconditionally
+// and without going through note_spot() -- which itself bails out early on
+// blindness/visibility/lighting -- so without this check any ungenerated
+// grid still holding that placeholder id after either spell would leak
+// through as known:true.
 bool is_grid_known_to_bot(const PlayerType &player, const Pos2D &pos)
 {
     if (is_grid_perceivable(player, pos)) {

--- a/src/bot/bot-json-output.cpp
+++ b/src/bot/bot-json-output.cpp
@@ -149,6 +149,15 @@ bool is_grid_perceivable(const PlayerType &player, const Pos2D &pos)
 // file relies on is_grid_perceivable()'s REMEMBER branch to keep
 // undiscovered secret walls hidden from bot consumers. Falling through to
 // raw CAVE_KNOWN for REMEMBER terrain would leak both of those.
+//
+// The placeholder "NONE" terrain is excluded too, for the same reason as
+// REMEMBER terrain: clear_cave() zero-fills every grid's feat before a
+// floor is generated, and that placeholder carries no REMEMBER flag (its
+// flags list is empty), so it isn't caught by the check above. wiz_lite()
+// (Clairvoyance) and map_area() (Magic Mapping) both set CAVE_KNOWN
+// unconditionally across the whole floor via note_spot(), so without this
+// check any ungenerated grid still holding that placeholder id after
+// either spell would leak through as known:true.
 bool is_grid_known_to_bot(const PlayerType &player, const Pos2D &pos)
 {
     if (is_grid_perceivable(player, pos)) {
@@ -156,18 +165,29 @@ bool is_grid_known_to_bot(const PlayerType &player, const Pos2D &pos)
     }
 
     const auto &grid = player.current_floor_ptr->get_grid(pos);
-    if (grid.get_terrain(TerrainKind::MIMIC).flags.has(TerrainCharacteristics::REMEMBER)) {
+    const auto &terrains = TerrainList::get_instance();
+    const auto terrain_id = grid.get_terrain_id(TerrainKind::MIMIC);
+    if (terrain_id == terrains.get_terrain_id(TerrainTag::NONE)) {
+        return false;
+    }
+
+    if (terrains.get_terrain(terrain_id).flags.has(TerrainCharacteristics::REMEMBER)) {
         return false;
     }
 
     return (grid.info & CAVE_KNOWN) != 0;
 }
 
-nlohmann::json make_grid_json(const PlayerType &player, const Pos2D &pos)
+// is_known is passed in rather than recomputed here because the sole
+// caller, make_nearby_grids_json(), already evaluates
+// is_grid_known_to_bot() once per grid to decide whether to include it at
+// all -- calling it again in here would re-walk the same REMEMBER/
+// CAVE_KNOWN checks (and, transitively, is_grid_perceivable()) a second
+// time per grid, for up to MAX_HGT * MAX_WID grids every snapshot.
+nlohmann::json make_grid_json(const PlayerType &player, const Pos2D &pos, bool is_known)
 {
     const auto &floor = *player.current_floor_ptr;
     const auto &grid = floor.get_grid(pos);
-    const auto is_known = is_grid_known_to_bot(player, pos);
     if (!is_known) {
         return {
             { "y", pos.y },
@@ -456,11 +476,12 @@ nlohmann::json make_nearby_grids_json(const PlayerType &player)
     // remembered by the game via CAVE_KNOWN even without a display mark --
     // see is_grid_known_to_bot() above.
     for (const auto &pos : floor.get_area()) {
-        if (!is_grid_known_to_bot(player, pos)) {
+        const auto is_known = is_grid_known_to_bot(player, pos);
+        if (!is_known) {
             continue;
         }
 
-        grids.push_back(make_grid_json(player, pos));
+        grids.push_back(make_grid_json(player, pos, is_known));
     }
 
     return grids;


### PR DESCRIPTION
## 現象

既定オプション（`view_torch_grids=false`）下で、`--bot-json-output`の`nearby_grids`から、プレイヤーが自前光源（松明等）で照らしていた通路の床タイルが、光源が離れた瞬間に消えます。

外部ツールがこのJSONを使って探索済みの通路床タイルへ経路探索しようとすると、直前まで存在していたはずのタイルが突然マップから欠落し、経路が見つからなくなる事象が発生します。実際にこのツールを使っている `hengband-ai`（AIプレイヤー）のログを解析したところ、前ターンに存在したグリッドが次ターンで`nearby_grids`から消える事象が延べ360件確認され、全件が`passable=true && cave_known=true`（=歩行可能で、ゲーム内部では記憶済み）でした。区間によっては経路探索の到達判定が3.6%〜50%反転していました。

## 原因

`is_grid_perceivable()`（`bot-json-output.cpp`）は、`display-map.cpp`の`map_info()`——人間プレイヤーの画面描画が何を表示するかを決める関数——を忠実にミラーしています。通常の（REMEMBER属性を持たない）床地形の場合、この判定は`CAVE_MARK`に依存しますが、`CAVE_MARK`は`view_torch_grids`オプションが有効なときのみ永続化されます（既定は無効）。

一方、ネイティブtravelコマンドを駆動する`travel-execution.cpp`の`travel_flow_aux()`は、代わりに`CAVE_KNOWN`——`note_spot()`内でタイルが最初に認識された時点で表示オプションとは無関係に無条件で立つ永続フラグ——を判定基準にしています。

つまり、`is_grid_perceivable()`（表示パリティ）と`make_nearby_grids_json()`のコメントが宣言している用途（ナビゲーションパリティ）という2つの契約が、既定オプション下で乖離しています。フラグを取り違えているのではなく、表示用に設計された関数がナビゲーション用途に転用されたことによるミスマッチです。

## 影響地形の限定

`TerrainDefinitions.jsonc`の全190地形のうち、REMEMBER属性を持たないのは14地形のみで、そのうち歩行可能なのは open floor(id=1) / invisible trap(id=2, mimic=open floor) / dirt(id=88) / patch of grass(id=89) / *floor*(id=160, mimic=open floor、生成時専用タグ) / glass floor(id=199) の6地形です（mimic解決後の内訳。ドア・階段・店舗・瓦礫・壁はすべてREMEMBER属性を持ち、`CAVE_MARK`経由で既に正しく出力されています）。実質的にこの問題は「暗い通路・部屋の床タイル」のみに限定されます。

## 修正内容

`is_grid_perceivable()`は一切変更せず、新しい述語`is_grid_known_to_bot()`を追加し、`make_grid_json()`/`make_nearby_grids_json()`の呼び出し元だけをこれに差し替えました。

```cpp
bool is_grid_known_to_bot(const PlayerType &player, const Pos2D &pos)
{
    if (is_grid_perceivable(player, pos)) {
        return true;
    }

    const auto &grid = player.current_floor_ptr->get_grid(pos);
    const auto &terrains = TerrainList::get_instance();
    const auto terrain_id = grid.get_terrain_id(TerrainKind::MIMIC);
    if (terrain_id == terrains.get_terrain_id(TerrainTag::NONE)) {
        return false;
    }

    if (terrains.get_terrain(terrain_id).flags.has(TerrainCharacteristics::REMEMBER)) {
        return false;
    }

    return (grid.info & CAVE_KNOWN) != 0;
}
```

差分は`src/bot/bot-json-output.cpp`1ファイルのみです。

## 設計上の選択の開示

レビューの際に別案をご検討いただけるよう、判断の詳細を開示します。

- **`is_grid_perceivable()`は無改造**: `map_info()`の忠実なミラーという不変条件を壊さないための判断です。副次的な帰結として、**この修正は画面描画に一切影響しません**（`map_info()`側の呼び出し元は無改造のため）。
- **REMEMBER地形は意図的にCAVE_KNOWNフォールバックから除外**しています。魔法地図（`map_area()`）は範囲内の岩盤を含む全グリッドに`CAVE_KNOWN`を無条件に立てるため、無条件でORすると (a) `is_revealed_wall()`が隠している「四方を壁に囲まれた壁」まで露出し、(b) `nearby_grids`に未発見の岩盤が大量に流入してJSONが肥大します。
- **placeholder地形（NONE, id=0）も同じ理由で除外**しています。`clear_cave()`は未生成グリッドの`feat`を0（NONE）で初期化しますが、NONEはREMEMBERフラグを持たないため上記の除外だけでは捕捉できません。`wiz_lite()`/`map_area()`はフロア全域に無条件で`CAVE_KNOWN`を立てるため、この除外がないと未生成グリッドが`known:true`として漏れます。
- **`known`フィールドの意味が「盤面上に描画されている」から「ゲームが地形を記憶している」へ広がります**。これが唯一の後方互換上の非互換点ですが、表示パリティが必要な既存の消費者は、既に出力済みの`flags.mark`/`flags.lite`/`flags.view`から従来の意味を再構成できます。
- **盲目状態でも挙動が変わります**: 現在は盲目時、`is_grid_perceivable()`のREMEMBER分岐（`is_blind()`チェックの手前）により壁は記憶として残り続けますが、通常床は`is_blind()`チェックで即座に除外されます。本修正後も`is_grid_perceivable()`自体は変わらないため盲目中に新たにCAVE_KNOWNフォールバックへ流入することはなく、**盲目になる前に既にCAVE_KNOWNだった床タイルのみ**、盲目中も引き続き出力され続けるという非対称性が生じます（壁は元々残り続けるため、この点で両者の非対称性がわずかに縮小する方向です）。
- **唯一の実質的な情報増分は「魔法地図をかけた後の未訪問部屋の床の通行可否」**です。これはネイティブtravelコマンドが人間プレイヤーに既に提供している情報と同一です。
- `monster_index`は`grid.is_view()`ゲート、`object_count`は`OmType::FOUND`ゲート（プレイヤーが既に発見済みの物のみ）で別途制御されているため、この修正による新規の情報漏洩はありません。
- **評価コストの重複を避けています**: `make_nearby_grids_json()`が`is_grid_known_to_bot()`でフィルタした結果を、そのまま`make_grid_json()`へ`bool`引数として渡します。同じ判定をグリッドごとに2回（最大`MAX_HGT × MAX_WID = 13,068`グリッド/スナップショット）走らせるコストを避けるためです。

## `view_torch_grids`オプションを有効にすれば回避できるのでは？

`user.prf`に`Y:view_torch_grids`を設定すれば、C++側を変更せずとも症状は解消します。しかし、外部ツール向けのナビゲーションペイロードの内容が、人間プレイヤー向けの表示オプションに依存して変わってしまうのは、そもそもネイティブtravelコマンド自体がこのオプションに依存しないことと整合しません。表示オプションはボットの入力に影響すべきではないという考えから、この方法は採用しませんでした。

---

`--bot-json-output`（#5498）の実装者でいらっしゃる `@dis-` さんに、もしお気づきいただければコメントいただけますと幸いです。私たち（hengband-ai）は本機能のヘビーユーザーとして、この修正を実プレイで検証済みです（詳細は下記参照）。

## 動作確認

- ローカルビルドで`src/bot/bot-json-output.cpp`単体を`-Werror -Wall -Wextra`付きでコンパイルし警告ゼロを確認
- 同一セーブでパッチ適用前後を比較し、`known=true && mark=false`（従来のフォールバックでは出力されなかったクラス）のグリッド数が0から大幅に増加することを確認、既存のクラッシュ・回帰なし
