### PR TITLE
[Refactor] MSVCプロジェクトの共通設定をプロパティシートへ切り出す

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,8 @@ AUTOMAKE_OPTIONS = foreign
 
 visual_studio_files = \
 	VisualStudio/Hengband.sln \
+	VisualStudio/Hengband/Hengband.Common.props \
+	VisualStudio/Hengband/Hengband.Configuration.props \
 	VisualStudio/Hengband/Hengband.vcxproj \
 	VisualStudio/Hengband/Hengband.vcxproj.filters \
 	VisualStudio/Hengband/packages.config

--- a/VisualStudio/Hengband/Hengband.Common.props
+++ b/VisualStudio/Hengband/Hengband.Common.props
@@ -43,6 +43,7 @@
 
       <IntrinsicFunctions Condition="'$(HengbandDebugBuild)'!='true'">true</IntrinsicFunctions>
       <FunctionLevelLinking Condition="'$(HengbandDebugBuild)'!='true'">true</FunctionLevelLinking>
+      <Optimization Condition="'$(HengbandDebugBuild)'!='true'">MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -55,6 +56,7 @@
       <ShowProgress Condition="'$(HengbandDebugBuild)'=='true'">LinkVerbose</ShowProgress>
       <OptimizeReferences Condition="'$(HengbandDebugBuild)'!='true'">true</OptimizeReferences>
       <EnableCOMDATFolding Condition="'$(HengbandDebugBuild)'!='true'">true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration Condition="'$(HengbandDebugBuild)'!='true'">UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <ResourceCompile Condition="'$(HengbandJapanese)'=='true'">
       <Culture>0x0411</Culture>

--- a/VisualStudio/Hengband/Hengband.Common.props
+++ b/VisualStudio/Hengband/Hengband.Common.props
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <LinkIncremental Condition="'$(HengbandDebugBuild)'!='true'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ConformanceMode>true</ConformanceMode>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
+      <StructMemberAlignment>16Bytes</StructMemberAlignment>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <CompileAsManaged>false</CompileAsManaged>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+
+      <!-- JP;SJIS;WORLD_SCORE は日本語版のみ、WIN_DEBUG はデバッグ構成のみ -->
+      <PreprocessorDefinitions Condition="'$(HengbandDebugBuild)'=='true' and '$(HengbandJapanese)'=='true'">WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(HengbandDebugBuild)'=='true' and '$(HengbandJapanese)'!='true'">WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(HengbandDebugBuild)'!='true' and '$(HengbandJapanese)'=='true'">WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(HengbandDebugBuild)'!='true' and '$(HengbandJapanese)'!='true'">WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+
+      <DisableSpecificWarnings Condition="'$(HengbandDebugBuild)'=='true'">4061;4062;4127;4244;4255;4365;4514;4668;4710;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(HengbandDebugBuild)'!='true'">4061;4062;4127;4244;4255;4365;4514;4668;4710;4711;4738;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+
+      <RuntimeLibrary Condition="'$(HengbandDebugBuild)'=='true'">MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(HengbandDebugBuild)'!='true'">MultiThreaded</RuntimeLibrary>
+      <DebugInformationFormat Condition="'$(HengbandDebugBuild)'=='true'">EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat Condition="'$(HengbandDebugBuild)'!='true'">ProgramDatabase</DebugInformationFormat>
+      <EnableEnhancedInstructionSet Condition="'$(HengbandDebugBuild)'=='true'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(HengbandDebugBuild)'!='true'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <BasicRuntimeChecks Condition="'$(HengbandDebugBuild)'=='true'">EnableFastChecks</BasicRuntimeChecks>
+
+      <IntrinsicFunctions Condition="'$(HengbandDebugBuild)'!='true'">true</IntrinsicFunctions>
+      <FunctionLevelLinking Condition="'$(HengbandDebugBuild)'!='true'">true</FunctionLevelLinking>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+
+      <AdditionalDependencies Condition="'$(HengbandDebugBuild)'=='true'">winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(HengbandDebugBuild)'!='true'">winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+
+      <ShowProgress Condition="'$(HengbandDebugBuild)'=='true'">LinkVerbose</ShowProgress>
+      <OptimizeReferences Condition="'$(HengbandDebugBuild)'!='true'">true</OptimizeReferences>
+      <EnableCOMDATFolding Condition="'$(HengbandDebugBuild)'!='true'">true</EnableCOMDATFolding>
+    </Link>
+    <ResourceCompile Condition="'$(HengbandJapanese)'=='true'">
+      <Culture>0x0411</Culture>
+      <PreprocessorDefinitions>JP</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/VisualStudio/Hengband/Hengband.Configuration.props
+++ b/VisualStudio/Hengband/Hengband.Configuration.props
@@ -8,8 +8,7 @@
     <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization Condition="'$(HengbandDebugBuild)'!='true'">true</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration">
     <UseDebugLibraries Condition="'$(HengbandDebugBuild)'=='true'">true</UseDebugLibraries>
+    <UseDebugLibraries Condition="'$(HengbandDebugBuild)'!='true'">false</UseDebugLibraries>
   </PropertyGroup>
 </Project>

--- a/VisualStudio/Hengband/Hengband.Configuration.props
+++ b/VisualStudio/Hengband/Hengband.Configuration.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="UserMacros">
+    <HengbandDebugBuild Condition="$(Configuration.EndsWith('Debug'))">true</HengbandDebugBuild>
+    <HengbandJapanese Condition="!$(Configuration.StartsWith('English'))">true</HengbandJapanese>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization Condition="'$(HengbandDebugBuild)'!='true'">true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <UseDebugLibraries Condition="'$(HengbandDebugBuild)'=='true'">true</UseDebugLibraries>
+  </PropertyGroup>
+</Project>

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -43,20 +43,6 @@
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../../\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">../../\</OutDir>
   </PropertyGroup>
-  <!--
-    以下の2つは元の Hengband.vcxproj で Release/English-Release 間に存在した非対称性。
-    挙動不変のため、その揺れをそのまま個別の残余設定として残す。
-  -->
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Link>
-      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">
-    <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\action\action-limited.cpp" />
     <ClCompile Include="..\..\src\action\activation-execution.cpp" />

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -38,10 +38,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\</OutDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">..\..\</OutDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../../\</OutDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">../../\</OutDir>
+    <OutDir>..\..\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\action\action-limited.cpp" />
@@ -462,10 +459,7 @@
     <ClCompile Include="..\..\src\status\experience.cpp" />
     <ClCompile Include="..\..\src\status\temporary-resistance.cpp" />
     <ClCompile Include="..\..\src\stdafx.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\src\store\home.cpp" />
     <ClCompile Include="..\..\src\store\museum.cpp" />

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -1,23 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -42,218 +24,38 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+  <Import Project="Hengband.Configuration.props" />
+  <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v145</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v145</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v145</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v145</PlatformToolset>
-    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Hengband.Common.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">..\..\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">$(Configuration)\</IntDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../../\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">../../\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">$(Configuration)\</IntDir>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <CompileAs>CompileAsCpp</CompileAs>
-      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <ConformanceMode>true</ConformanceMode>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
-      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
-      <StructMemberAlignment>16Bytes</StructMemberAlignment>
-      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <CompileAsManaged>false</CompileAsManaged>
-      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
-      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
-    </ClCompile>
-    <Link>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <ShowProgress>LinkVerbose</ShowProgress>
-      <SubSystem>Windows</SubSystem>
-    </Link>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
-    <ResourceCompile>
-      <Culture>0x0411</Culture>
-      <PreprocessorDefinitions>JP</PreprocessorDefinitions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='English-Debug|Win32'">
-    <ClCompile>
-      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;WIN_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <CompileAs>CompileAsCpp</CompileAs>
-      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
-      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
-      <StructMemberAlignment>16Bytes</StructMemberAlignment>
-      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <CompileAsManaged>false</CompileAsManaged>
-      <ConformanceMode>true</ConformanceMode>
-      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
-      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
-    </ClCompile>
-    <Link>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <TargetMachine>MachineX86</TargetMachine>
-      <ShowProgress>LinkVerbose</ShowProgress>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-    </Link>
-  </ItemDefinitionGroup>
+  <!--
+    以下の2つは元の Hengband.vcxproj で Release/English-Release 間に存在した非対称性。
+    挙動不変のため、その揺れをそのまま個別の残余設定として残す。
+  -->
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;JP;SJIS;WORLD_SCORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4711;4738;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <CompileAs>CompileAsCpp</CompileAs>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
-      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <StructMemberAlignment>16Bytes</StructMemberAlignment>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <CompileAsManaged>false</CompileAsManaged>
-      <ConformanceMode>true</ConformanceMode>
-      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
-      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
-    </ClCompile>
     <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OptimizeReferences>true</OptimizeReferences>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <SubSystem>Windows</SubSystem>
     </Link>
-    <ResourceCompile>
-      <PreprocessorDefinitions>JP</PreprocessorDefinitions>
-    </ResourceCompile>
-    <ResourceCompile>
-      <Culture>0x0411</Culture>
-    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='English-Release|Win32'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;WIN32;HAVE_STDINT_H;%(PreprocessorDefinitions);</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <DisableSpecificWarnings>4061;4062;4127;4244;4255;4365;4514;4668;4710;4711;4738;4820;4996;4774;5045;5264;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>..\..\src;..\..\src\external-lib\include;libcurl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <CompileAs>CompileAsCpp</CompileAs>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
-      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift-jis %(AdditionalOptions)</AdditionalOptions>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <StructMemberAlignment>16Bytes</StructMemberAlignment>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <CompileAsManaged>false</CompileAsManaged>
-      <ConformanceMode>true</ConformanceMode>
-      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
-      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <TreatAngleBracketIncludesAsExternal>true</TreatAngleBracketIncludesAsExternal>
     </ClCompile>
-    <Link>
-      <AdditionalDependencies>winmm.lib;gdiplus.lib;Ws2_32.lib;Wldap32.lib;Crypt32.lib;Normaliz.lib;DbgHelp.lib;libcurl\lib\libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OptimizeReferences>true</OptimizeReferences>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <TargetMachine>MachineX86</TargetMachine>
-    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\action\action-limited.cpp" />


### PR DESCRIPTION
## 概要

Windows (Visual Studio) でユニットテストを実行できるようにする作業の1段階目(PR1)。
`Hengband.vcxproj` が4構成(Debug/Release/English-Debug/English-Release)分の
`ItemDefinitionGroup` を重複して持っており、今後テスト用プロジェクトを追加して
3プロジェクト構成にすると重複が3倍に膨れるため、先に共通設定をプロパティシート
(`Hengband.Configuration.props` / `Hengband.Common.props`)へ切り出して一元化する。

- 1コミット目: 挙動不変のリファクタ。`Microsoft.Cpp.Default.props` インポート前にあった
  死んでいる `PropertyGroup` の削除も含む。
- 2コミット目: 1コミット目で見つかった `Optimization`/`LinkTimeCodeGeneration` の
  `Release`/`English-Release` 間の揺れ(実害なし、ツールセット既定値解決で結果は
  同一だったことを確認済み)を明示的に統一する変更。挙動不変のリファクタと切り分けるため
  別コミットにしている。

## 検証

変更前後で4構成すべてを `Rebuild` し、`-flp:verbosity=diagnostic` の診断ログから
`cl.exe`/`link.exe`/`rc.exe` の実コマンドラインを比較した。

- 1コミット目: 差分は意図した2点のみ
  - `IntDir` のパス変更 (`$(Configuration)\` → `$(Configuration)\$(ProjectName)\`)
  - `English-Release` への `/SUBSYSTEM:WINDOWS` の明示付与
- 2コミット目: 変更前後でコマンドラインは完全一致(差分なし)

`Hengband.exe` がリポジトリルートに生成され、起動してタイトル画面が表示されることを確認した。

## Test plan

- [x] 4構成 (`Debug`/`English-Debug`/`Release`/`English-Release`) すべてで `MSBuild -warnAsError` によるリビルドが成功すること
- [x] 変更前後で `cl.exe`/`link.exe`/`rc.exe` の実コマンドラインを比較し、意図した差分以外が無いこと
- [x] `Hengband.exe` がリポジトリルートに生成され、起動できること
- [ ] レビュー後、実際にゲームプレイ(新規キャラクター作成など)で動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - Visual Studio のビルド設定を整理し、Debug／Release 構成や日本語・英語向け設定を一貫して利用できるようになりました。
  - C++20、Unicode、文字コード、最適化などの共通設定を適用し、ビルド環境の再現性を向上しました。

- **配布**
  - Visual Studio 用の共通設定ファイルを配布対象に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->