### PR TITLE
[Fix] #5532 射撃武器の命中・ダメージ修正が変異打撃や投擲に乗る

### DIFF
--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2021,6 +2021,25 @@ static bool is_bare_knuckle(PlayerType *player_ptr)
     return bare_knuckle;
 }
 
+/*!
+ * @brief 武器以外の装備による命中・ダメージ修正を加算する対象のスロットかを判定する
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param slot 判定する装備スロット
+ * @return 加算対象ならtrue
+ * @details
+ * 空きスロットとモンスター・ボールは対象外。打撃武器と遠隔武器自身の修正は武器の分として別に計算するため、
+ * 打撃武器を装備している手と遠隔武器のスロットも対象外とする。
+ */
+static bool is_non_weapon_bonus_slot(PlayerType *player_ptr, inventory_slot_type slot)
+{
+    const auto &item = *player_ptr->inventory[slot];
+    if (!item.is_valid() || (item.bi_key.tval() == ItemKindType::CAPTURE)) {
+        return false;
+    }
+
+    return (slot != INVEN_BOW) && !has_melee_weapon(player_ptr, slot);
+}
+
 static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_real_value)
 {
     const auto *o_ptr = player_ptr->inventory[slot].get();
@@ -2081,12 +2100,7 @@ static short calc_to_damage(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_
     for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         int bonus_to_d = 0;
         o_ptr = player_ptr->inventory[i_idx].get();
-        const auto has_melee = has_melee_weapon(player_ptr, i_idx);
-        if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
-            continue;
-        }
-
-        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
+        if (!is_non_weapon_bonus_slot(player_ptr, i_idx)) {
             continue;
         }
 
@@ -2321,13 +2335,7 @@ static short calc_to_hit(PlayerType *player_ptr, INVENTORY_IDX slot, bool is_rea
     for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         auto *o_ptr = player_ptr->inventory[i_idx].get();
 
-        /* Ignore empty hands, handed weapons, bows and capture balls */
-        const auto has_melee = has_melee_weapon(player_ptr, i_idx);
-        if (!o_ptr->is_valid() || o_ptr->bi_key.tval() == ItemKindType::CAPTURE) {
-            continue;
-        }
-
-        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
+        if (!is_non_weapon_bonus_slot(player_ptr, i_idx)) {
             continue;
         }
 
@@ -2462,12 +2470,7 @@ static int16_t calc_to_hit_bow(PlayerType *player_ptr, bool is_real_value)
     for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         int bonus_to_h;
         o_ptr = player_ptr->inventory[i_idx].get();
-        const auto has_melee = has_melee_weapon(player_ptr, i_idx);
-        if (!o_ptr->is_valid() || (o_ptr->bi_key.tval() == ItemKindType::CAPTURE)) {
-            continue;
-        }
-
-        if (((i_idx == INVEN_MAIN_HAND) && has_melee) || ((i_idx == INVEN_SUB_HAND) && has_melee) || (i_idx == INVEN_BOW)) {
+        if (!is_non_weapon_bonus_slot(player_ptr, i_idx)) {
             continue;
         }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -2500,7 +2500,7 @@ static int16_t calc_to_damage_misc(PlayerType *player_ptr)
 
     for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i_idx].get();
-        if (!o_ptr->is_valid()) {
+        if (!is_non_weapon_bonus_slot(player_ptr, i_idx)) {
             continue;
         }
 
@@ -2530,7 +2530,7 @@ static int16_t calc_to_hit_misc(PlayerType *player_ptr)
 
     for (const auto i_idx : INVEN_WIELDING_SLOTS) {
         o_ptr = player_ptr->inventory[i_idx].get();
-        if (!o_ptr->is_valid()) {
+        if (!is_non_weapon_bonus_slot(player_ptr, i_idx)) {
             continue;
         }
 


### PR DESCRIPTION
## 概要

close #5532

遠隔武器スロットに装備した弓の命中・ダメージ修正が `PlayerType::to_h_m` / `to_d_m` に混入し、
打撃側に乗ってしまう不具合を修正します。同じ経路で、装備中の打撃武器の修正も混入していました。

`to_h_m` / `to_d_m` は「武器以外の装備による修正」を表す値で、以下の3箇所で使われています。

| 箇所 | 影響 |
| --- | --- |
| `natural_attack()` | 変異による打撃（角・クチバシ・象の鼻・触手・サソリの尻尾）の命中とダメージ |
| `ObjectThrowEntity::calc_racial_power_damage()` | 投擲のダメージ |
| `display_first_page()` | キャラクターシートの「打撃命中」表示 |

通常の武器打撃は `to_h[]` を使うため影響を受けません。

## 原因

2.2.1r2 までは `xtra1.c` の `calc_bonuses()` 内の装備ループで、`to_h_m` / `to_d_m` に加算する
直前に遠隔武器スロットと打撃武器のスロットを明示的に除外していました。

```c
/* Hack -- do not apply "weapon" bonuses */
if (i == INVEN_RARM && buki_motteruka(i)) continue;
if (i == INVEN_LARM && buki_motteruka(i)) continue;

/* Hack -- do not apply "bow" bonuses */
if (i == INVEN_BOW) continue;
...
p_ptr->to_h_m += bonus_to_h;
p_ptr->to_d_m += bonus_to_d;
```

その後 #40514 のリファクタで `calc_bonuses()` から分離した際、新しく書き起こしたループに
この除外条件が引き継がれませんでした。

- ce98344521 (2020-07-12) `calc_to_hit_misc()` を `calc_bonuses()` から分離
- d502a3dd78 (2020-07-12) `calc_to_damage_misc()` を `calc_bonuses()` から分離

`git tag --contains` で確認したところ、影響するのは 3.0.0Alpha6 以降のすべてのバージョンです。
意図した仕様変更ではないため、2.2.1r2 相当の除外に戻します。

## 変更内容

同じ除外条件が `calc_to_damage()` / `calc_to_hit()` / `calc_to_hit_bow()` にも重複して
書かれていたため、判定を切り出してから修正を載せる2コミット構成にしました。

**1. [Refactor] 対象スロット判定の切り出し（挙動不変）**

3箇所に重複していた判定を `is_non_weapon_bonus_slot()` に切り出しました。

```cpp
static bool is_non_weapon_bonus_slot(PlayerType *player_ptr, inventory_slot_type slot)
{
    const auto &item = *player_ptr->inventory[slot];
    if (!item.is_valid() || (item.bi_key.tval() == ItemKindType::CAPTURE)) {
        return false;
    }

    return (slot != INVEN_BOW) && !has_melee_weapon(player_ptr, slot);
}
```

**2. [Fix] misc 系2関数への適用（挙動変更）**

`calc_to_hit_misc()` / `calc_to_damage_misc()` のループでこの判定を使うようにしました。
差分は各1行で、これが不具合の実体です。

## 副次的な効果

ブーメラン投げのダメージ二重計上も解消されます。投げた武器自身の `to_d` は
`calc_racial_power_damage()` で個別に加算された上、装備中だったその武器の `to_d` が
`to_d_m` にも入っていたためです。

## 動作確認

`--headless` + 制御サーバで、同一のキー列を流して「打撃命中」「射撃命中」を比較しました
（人間・戦士、`--fixed-seed=12345`）。装備の修正値はデバッグコマンドの tweak で変更しています。

| 状態 | 打撃命中 (develop) | 打撃命中 (リファクタのみ) | 打撃命中 (修正後) | 射撃命中 (全ビルド共通) |
| --- | --- | --- | --- | --- |
| ロング・ボウ (+3) 装備のみ | 88 | 88 | **79** | 73 |
| 弓の命中を +30 に変更 | 169 | 169 | **79** | 154 |
| 打撃武器の命中を +30 に変更 | 169 | 169 | **79** | 64 |
| 指輪の命中を +30 に変更 | 169 | 169 | 169 | 154 |

- リファクタコミット単体では develop と全数値が一致し、挙動不変を確認しています
- 修正後は遠隔武器と打撃武器の修正が「打撃命中」から消え、指輪など武器以外の装備の分は従来どおり残ります
- 射撃命中は全ビルドで同値で、射撃側に回帰はありません
- 日本語版・英語版ともビルドが通り、`make check` も PASS します

`to_d_m` 側は表示に出ない値のため、同一形の修正であることの確認とビルド・テストのみです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 武器以外の装備による命中率・ダメージ補正の判定を統一しました。
  * 近接攻撃、射撃などの計算で、空きスロットや武器類が誤って補正対象になる問題を修正しました。
  * 装備効果が適切な攻撃計算にのみ反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->