### PR TITLE
[Fix] #5531 デバッグコマンドの「願い」でクラッシュする

### DIFF
--- a/src/flavor/named-item-describer.cpp
+++ b/src/flavor/named-item-describer.cpp
@@ -250,7 +250,7 @@ static std::string describe_item_count_or_article_en(const ItemEntity &item, con
     }
 
     auto is_unique_item = opt.known && item.is_fixed_or_random_artifact();
-    is_unique_item |= (item.bi_key.tval() == ItemKindType::MONSTER_REMAINS) && item.get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
+    is_unique_item |= (item.bi_key.tval() == ItemKindType::MONSTER_REMAINS) && none_bits(opt.mode, OD_OMIT_MONRACE) && item.get_monrace().kind_flags.has(MonsterKindType::UNIQUE);
     if (is_unique_item) {
         return "The ";
     }

--- a/src/flavor/object-flavor-types.h
+++ b/src/flavor/object-flavor-types.h
@@ -10,5 +10,6 @@ enum object_description_type {
     OD_NO_FLAVOR = 0x00000040, /* Allow to hidden flavor */
     OD_FORCE_FLAVOR = 0x00000080, /* Get un-shuffled flavor name */
     OD_BASE_NAME = 0x00000100, /* Use kind name without artifact, ego, or smithing details */
+    OD_OMIT_MONRACE = 0x00000200, /* Omit monrace name (the item is a baseitem template and its monrace is unset) */
     OD_DEBUG = 0x10000000, /* Print for DEBUG */
 };

--- a/src/flavor/tval-description-switcher.cpp
+++ b/src/flavor/tval-description-switcher.cpp
@@ -17,10 +17,36 @@
 #include "system/monrace/monrace-definition.h"
 #include "util/bit-flags-calculator.h"
 #include "util/enum-converter.h"
+#include "util/string-processor.h"
+#include <array>
 #ifdef JP
 #else
 #include "player-info/class-info.h"
 #endif
+
+/*!
+ * @brief 表示テンプレートからモンスター種族名のプレースホルダを取り除く
+ * @param basename モンスター種族名を含む表示テンプレート
+ * @return 種族名のプレースホルダを取り除いた表示テンプレート
+ * @details 人形・像・死体類の表示テンプレートは種族名に係る助詞・前置詞を含んでいる
+ * (日本語版「#の人形」、英語版「& Magical Figurine~ of #」など)。'#' だけを取り除くと
+ * 「の人形」「Magical Figurine of 」のような不自然な名前になるため、併せて取り除く.
+ */
+static std::string omit_monrace_placeholder(std::string_view basename)
+{
+#ifdef JP
+    static constexpr std::array<std::string_view, 2> patterns = { { "#の", "#" } };
+#else
+    static constexpr std::array<std::string_view, 3> patterns = { { " of #", "# ", "#" } };
+#endif
+
+    std::string result(basename);
+    for (const auto &pattern : patterns) {
+        result = str_replace(result, pattern, "");
+    }
+
+    return result;
+}
 
 static std::pair<std::string, std::string> describe_monster_ball(const ItemEntity &item, const describe_option_type &opt)
 {
@@ -47,9 +73,17 @@ static std::pair<std::string, std::string> describe_monster_ball(const ItemEntit
     return { basename, monrace_name };
 }
 
-static std::pair<std::string, std::string> describe_statue(const ItemEntity &item)
+/*!
+ * @brief 人形・像の名前を記述する
+ * @details OD_OMIT_MONRACE 指定時は種族名を省いた記述を返す.
+ */
+static std::pair<std::string, std::string> describe_statue(const ItemEntity &item, const describe_option_type &opt)
 {
     const auto &basename = item.get_baseitem().name;
+    if (any_bits(opt.mode, OD_OMIT_MONRACE)) {
+        return { omit_monrace_placeholder(basename), "" };
+    }
+
     const auto &monrace = item.get_monrace();
 #ifdef JP
     const auto &monrace_name = monrace.name.string();
@@ -64,8 +98,18 @@ static std::pair<std::string, std::string> describe_statue(const ItemEntity &ite
     return { basename, monrace_name };
 }
 
-static std::pair<std::string, std::string> describe_corpse(const ItemEntity &item)
+/*!
+ * @brief 死体・骨の名前を記述する
+ * @details OD_OMIT_MONRACE 指定時は種族名を省いた記述を返す.
+ */
+static std::pair<std::string, std::string> describe_corpse(const ItemEntity &item, const describe_option_type &opt)
 {
+    if (any_bits(opt.mode, OD_OMIT_MONRACE)) {
+        // 種族が未設定ならユニークかどうかも判らないので非ユニーク側の書式を使う
+        constexpr std::string_view basename = _("#%", "& # %");
+        return { omit_monrace_placeholder(basename), "" };
+    }
+
     const auto &monrace = item.get_monrace();
 #ifdef JP
     const auto basename = "#%";
@@ -375,9 +419,9 @@ std::pair<std::string, std::string> switch_tval_description(const ItemEntity &it
         return describe_monster_ball(item, opt);
     case ItemKindType::FIGURINE:
     case ItemKindType::STATUE:
-        return describe_statue(item);
+        return describe_statue(item, opt);
     case ItemKindType::MONSTER_REMAINS:
-        return describe_corpse(item);
+        return describe_corpse(item, opt);
     case ItemKindType::SHOT:
     case ItemKindType::BOLT:
     case ItemKindType::ARROW:

--- a/src/perception/identification.cpp
+++ b/src/perception/identification.cpp
@@ -37,6 +37,8 @@ bool screen_object(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mod
 {
     std::array<std::string, 128> info{};
     auto trivial_info = 0;
+    // ベースアイテムから作った仮のアイテムは人形・像・死体類のモンスター種族が未設定である
+    const auto is_fake_object = any_bits(mode, SCROBJ_FAKE_OBJECT);
     const auto flags = item.get_flags();
     const auto item_text = item.is_fixed_artifact() ? item.get_fixed_artifact().text.data() : item.get_baseitem().text.data();
     const auto item_text_lines = shape_buffer(item_text, 77 - 15);
@@ -91,7 +93,7 @@ bool screen_object(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mod
         info[i++] = _("それは物を強く投げることを可能にする。", "It provides great strength when you throw an item.");
     }
 
-    if (bi_key.tval() == ItemKindType::STATUE) {
+    if (!is_fake_object && (bi_key.tval() == ItemKindType::STATUE)) {
         const auto &monrace = item.get_monrace();
         if (monrace.idx == MonraceId::BULLGATES) {
             info[i++] = _("それは部屋に飾ると恥ずかしい。", "It is shameful.");
@@ -760,10 +762,10 @@ bool screen_object(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mod
     screen_save();
     const auto &[wid, hgt] = term_get_size();
     std::string item_name;
-    if (!(mode & SCROBJ_FAKE_OBJECT)) {
+    if (!is_fake_object) {
         item_name = describe_flavor(player_ptr, item, 0);
     } else {
-        item_name = describe_flavor(player_ptr, item, (OD_NAME_ONLY | OD_STORE));
+        item_name = describe_flavor(player_ptr, item, (OD_NAME_ONLY | OD_STORE | OD_OMIT_MONRACE));
     }
 
     prt(item_name, 0, 0);
@@ -771,7 +773,7 @@ bool screen_object(PlayerType *player_ptr, const ItemEntity &item, BIT_FLAGS mod
         prt("", k, 13);
     }
 
-    if (bi_key == BaseitemKey(ItemKindType::STATUE, SV_PHOTO)) {
+    if (!is_fake_object && (bi_key == BaseitemKey(ItemKindType::STATUE, SV_PHOTO))) {
         const auto &monrace = item.get_monrace();
         const auto name_length = monrace.name->length();
         prt(format("%s: '", monrace.name.data()), 1, 15);

--- a/src/wizard/items-spoiler.cpp
+++ b/src/wizard/items-spoiler.cpp
@@ -98,7 +98,9 @@ static std::string describe_weight(const ItemEntity &item)
  * @brief obj-desc.txt出力用にベースアイテムIDからItemEntityオブジェクトを生成する
  * @param bi_id ベースアイテムID
  * @return obj-desc.txt出力用に使用するItemEntityオブジェクト
- * @details 人形・像・死体類はpvalが0だと異常アイテム扱いで例外が飛ぶためダミー値を入れておく.
+ * @details 人形・像・死体類はpvalにモンスター種族IDが入る。スポイラーには種族名込みの名前と
+ * 価格の双方を出力するため、pvalが0のままだと名前の記述と価格計算
+ * (ItemEntity::calc_figurine_value()) の両方で例外が飛ぶ。ダミー値を入れておく.
  */
 static ItemEntity prepare_item_for_obj_desc(short bi_id)
 {

--- a/src/wizard/wizard-item-modifier.cpp
+++ b/src/wizard/wizard-item-modifier.cpp
@@ -1001,12 +1001,14 @@ WishResultType do_cmd_wishing(PlayerType *player_ptr, int prob, bool allow_art, 
     if (exam_base) {
         auto max_len = 0;
         const auto &baseitems = BaseitemList::get_instance();
+        // ベースアイテムの照合用なので、モンスター種族が未設定の人形・像・死体類は種族名を省いて記述する
+        constexpr auto mode = OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE | OD_OMIT_MONRACE;
         for (short bi_id : baseitems.collect_valid_bi_ids()) {
             ItemEntity item(bi_id);
 #ifdef JP
-            const auto item_name = describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE));
+            const auto item_name = describe_flavor(player_ptr, item, mode);
 #else
-            const auto item_name = str_tolower(describe_flavor(player_ptr, item, (OD_OMIT_PREFIX | OD_NAME_ONLY | OD_STORE)));
+            const auto item_name = str_tolower(describe_flavor(player_ptr, item, mode));
 #endif
             if (cheat_xtra) {
                 msg_format("Matching object No.%d %s", bi_id, item_name.data());


### PR DESCRIPTION
## 概要

#5531 の修正です。

デバッグコマンドの「願い」(`^A` → `I` → `w`) で品目名を入力すると、日本語版・英語版のどちらでもその場でクラッシュする不具合を修正します。

```
item-entity.cpp:977: This item is not related to monrace!: tval = 8, sval = 0, pval = 0
terminate called after throwing an instance of 'std::logic_error'
```

同じ原因で、ウィザードモードのアイテム知識一覧から写真の詳細を表示したときにもクラッシュしていたため、あわせて修正します。

## 原因

`do_cmd_wishing()` は入力文字列と照合するために全ベースアイテムを走査し、その場で生成した `ItemEntity` を `describe_flavor()` に渡します。

https://github.com/hengband/hengband/blob/7e9ededb48/src/wizard/wizard-item-modifier.cpp#L1002-L1010

`ItemEntity::generate()` は `pval = baseitem.pval` を代入するだけでモンスター種族の抽選を行わず、人形・像・死体類のベースアイテム定義は全て `parameter_value: 0` です。その結果 `has_monrace()` が偽になり、`describe_statue()` / `describe_corpse()` 内の `get_monrace()` が `std::logic_error` を投げます。

走査順で最初に当たる bi_id 567 (`#の人形`) で必ず例外になるため、品目名に関係なくクラッシュします。日本語版で `★` を付けたときだけ助かるのは、`★` の分岐だけが `exam_base = false` を立ててベースアイテム走査を丸ごと飛ばすためです。**この分岐は `#ifdef JP` の中にあり、英語版の `The ` 分岐は `exam_base` を落とさない**ので、英語版は全入力でクラッシュしていました。

回帰の起点は `get_monrace()` の導入 (837179e4d1, #4222)。それ以前は 0 番のダミー種族を引いて名前が空になるだけでした。初出タグは 3.0.1.15-Beta です。

**同じ不具合はスポイラー出力で一度発覚しています** (1d52bf6497, #4281)。そのときは `items-spoiler.cpp` の呼び出し側でダミー pval を差し込む対症療法で塞がれ、`do_cmd_wishing()` は漏れたまま今日に至りました。

## 変更内容

同じ穴を 2 度踏んでいるため、呼び出し側ごとの回避策ではなく describer 側で対処します。ただし `get_monrace()` の例外は本来バグ検出機構なので、単に `has_monrace()` で握り潰すと実アイテムの pval 設定漏れを見逃すようになります。そこで、**列挙する側が「モンスター種族を設定していない」と明示的に宣言する**形にしました。

- アイテム表示オプションに `OD_OMIT_MONRACE` を追加
- `describe_statue()` / `describe_corpse()` は、このフラグが立っているときだけ種族名を省いた記述を返す。フラグなしで pval が 0 なら**従来どおり例外を投げる**
- 種族名を省く際は、表示テンプレートから `#` だけでなくそれに係る助詞・前置詞も取り除く (`omit_monrace_placeholder()`)。「#の人形」から `#` だけを取り除くと「の人形」という不自然な名前になり、知識一覧で人形の詳細を開いたときにそのまま表示されてしまうため。置換には既存の `str_replace()` を使っており、EUC-JP / Shift-JIS の差は同関数が吸収する
- `do_cmd_wishing()` の照合ループがフラグを渡す
- 英語版の冠詞判定 (`describe_item_count_or_article_en()`) も同じフラグで分岐

写真のクラッシュは `screen_object()` が `get_monrace()` を直接呼んでいる別経路でした。こちらはベースアイテムから作った仮のアイテムかどうか (`SCROBJ_FAKE_OBJECT`) で分岐し、仮のアイテムには種族に依存する情報（像の感想文・写真の被写体表示）を出さないようにしています。修正後は他のテンプレートと同じく「特に変わったところはないようだ。」になります。

`items-spoiler.cpp` のダミー pval は残しました。スポイラーは種族名込みの名前と価格の双方を出力し、`ItemEntity::calc_figurine_value()` が `get_monrace()` を無条件に呼ぶためです。理由の記述が実態と合っていなかったので、コメントのみ修正しています。

## 動作確認

`--headless` + 制御サーバで、日本語版・英語版の両方を確認しました。

### 「願い」

| ビルド | 入力 | 結果 |
| --- | --- | --- |
| 日本語版 | `折れた剣` | `折れた剣 (1d2)` が生成される |
| 日本語版 | `zzz` | 「うーん、そんなものは存在しないようだ。」 |
| 日本語版 | `★グロンド` | `冥界の大鉄杖 (9d9)` が生成される（退行なし） |
| 日本語版 | `人形` | `ダークエルフの人形 {未鑑定}` が生成される |
| 日本語版 | `の骨` | `汚いイタズラ小僧の骨` が生成される |
| 英語版 | `Broken Sword` | `a Broken Sword (1d2)` が生成される |
| 英語版 | `magical figurine` | `a Magical Figurine of a Singing, happy drunk` が生成される |
| 英語版 | `skeleton` | `a Chaffinch Skeleton` が生成される |
| 英語版 | `zzz` / `The Grond` | `Ummmm, that is not existing...` |

最後の 4 ケースが重要で、フォールバック名でマッチして生成された人形・死体が**種族名付きで正しく表示**されています。`ItemMagicApplier` → `OtherItemsEnchanter` が pval を設定するため、通常のアイテム記述がフォールバックに食われていないことの確認になります。

### アイテム知識一覧（ウィザードモード）

写真・像 11 種・人形・骨・死体をすべて `r` で表示し、クラッシュしないことを確認しました。
人形の詳細画面のタイトル行が「人形」/「a Magical Figurine」になることも確認しています。

### その他

- スポイラー `obj-desc.txt` を再生成し、`a Magical Figurine of a Filthy street urchin` 等、従来どおり種族名・価格付きで出力されることを確認
- `make check` が日本語版・英語版とも PASS

## 補足

英語版には日本語版の `★`（固定アーティファクト指定）に相当する入力がありません。`The ` は `wish_randart` も立ててしまうため、英語版では固定アーティファクトを名指しで願えず `The Grond` が「存在しない」になります。今回のクラッシュとは独立した既存の挙動なので、本 PR では手を付けていません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 人形・像・死体・残骸などのアイテム名表示を改善しました。
  * 不要なモンスター種族名が表示されなくなりました。
  * 鑑定済みのユニークモンスター由来の死体・残骸は、適切な定冠詞付きで表示されます。
  * 願いの対象アイテム照合時も、種族名を除いた名称で正しく判定されます。
  * 仮の像などでも、実体に即したアイテム名が表示されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->