### PR TITLE
[Fix] #5529 武器匠で折れた武器を一度に複数修復できてしまう

### DIFF
--- a/src/market/building-craft-fix.cpp
+++ b/src/market/building-craft-fix.cpp
@@ -26,6 +26,7 @@
 #include "term/screen-processor.h"
 #include "util/bit-flags-calculator.h"
 #include "view/display-messages.h"
+#include <tl/optional.hpp>
 #include <utility>
 #include <vector>
 
@@ -85,7 +86,14 @@ static void give_one_ability_of_object(ItemEntity *to_ptr, ItemEntity *from_ptr)
     }
 }
 
-static std::pair<short, std::shared_ptr<ItemEntity>> select_repairing_broken_weapon(PlayerType *player_ptr, const int row)
+/*!
+ * @brief 修復対象の折れた武器を選択する
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param row 案内メッセージを表示する行
+ * @return 修復可能な武器を選択したならばその武器とインベントリ内の位置のペア、
+ * 選択しなかった場合や修復できない武器を選択した場合は tl::nullopt
+ */
+static tl::optional<std::pair<std::shared_ptr<ItemEntity>, short>> select_repairing_broken_weapon(PlayerType *player_ptr, const int row)
 {
     prt(_("修復には材料となるもう1つの武器が必要です。", "Hand one material weapon to repair a broken weapon."), row, 2);
     prt(_("材料に使用した武器はなくなります！", "The material weapon will disappear after repairing!!"), row + 1, 2);
@@ -93,20 +101,20 @@ static std::pair<short, std::shared_ptr<ItemEntity>> select_repairing_broken_wea
     constexpr auto s = _("修復できる折れた武器がありません。", "You have no broken weapon to repair.");
     const auto &[item, i_idx] = choose_item(player_ptr, q, s, (USE_INVEN | USE_EQUIP), FuncItemTester(&ItemEntity::is_broken_weapon));
     if (!item) {
-        return { i_idx, nullptr };
+        return tl::nullopt;
     }
 
     if (!item->is_ego() && !item->is_fixed_or_random_artifact()) {
-        msg_format(_("それは直してもしょうがないぜ。", "It is worthless to repair."));
-        return { i_idx, item };
+        msg_print(_("それは直してもしょうがないぜ。", "It is worthless to repair."));
+        return tl::nullopt;
     }
 
     if (item->number > 1) {
-        msg_format(_("一度に複数を修復することはできません！", "They are too many to repair at once!"));
-        return { i_idx, item };
+        msg_print(_("一度に複数を修復することはできません！", "They are too many to repair at once!"));
+        return tl::nullopt;
     }
 
-    return { i_idx, item };
+    return std::make_pair(item, i_idx);
 }
 
 static void display_reparing_weapon(PlayerType *player_ptr, const ItemEntity &item, const int row)
@@ -136,10 +144,12 @@ static PRICE repair_broken_weapon_aux(PlayerType *player_ptr, PRICE bcost)
 {
     clear_bldg(0, 22);
     auto row = 7;
-    const auto &[item_idx_broken, item_broken] = select_repairing_broken_weapon(player_ptr, row);
-    if (!item_broken) {
+    const auto selection = select_repairing_broken_weapon(player_ptr, row);
+    if (!selection) {
         return 0;
     }
+
+    const auto &[item_broken, item_idx_broken] = *selection;
 
     display_reparing_weapon(player_ptr, *item_broken, row);
     constexpr auto q = _("材料となる武器は？", "Which weapon for material? ");


### PR DESCRIPTION
## 概要

#5529 の修正です。

武器匠の「折れた武器を修復する」で、折れた武器が複数本スタックしていると、代金1回分で修復済みの武器が複数本手に入ってしまう不具合を修正します。

同じ原因で「エゴでも★でもない折れた武器は修復しない」チェックも機能しておらず、「それは直してもしょうがないぜ。」と表示された後にそのまま修復が進んでいました。

## 原因

`select_repairing_broken_weapon()` は修復対象の選択に失敗する3ケースすべてで `{ i_idx, item }` を返しており、エラーの2ケース（修復価値がない／複数をまとめて修復できない）でも `item` が非nullのまま返っていました。

呼び出し側の `repair_broken_weapon_aux()` は `if (!item_broken)` でしか失敗を判定していないため、メッセージを表示した後もそのまま修復処理に進んでいました。修復対象の `number` は2のままなので、スタック全体が修復されて武器が2本できあがります。

これは 5edb65a96e 「[Refactor] #3152 select_repairing_broken_weapon() の引数と戻り値を調整した」での回帰です。それ以前は `std::pair<bool, ItemEntity *>` の `bool` で成否を返しており、エラー時は `{ false, o_ptr }` で正しく中断していました。この `bool` をインベントリ添字の `short` に置き換えた際に、失敗を表現するチャネルが型から失われています。

## 変更内容

「アイテムは取得できたがエラー」という状態を表現できない戻り値型が原因なので、成否を型で表現し直しました。

- `select_repairing_broken_weapon()` の戻り値を `tl::optional<std::pair<std::shared_ptr<ItemEntity>, short>>` に変更し、失敗する3ケースすべてで `tl::nullopt` を返す
- ペアの要素順は、呼び出している `choose_item()` の戻り値 (`std::pair<std::shared_ptr<ItemEntity>, short>`) に揃えました。従来は添字が先で順序が逆転しており、structured binding を読み違えやすい形でした
- 併せて、書式引数を取らない `msg_format()` の呼び出し2箇所を `msg_print()` に変更しました

修復処理の本体（ベースアイテムの抽選、ダイスや特性の引き継ぎ、材料の消費）は変更していません。

なお、「エゴまたは★であること」「スタックしていないこと」をアイテムテスタ側に寄せて最初から選べなくする案も検討しましたが、`ItemEntity::is_ego()` は鑑定状態を見ないため、未鑑定の折れた武器のうち当たりのものだけが選択肢に出てしまい、鑑定せずに判別できてしまいます。同じ `src/market/` の `building-recharger.cpp` が同じ理由で意図的に選択後バリデーションにしているため、本PRもその方式を踏襲しています。

## 動作確認

`--headless` + 制御サーバでモリバントの武器匠まで到達し、以下を確認しました。

| ケース | 結果 |
| --- | --- |
| エゴの折れた剣 2本スタック | 「一度に複数を修復することはできません！」で中断し、材料選択に進まない。所持金・アイテムとも変化なし |
| エゴでない折れた剣 | 「それは直してもしょうがないぜ。」で中断 |
| エゴの折れた剣 1本 | 材料選択 → 支払い → ツヴァイハンダーに修復成功（正常系に回帰なし） |

`make check` も通ることを確認済みです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 壊れた武器の修理時に、選択に失敗した場合や修理できない武器を選んだ場合の処理を改善しました。
  - 複数の対象を所持している場合でも、誤った武器やインベントリ位置が選択される問題を防止しました。
  - 無効な選択時のエラー表示に頼らず、修理処理を安全に終了できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->