### PR TITLE
[Fix] macOS / OpenBSD でコンパイルできない問題を修正

### DIFF
--- a/src/bot/bot-socket-server.cpp
+++ b/src/bot/bot-socket-server.cpp
@@ -386,9 +386,12 @@ bool BotSocketServer::listen_on_loopback()
 
     sockaddr_in address{};
     address.sin_family = AF_INET;
-    address.sin_addr.s_addr = ::htonl(INADDR_LOOPBACK);
+    // htonl()/htons()はmacOSやOpenBSDでは関数ではなく関数形式マクロとして定義されている。
+    // プリプロセッサは直前の"::"を無視して展開するため、他のソケットAPIと同様に"::"を付けると
+    // 展開結果が"::"の直後に来てコンパイルできない。ここだけは意図的に修飾なしで呼ぶこと。
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     // portが1〜65535に収まることはコンストラクタの事前条件
-    address.sin_port = ::htons(static_cast<uint16_t>(this->port));
+    address.sin_port = htons(static_cast<uint16_t>(this->port));
     if (::bind(native_socket(socket), reinterpret_cast<const sockaddr *>(&address), static_cast<socket_length_t>(sizeof(address))) != 0) {
         report_bot_message(fmt::format("failed to bind the listening socket (error {})", last_socket_error()));
         close_socket_handle(socket);

--- a/src/system/angband-version.h
+++ b/src/system/angband-version.h
@@ -54,17 +54,16 @@ enum class VersionExpression {
     FULL,
 };
 
+/*!
+ * @brief バージョン番号
+ * @details
+ * OpenBSD等のsys/types.hはmajor()/minor()を関数形式マクロとして定義しており、
+ * ソース中に "major(" や "minor(" というトークン列があるとそこで展開されてしまう。
+ * コンストラクタを持たない集成体とすることでその形の記述を避けているので、
+ * メンバ初期化子リスト等でmajor/minorを関数呼び出しの形で書かないこと。
+ */
 class AngbandVersion {
 public:
-    AngbandVersion() = default;
-    AngbandVersion(uint8_t major, uint8_t minor, uint8_t patch, uint8_t extra)
-        : major(major)
-        , minor(minor)
-        , patch(patch)
-        , extra(extra)
-    {
-    }
-
     uint8_t major = 0; //!< 変愚蛮怒バージョン(メジャー番号)
     uint8_t minor = 0; //!< 変愚蛮怒バージョン(マイナー番号)
     uint8_t patch = 0; //!< 変愚蛮怒バージョン(パッチ番号)


### PR DESCRIPTION
## 概要

#5523 で報告された、macOS 26.6.1 (Apple clang 21) および OpenBSD 7.9/arm64 (clang 19.1.7) で
コンパイルできない問題を修正します。

原因は独立した 2 つで、それぞれ 1 コミットに分けています。

## 修正1: `::htonl()` / `::htons()`

`src/bot/bot-socket-server.cpp` が `::htonl()` / `::htons()` とスコープ解決演算子付きで呼んでいました。

`htonl`/`htons` は多くの環境で**関数ではなく関数形式マクロ**です。プリプロセッサは直前の `::` を
無視して展開するため、展開結果が `::` の直後に来ます。

| 環境 | `htonl(x)` の展開 | 結果 |
| --- | --- | --- |
| Linux/glibc | `__bswap_32 (x)` (`__bswap_32` は inline **関数**) | `::__bswap_32(x)` となり偶然通る |
| macOS | `__DARWIN_OSSwapInt32(x)` → 更にマクロ | `::(__builtin_constant_p(x) ? …)` で `expected unqualified-id` |
| OpenBSD | `__htobe32(x)` → `__swap32(x)` → 更にマクロ | 同上 |

Linux で通っていたのは実装依存の偶然で、`::` を付けること自体が誤りでした。
**修飾を外せばマクロ実装・関数実装のどちらの環境でも正しく動く**ため、そのようにしています。
プラットフォーム分岐も configure での検査も不要です。

このファイルは他の OS API を `::socket()` `::bind()` `::recv()` … と `::` 付きで統一しているため、
なぜここだけ修飾が無いのかをコメントで明記しました。

## 修正2: `major()` / `minor()` マクロとの衝突

こちらは #5518 とは無関係の既存問題ですが、#5523 の再現手順で
「OpenBSD では `#undef major` / `#undef minor` を足す前作業が必要」と報告されているため併せて直します。

OpenBSD 等の `sys/types.h` は `major()` / `minor()` をデバイス番号を分解する関数形式マクロとして
定義しており、これが `AngbandVersion` のコンストラクタのメンバ初期化子と衝突します。

```cpp
AngbandVersion(uint8_t major, uint8_t minor, uint8_t patch, uint8_t extra)
    : major(major)   // ← "major(" が展開されてコンパイルエラー
    , minor(minor)
```

関数形式マクロは識別子の直後が `(` のときだけ展開されるため、メンバ宣言 `uint8_t major = 0;` や
参照 `version.major`、引数宣言 `h_older_than(uint8_t major, …)` は無害です。
コードベース全体で `major(` / `minor(` の形になっているのはこの 2 行だけでした。

`#undef` は OS の API をプリプロセッサで潰す副作用があり、メンバ名の改名は参照側 10 数箇所に
波及するため、いずれも採らず、**コンストラクタを削除して集成体 (aggregate) にする**ことで
`major(` というトークン列自体を無くしました。全メンバが public でデフォルトメンバ初期化子を
持つため、既存の使い方はそのまま通ります。

- `AngbandVersion version{};` → 集成体の値初期化で全メンバ 0
- `set_version({ major, minor, patch, extra });` → 集成体初期化

再発防止として、その旨をクラスのコメントに残しています。

## 動作確認

- Linux (g++) でのビルド: 成功
- macOS / OpenBSD 流のマクロ定義を模した TU での構文チェック: 修正前は両方の箇所が同じエラーを
  再現し、修正後は通過することを確認
- 制御サーバの実動作: `--headless --control-port=<port>` で待ち受けが張れ、`info` / `screen` が
  正常に応答することを確認
- セーブデータのロード: 既存のセーブファイルを読み込んでプレイ画面まで到達することを確認
  (集成体初期化になった `set_version()` の経路とロード中のバージョン比較を通過)

macOS / OpenBSD の実機は手元に無いため、最終確認は報告者にお願いできればと思います。

Fixes #5523

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 特定の環境で発生していたコンパイル上の互換性問題を修正しました。
  - バージョン情報の扱いを整理し、環境によって発生する名前の衝突を回避しました。

- **改善**
  - 通信設定およびバージョン情報の初期化方法を見直し、ビルドの安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->