### PR TITLE
[Refactor] ゲーム本体をHengbandCore静的ライブラリプロジェクトへ分割する

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ visual_studio_files = \
 	VisualStudio/Hengband/Hengband.Common.props \
 	VisualStudio/Hengband/Hengband.Configuration.props \
 	VisualStudio/Hengband/Hengband.vcxproj \
-	VisualStudio/Hengband/Hengband.vcxproj.filters \
+	VisualStudio/Hengband/HengbandCore.vcxproj \
+	VisualStudio/Hengband/HengbandCore.vcxproj.filters \
 	VisualStudio/Hengband/packages.config
 
 visual_studio_libcurl_files = \

--- a/VisualStudio/Hengband.sln
+++ b/VisualStudio/Hengband.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.5.11716.220 stable
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Hengband", "Hengband\Hengband.vcxproj", "{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Hengband", "Hengband\Hengband.vcxproj", "{32D43DED-9745-48F3-892D-231695D201A6}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HengbandCore", "Hengband\HengbandCore.vcxproj", "{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{82CF9010-9443-4FFF-ADF0-0D3E81C732CC}"
 	ProjectSection(SolutionItems) = preProject
@@ -26,6 +28,14 @@ Global
 		{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}.English-Release|Win32.Build.0 = English-Release|Win32
 		{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}.Release|Win32.ActiveCfg = Release|Win32
 		{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}.Release|Win32.Build.0 = Release|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.Debug|Win32.ActiveCfg = Debug|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.Debug|Win32.Build.0 = Debug|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.English-Debug|Win32.ActiveCfg = English-Debug|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.English-Debug|Win32.Build.0 = English-Debug|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.English-Release|Win32.ActiveCfg = English-Release|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.English-Release|Win32.Build.0 = English-Release|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.Release|Win32.ActiveCfg = Release|Win32
+		{32D43DED-9745-48F3-892D-231695D201A6}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VisualStudio/Hengband/Hengband.vcxproj
+++ b/VisualStudio/Hengband/Hengband.vcxproj
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="English-Debug|Win32">
+      <Configuration>English-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="English-Release|Win32">
+      <Configuration>English-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{32D43DED-9745-48F3-892D-231695D201A6}</ProjectGuid>
+    <RootNamespace>Hengband</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="Hengband.Configuration.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Hengband.Common.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>..\..\</OutDir>
+    <TargetName>Hengband</TargetName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\main-win.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\src\angband.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\src\wall.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="HengbandCore.vcxproj">
+      <Project>{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/VisualStudio/Hengband/HengbandCore.vcxproj
+++ b/VisualStudio/Hengband/HengbandCore.vcxproj
@@ -20,13 +20,13 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}</ProjectGuid>
-    <RootNamespace>Hengband</RootNamespace>
+    <RootNamespace>HengbandCore</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="Hengband.Configuration.props" />
   <PropertyGroup Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -38,7 +38,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir>..\..\</OutDir>
+    <OutDir>$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\action\action-limited.cpp" />
@@ -1631,7 +1631,6 @@
     <ClCompile Include="..\..\src\locale\localized-string.cpp" />
     <ClCompile Include="..\..\src\locale\japanese.cpp" />
     <ClCompile Include="..\..\src\load\load.cpp" />
-    <ClCompile Include="..\..\src\main-win.cpp" />
     <ClCompile Include="..\..\src\cmd-action\cmd-mind.cpp" />
     <ClCompile Include="..\..\src\monster\monster-info.cpp" />
     <ClCompile Include="..\..\src\monster\monster-list.cpp" />
@@ -1958,10 +1957,6 @@
     <ClInclude Include="..\..\src\term\z-util.h" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\..\src\angband.rc" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\src\wall.bmp" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualStudio/Hengband/HengbandCore.vcxproj.filters
+++ b/VisualStudio/Hengband/HengbandCore.vcxproj.filters
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="..\..\src\main-win.cpp" />
     <ClCompile Include="..\..\src\combat\shoot.cpp">
       <Filter>combat</Filter>
     </ClCompile>
@@ -5735,7 +5734,6 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\src\wall.bmp" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -6045,8 +6043,5 @@
     <Filter Include="rumor">
       <UniqueIdentifier>{c62f5f7a-ab76-464e-ad5b-3342523e5520}</UniqueIdentifier>
     </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="..\..\src\angband.rc" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 概要

Windows (Visual Studio) でユニットテストを実行できるようにする作業の2段階目(PR2)。PR #5526 でプロパティシートへ共通化した `Hengband.vcxproj` を、autotools側の `libhengband.a` と同じ構成に分割する。

```
autotools                          MSVC
─────────────────────────────      ──────────────────────────────────
libhengband.a  (main.cpp 以外)     HengbandCore.vcxproj  (StaticLibrary)   ← 今回
hengband       (main.cpp)          Hengband.vcxproj      (Application, WINDOWS) ← 今回
hengband-test  (test/**)           HengbandTest.vcxproj  (Application, CONSOLE)  ← 次PR
```

## 変更内容

1. **`Hengband.vcxproj` → `HengbandCore.vcxproj`**(`git mv` でリネーム検出): `ConfigurationType` を `StaticLibrary` に変更し、`main-win.cpp`・`angband.rc`・`wall.bmp` を除外(実行ファイル側へ移動)。`OutDir` を `$(Configuration)\` に変更
2. **新規 `Hengband.vcxproj`**(Application): `main-win.cpp`(PCH NotUsing)・`angband.rc`・`wall.bmp` のみを持つ薄いプロジェクト。`HengbandCore.vcxproj` を `ProjectReference` でリンクし、`OutDir=..\..\`・`TargetName=Hengband` でリポジトリルートに `Hengband.exe`/`.pdb` が出る現状を維持
3. `Hengband.sln` に `HengbandCore` のエントリを追加、`Hengband` は新しいGUIDに差し替え

`main-win.cpp` が定義する外部シンボル(`win_maximized`/`game_in_progress`/`movie_in_progress`/`create_debug_spoiler`)を参照しているのは `main-win/commandline-win.cpp` だけで、これは `main-win.cpp` からしか呼ばれないため、静的ライブラリからテスト実行ファイル(次PR)のリンク時に引きずり込まれることはない。

## ⚠️ スタートアッププロジェクトについて

`Hengband.sln` の `Project()` エントリは `Hengband`(実行ファイル)を `HengbandCore`(静的ライブラリ)より先に列挙している。Visual Studio はスタートアッププロジェクト未指定時(`.suo` が存在しない新規cloneの場合)、`.sln` の先頭に列挙されたプロジェクトを既定にするため、この順序が重要。

**もし逆順だと**、ローカルWindowsデバッガー起動時に「`HengbandCore.lib` は有効な Win32 アプリケーションではありません」というエラーになる(静的ライブラリを実行しようとしてしまう)。

既に `.vs`/`.suo`(gitignore対象のローカルキャッシュ)でスタートアッププロジェクトが `HengbandCore` に固定されてしまっている場合は、`.sln` の並び順を直すだけでは反映されない。以下のいずれかで対応する。

- Solution Explorer で `Hengband` を右クリック→「スタートアップ プロジェクトに設定」
- `VisualStudio\.vs` フォルダを削除してソリューションを開き直す(ローカルキャッシュなので削除して問題ない)

## 検証

- 4構成すべて `MSBuild -warnAsError /t:Rebuild` が成功
- `Hengband.exe`(PE32 GUI実行ファイル)/`.pdb` がリポジトリルートに生成され、`HengbandCore.lib` は各構成の中間ディレクトリに生成されることを確認
- `.\Build-Windows-Release-Package.ps1` が最後まで通り、日本語版・英語版とも zip が作成されることを確認
- 日本語版(Debug)・英語版(English-Debug)とも実際に起動し、ウィンドウタイトルが正しく表示されることを確認(「変愚蛮怒」/「Hengband」)
- 実機のVisual Studioでローカルデバッガー起動を確認(スタートアッププロジェクト問題を発見・修正済み)

## Test plan

- [x] 4構成すべてで `MSBuild -warnAsError` によるリビルドが成功すること
- [x] `Hengband.exe`/`.pdb` がリポジトリルートに生成されること
- [x] `Build-Windows-Release-Package.ps1` が成功しzipが作られること
- [x] 日本語版・英語版とも起動して正しく表示されること
- [x] Visual Studio のローカルデバッガーでスタートアッププロジェクトが正しく `Hengband` になること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Visual Studio ソリューションにコア機能用プロジェクトを追加しました。
  - Debug、Release、英語版を含む各 Win32 構成でビルドできるようになりました。
  - Visual Studio のプロジェクト構成とフィルター設定を整理し、不要な項目を削除しました。
- **互換性**
  - Visual Studio での開発・ビルド環境をより明確に分離し、構成管理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->