### PR TITLE
[Feature] Windowsでユニットテストをビルド・実行できるようにする

### DIFF
--- a/.github/scripts/check-test-registration.sh
+++ b/.github/scripts/check-test-registration.sh
@@ -1,15 +1,17 @@
 #!/bin/sh
 
-# src/test 以下のテストソースが src/Makefile.am の hengband_test_SOURCES に
+# src/test 以下のテストソースが、autotools (src/Makefile.am) と
+# MSVC (VisualStudio/Hengband/HengbandTest.vcxproj) の両方のビルド定義に
 # 登録されているかをチェックする。
-# automake はソースファイルを自動収集しないため、登録を忘れたテストは
+# automake も MSBuild もソースファイルを自動収集しないため、登録を忘れたテストは
 # ビルドも実行もされない。それを検出する。
 
 MAKEFILE_AM=src/Makefile.am
+VCXPROJ=VisualStudio/Hengband/HengbandTest.vcxproj
 
 # hengband_test_SOURCES への代入を、行継続とコメントを処理して
 # 空白区切りの1行として取り出す
-REGISTERED_SOURCES=$(awk '
+MAKEFILE_AM_SOURCES=$(awk '
     /^hengband_test_SOURCES[ \t]*\+?=/ { in_block = 1 }
     in_block {
         line = $0
@@ -21,8 +23,53 @@ REGISTERED_SOURCES=$(awk '
     }
 ' $MAKEFILE_AM | tr -s ' \t\n\\' ' ')
 
-if [ -z "$REGISTERED_SOURCES" ]; then
+# vcxproj の <ClCompile Include="..\..\src\..." /> から src/ 相対のパスを取り出す。
+# Makefile.am 側で # コメントを除去しているのと揃えて、コメントアウトされた
+# <ClCompile> を登録済みと誤判定しないよう、先に XML コメントを除去する。
+# vcxproj は CRLF かつパスの区切りが \ なので、それぞれ除去・変換する
+VCXPROJ_SOURCES=$(tr -d '\r' <$VCXPROJ |
+    awk '
+        {
+            line = $0
+            result = ""
+            while (length(line) > 0) {
+                if (in_comment) {
+                    end = index(line, "-->")
+                    if (end == 0) {
+                        line = ""
+                        break
+                    }
+                    line = substr(line, end + 3)
+                    in_comment = 0
+                } else {
+                    start = index(line, "<!--")
+                    if (start == 0) {
+                        result = result line
+                        break
+                    }
+                    result = result substr(line, 1, start - 1)
+                    line = substr(line, start + 4)
+                    in_comment = 1
+                }
+            }
+            print result
+        }
+    ' |
+    sed -n 's|.*<ClCompile Include="\([^"]*\)".*|\1|p' |
+    tr '\\' '/' |
+    sed -n 's|^\.\./\.\./src/||p' |
+    tr '\n' ' ')
+
+if [ -z "$MAKEFILE_AM_SOURCES" ]; then
     echo "$MAKEFILE_AM: hengband_test_SOURCES is not defined."
+    exit 1
+fi
+
+# ClCompile が1つも取れないのは、パスの記法変更などでこのスクリプトが
+# 追随できていない状態。黙って通さずエラーにする
+if [ -z "$VCXPROJ_SOURCES" ]; then
+    echo "$VCXPROJ: no <ClCompile> item was found."
+    echo "If the project file has been moved or restructured, update this script."
     exit 1
 fi
 
@@ -43,11 +90,21 @@ IFS='
 '
 
 for file in $TEST_SOURCES; do
-    # src/Makefile.am には src/ からの相対パスで記述する
-    case " $REGISTERED_SOURCES " in
-    *" ${file#src/} "*) ;;
+    # どちらのビルド定義にも src/ からの相対パスで記述する
+    RELATIVE_PATH=${file#src/}
+
+    case " $MAKEFILE_AM_SOURCES " in
+    *" $RELATIVE_PATH "*) ;;
     *)
         echo "$file: not registered in hengband_test_SOURCES of $MAKEFILE_AM."
+        STATUS=1
+        ;;
+    esac
+
+    case " $VCXPROJ_SOURCES " in
+    *" $RELATIVE_PATH "*) ;;
+    *)
+        echo "$file: not registered as <ClCompile> in $VCXPROJ."
         STATUS=1
         ;;
     esac
@@ -55,7 +112,9 @@ done
 
 if [ $STATUS -ne 0 ]; then
     echo ""
-    echo "Add the test source files above to hengband_test_SOURCES in $MAKEFILE_AM."
+    echo "Add the test source files above to both build definitions:"
+    echo "  - hengband_test_SOURCES in $MAKEFILE_AM"
+    echo "  - <ClCompile> items in $VCXPROJ"
     echo "See src/test/README.md for details."
 fi
 

--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -1,4 +1,4 @@
-name: Build test with MSVC
+name: Build and test with MSVC
 on:
   workflow_call:
 
@@ -31,3 +31,9 @@ jobs:
       - name: Run build test
         run: |
           MSBuild -warnAsError .\VisualStudio\Hengband.sln /t:Rebuild /p:Configuration=Debug
+
+      # 上のビルドで HengbandTest プロジェクトも生成される。
+      # doctest はテストが失敗すると非ゼロの終了コードを返す
+      - name: Run unit tests
+        run: |
+          .\VisualStudio\Hengband\Debug\hengband-test.exe

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -51,7 +51,7 @@ jobs:
       - run: python3 .github/scripts/check-include-style.py
 
   check_test_registration:
-    name: Check the registration of the unit test sources
+    name: Check the registration of the unit test sources (Makefile.am / HengbandTest.vcxproj)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -101,7 +101,7 @@ jobs:
       use-ccache: true
 
   build_test_with_msvc:
-    name: Build test with MSVC
+    name: Build and test with MSVC
     uses: ./.github/workflows/build-test-with-msvc.yml
 
   json-schema-validation:

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,8 @@ visual_studio_files = \
 	VisualStudio/Hengband/Hengband.vcxproj \
 	VisualStudio/Hengband/HengbandCore.vcxproj \
 	VisualStudio/Hengband/HengbandCore.vcxproj.filters \
+	VisualStudio/Hengband/HengbandTest.vcxproj \
+	VisualStudio/Hengband/HengbandTest.vcxproj.filters \
 	VisualStudio/Hengband/packages.config
 
 visual_studio_libcurl_files = \

--- a/VisualStudio/Hengband.sln
+++ b/VisualStudio/Hengband.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Hengband", "Hengband\Hengba
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HengbandCore", "Hengband\HengbandCore.vcxproj", "{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HengbandTest", "Hengband\HengbandTest.vcxproj", "{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{82CF9010-9443-4FFF-ADF0-0D3E81C732CC}"
 	ProjectSection(SolutionItems) = preProject
 		..\.clang-format = ..\.clang-format
@@ -36,6 +38,14 @@ Global
 		{32D43DED-9745-48F3-892D-231695D201A6}.English-Release|Win32.Build.0 = English-Release|Win32
 		{32D43DED-9745-48F3-892D-231695D201A6}.Release|Win32.ActiveCfg = Release|Win32
 		{32D43DED-9745-48F3-892D-231695D201A6}.Release|Win32.Build.0 = Release|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.Debug|Win32.Build.0 = Debug|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.English-Debug|Win32.ActiveCfg = English-Debug|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.English-Debug|Win32.Build.0 = English-Debug|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.English-Release|Win32.ActiveCfg = English-Release|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.English-Release|Win32.Build.0 = English-Release|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.Release|Win32.ActiveCfg = Release|Win32
+		{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VisualStudio/Hengband/HengbandTest.vcxproj
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="English-Debug|Win32">
+      <Configuration>English-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="English-Release|Win32">
+      <Configuration>English-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B19D3F7B-EED0-407D-97A8-0AAC5BB88BD5}</ProjectGuid>
+    <RootNamespace>HengbandTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="Hengband.Configuration.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Hengband.Common.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(Configuration)\</OutDir>
+    <TargetName>hengband-test</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <Link>
+      <!-- doctest が生成する main() を持つコンソールアプリのため、
+           Hengband.Common.props の SubSystem=Windows を上書きする -->
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <!--
+      プリコンパイルヘッダ。HengbandCore とは IntDir が異なり pch を共有できないため、
+      テストプロジェクト側でも stdafx.cpp から生成する。
+      stdafx.cpp はシンボルを定義しないので HengbandCore.lib 内の同名オブジェクトとは衝突しない。
+    -->
+    <ClCompile Include="..\..\src\stdafx.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\test-main.cpp" />
+    <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp" />
+    <ClCompile Include="..\..\src\test\timed-effect\test-player-stun.cpp" />
+    <ClCompile Include="..\..\src\test\timed-effect\test-timed-effect.cpp" />
+    <ClCompile Include="..\..\src\test\util\test-probability-table.cpp" />
+    <ClCompile Include="..\..\src\test\util\test-sha256.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\stdafx.h" />
+    <ClInclude Include="..\..\src\test\scoped-rng.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="HengbandCore.vcxproj">
+      <Project>{C00503B6-18FF-42F1-BAC0-6C94EDE62CB2}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/VisualStudio/Hengband/HengbandTest.vcxproj.filters
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj.filters
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="timed-effect">
+      <UniqueIdentifier>{713ac6ea-8881-48d4-beac-cf75e9e6b037}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="util">
+      <UniqueIdentifier>{88a7a349-31ae-4d18-a09a-c749dff85ef9}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\stdafx.cpp" />
+    <ClCompile Include="..\..\src\test\test-main.cpp" />
+    <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\timed-effect\test-player-stun.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\timed-effect\test-timed-effect.cpp">
+      <Filter>timed-effect</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\util\test-probability-table.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\util\test-sha256.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\stdafx.h" />
+    <ClInclude Include="..\..\src\test\scoped-rng.h" />
+  </ItemGroup>
+</Project>

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -1,6 +1,7 @@
 # ユニットテスト
 
-変愚蛮怒のユニットテストは [doctest](https://github.com/doctest/doctest) で記述し、`make check` で実行します。
+変愚蛮怒のユニットテストは [doctest](https://github.com/doctest/doctest) で記述します。
+autotools（Unix 系）では `make check`、Windows では Visual Studio の `HengbandTest` プロジェクトで実行します。
 
 ## どちらのテスト手段を使うか
 
@@ -8,7 +9,7 @@
 
 | 層             | 手段                                               | 向いている対象                                                                |
 | -------------- | -------------------------------------------------- | ----------------------------------------------------------------------------- |
-| ユニットテスト | doctest / `make check`（このドキュメント）         | 純粋関数、値クラス、計算ロジック（`util/`、`system/` の型、ダメージ計算など） |
+| ユニットテスト | doctest / `make check`・Visual Studio（このドキュメント） | 純粋関数、値クラス、計算ロジック（`util/`、`system/` の型、ダメージ計算など） |
 | シナリオテスト | `--headless --control-port` + `tools/bot/hbctl.py` | ゲームループ、コマンド処理、画面表示、グローバル状態をまたぐ挙動              |
 
 判断の基準は **「対象を呼び出すために `PlayerType` やフロア、ターミナル (`term`) を用意する必要があるか」** です。
@@ -19,6 +20,8 @@
 ---
 
 ## 実行方法
+
+### autotools（Unix 系）
 
 ```sh
 cd src
@@ -38,6 +41,30 @@ make check VERBOSE=1          # 失敗時にテストの出力をその場で表
 ```
 
 テストが失敗すると `make check` は非ゼロで終了し、`src/test-suite.log` に出力が残ります。
+
+### Visual Studio（Windows）
+
+`VisualStudio/Hengband.sln` の `HengbandTest` プロジェクトがテスト実行ファイルを生成します。
+ソリューションをビルドすればゲーム本体と一緒にビルドされます。
+
+コマンドラインからビルドする場合は次のとおりです。
+
+```pwsh
+MSBuild .\VisualStudio\Hengband.sln /p:Configuration=Debug
+.\VisualStudio\Hengband\Debug\hengband-test.exe
+```
+
+出力先は構成ごとに分かれます（`Debug` / `English-Debug` / `Release` / `English-Release`）。
+
+```pwsh
+.\VisualStudio\Hengband\<構成>\hengband-test.exe
+```
+
+Visual Studio の IDE から実行する場合は、`HengbandTest` を右クリックして
+「スタートアップ プロジェクトに設定」してから開始してください
+（既定のスタートアッププロジェクトはゲーム本体の `Hengband` です）。
+
+`--list-test-cases` などの doctest のオプションは autotools 版と共通です。
 
 ## テストの追加手順
 
@@ -68,10 +95,13 @@ make check VERBOSE=1          # 失敗時にテストの出力をその場で表
    }
    ```
 
-3. **`src/Makefile.am` の `hengband_test_SOURCES` に 1 行追加する**
+3. **2 つのビルド定義の両方に登録する**
 
-   **自動収集はされません。** 登録を忘れたテストはビルドも実行もされないので、必ず追加してください
-   （CI の `check_test_registration` が登録漏れを検出します）。
+   **どちらも自動収集はされません。** 登録を忘れたテストはビルドも実行もされないので、
+   必ず両方に追加してください（CI の `check_test_registration` が**両方**の追加忘れを検出します。
+   コメントアウトによる無効化も検出しますが、vcxproj の `<ExcludedFromBuild>` は検出できません）。
+
+   `src/Makefile.am` の `hengband_test_SOURCES`:
 
    ```make
    hengband_test_SOURCES = \
@@ -82,9 +112,25 @@ make check VERBOSE=1          # 失敗時にテストの出力をその場で表
        ...
    ```
 
-4. **`make check` で確認する**
+   `VisualStudio/Hengband/HengbandTest.vcxproj` の `<ClCompile>`:
 
-   `Makefile.am` を変更したので、`make` が自動的に `configure` を回し直します。
+   ```xml
+   <ItemGroup>
+     <ClCompile Include="..\..\src\test\test-main.cpp" />
+     <ClCompile Include="..\..\src\test\util\test-probability-table.cpp" />
+     <ClCompile Include="..\..\src\test\util\test-sha256.cpp" />
+     ...
+   </ItemGroup>
+   ```
+
+   Visual Studio 上での表示を整えるため、`HengbandTest.vcxproj.filters` にも
+   同じファイルを追加しておくとよいです（こちらは登録しなくてもビルド・実行はできます）。
+
+4. **ビルドして確認する**
+
+   autotools では `make check` を実行します（`Makefile.am` を変更したので、`make` が
+   自動的に `configure` を回し直します）。Windows では Visual Studio でソリューションを
+   ビルドし、`hengband-test.exe` を実行します。
 
 ## doctest の書き方
 
@@ -152,6 +198,8 @@ for (const auto &test : TEST_VECTORS) {
 
 日本語版のビルドでは `gcc-wrap` がソース中の文字列リテラルを UTF-8 から EUC-JP に変換します。
 テストケース名に日本語を使うと、UTF-8 の端末でテスト結果が文字化けします。
+MSVC の日本語版構成も同様に、文字列リテラルを Shift_JIS に変換 (`/execution-charset:shift-jis`)
+するため文字化けします。
 
 **コメントはこれまでどおり日本語で構いません。** 制約を受けるのは実行時に出力される文字列（テストケース名、
 `CAPTURE` する文字列など）だけです。
@@ -215,9 +263,28 @@ const auto restore_hoge = util::make_finalizer([&system, backup = system.get_hog
 
 ## リンクについて
 
-テストは、ゲーム本体のソースを `main.cpp` を除いてすべてまとめた `libhengband.a` にリンクされます。
+テストは、ゲーム本体のソースをエントリポイントだけ除いてすべてまとめた静的ライブラリに
+リンクされます。autotools では `libhengband.a`（`main.cpp` 以外）、MSVC では
+`HengbandCore.lib`（`main-win.cpp` 以外）です。
 **テスト対象の `.cpp` を個別に指定する必要はありません。** ゲーム内のどの関数・クラスでも、
 ヘッダを `#include` すればテストから呼び出せます。
+
+ただし、静的ライブラリからは**未定義シンボルの解決に必要なオブジェクトしか取り込まれません。**
+静的初期化子による自己登録だけを目的とする翻訳単位を追加しても、リンクされず、警告も出ないまま
+無視されます。autotools には `--whole-archive` という逃げ道がありますが、**MSVC で
+`/WHOLEARCHIVE` は使えません。** GUI 専用のオブジェクト（`main-win.cpp` にしか定義のない
+シンボルを参照する `main-win/commandline-win.cpp` など）まで引き込んでリンクエラーになります。
+
+## doctest の警告について
+
+MSVC のビルドは `/Wall`（`EnableAllWarnings`）と `TreatWarningAsError` を使っていますが、
+doctest 由来の警告を個別に抑止する指定は必要ありません。
+
+doctest は `src/external-lib/include/` にあり、`check_include_style` が同ディレクトリの
+ヘッダを `<>` で include するよう強制しています。そのため
+`Hengband.Common.props` の `TreatAngleIncludeAsExternal` と
+`ExternalWarningLevel=TurnOffAllWarnings` が必ず効きます
+（`/external:templates-` を指定していないので、テンプレートの実体化も対象です）。
 
 ## テストしにくいコードをどう確かめるか
 
@@ -244,5 +311,12 @@ doctest によるユニットテストのみです）。
 
 ## 制限
 
-**ユニットテストは autotools ビルド（Unix 系）専用です。** MSVC の
-`VisualStudio/Hengband.sln` にはテスト用のプロジェクトが無く、Windows 上ではテストをビルド・実行できません。
+- **`PlayerType` やフロア、`term` を必要とするコードはユニットテストにできません。**
+  冒頭の判断基準のとおり、シナリオテストで確かめてください。
+- **シナリオテストを自動実行する仕組みはありません。** `make check` と MSVC の CI が
+  対象とするのは doctest によるユニットテストのみです。
+- **MSVC の CI がテストを実行するのは Debug 構成だけです。** 手元では 4 構成すべてで
+  ビルド・実行できます。Release 系は警告の除外リストが Debug と異なる（`4711;4738` が加わる）
+  ため、Release でだけ壊れる変更は CI をすり抜けます。
+  `Build-Windows-Release-Package.ps1` はソリューション全体をリビルドするので、
+  リリースパッケージの作成もテストプロジェクトのビルドが通ることに依存します。


### PR DESCRIPTION
## 概要

Windows (Visual Studio) でユニットテストを実行できるようにする作業の3段階目(最終)。
PR #5526(プロパティシートへの共通化)、PR #5528(HengbandCore への分割)に続き、テストプロジェクトを追加して CI でも実行する。

これにより、`src/test/README.md` に「制限」として明記されていた「ユニットテストは autotools ビルド(Unix系)専用」という状態が解消される。MSVC 固有のコンパイルエラーやランタイム差異を、CI のビルド成否だけでなくユニットテストでも検出できるようになる。

```
autotools                          MSVC
─────────────────────────────      ──────────────────────────────────
libhengband.a  (main.cpp 以外)     HengbandCore.vcxproj  (StaticLibrary)   済 #5528
hengband       (main.cpp)          Hengband.vcxproj      (Application, WINDOWS) 済 #5528
hengband-test  (test/**)           HengbandTest.vcxproj  (Application, CONSOLE)  ← 今回
```

## 変更内容

### 1. `HengbandTest.vcxproj{,.filters}` の追加

- `ConfigurationType=Application`。`Hengband.Common.props` の `SubSystem=Windows` を `Console` に上書きする(doctest が生成するのは `main()` のため)
- `OutDir=$(Configuration)\`、`TargetName=hengband-test` とし、`VisualStudio\Hengband\<構成>\hengband-test.exe` を生成する。出力先は `.gitignore` の `[Dd]ebug/` 等で既に無視されている
- PCH はテストプロジェクト側で `stdafx.cpp` から生成する。`IntDir` が `$(Configuration)\$(ProjectName)\` で HengbandCore とは別のため pch を共有できず、`PrecompiledHeader=NotUsing` にしても `ForcedIncludeFiles=stdafx.h` は残るため `range/v3` 等を6TU分毎回展開することになりビルドが極端に遅くなる
- テストソースは `src/Makefile.am` の `hengband_test_SOURCES` と同じ考え方で明示列挙する

`Hengband.sln` には `HengbandCore` の後ろに追加し、4構成すべての `ActiveCfg`/`Build.0` を登録した。スタートアッププロジェクトの既定を変えないよう、`Hengband` は先頭のままにしている。

### 2. CI でのテスト実行

既存の `MSBuild /t:Rebuild` がソリューション全体を対象にしているため、テストプロジェクトもそのステップでビルドされる。生成された `hengband-test.exe` を実行するステップを追加した。実行するのは現状 CI がビルドしている Debug 構成のみ。

### 3. 登録漏れチェックの拡張

`check-test-registration.sh` が `src/Makefile.am` に加えて `HengbandTest.vcxproj` の `<ClCompile>` も検査するようにした。automake と MSBuild のどちらもソースを自動収集しないため、片方だけに登録した状態を検出できる。

### 4. `src/test/README.md` の更新

「実行方法」を autotools と Visual Studio に分け、「テストの追加手順」を両方のビルド定義に登録する手順に書き換えた。「リンクについて」には、MSVC では `HengbandCore.lib` にリンクされること、および **autotools の `--whole-archive` に相当する `/WHOLEARCHIVE` は MSVC では使えない**(GUI 専用オブジェクトを引き込んでリンクエラーになる)ことを明記した。

## 検証

### Windows

- 4構成すべてで `MSBuild -warnAsError /t:Rebuild` が**警告ゼロ**で成功
- 4構成すべてで **22テストケース / 10758アサーション**が全件成功
- `hengband-test.pch` が生成され PCH が効いていること、`Hengband.exe` が従来どおりリポジトリルートに出ることを確認
- `--list-test-cases` が6ファイル分22件すべてを列挙(静的登録の取りこぼしが無いこと)
- Visual Studio でスタートアッププロジェクトが `Hengband` のままであることを確認

懸念していた doctest マクロ展開由来の `/Wall` 警告と、`main-win.cpp` 依存によるリンクエラーは、いずれも発生しなかったため警告抑止の追加は不要だった。

### Linux (回帰確認)

- `make check` が PASS(FAIL: 0)。テストケース数・アサーション数とも Windows と完全に一致
- `make dist` の tarball に `HengbandTest.vcxproj{,.filters}` が含まれることを確認
- `check-test-registration.sh` が Linux 上でも正常に動作し、vcxproj 側の登録漏れを検出することを確認

### CI

fork 側で `workflow_dispatch` により事前確認済み。

- 正常系: 全ステップ成功、CI 上でも 22テストケース全件成功
- 失敗系: わざとテストを1件失敗させたところ、`Run build test`(ビルド)は成功のまま `Run unit tests` だけが失敗し、ジョブが赤くなることを確認。ログに失敗したファイル・行・値が出力されることも確認

## Test plan

- [x] 4構成すべてで `-warnAsError` のリビルドが成功すること
- [x] 4構成すべてでテストが全件成功すること
- [x] `--list-test-cases` の内容が autotools 版と一致すること
- [x] Linux 側で `make check` が通ること(回帰確認)
- [x] `make dist` の tarball に新規ファイルが含まれること
- [x] `check-test-registration.sh` が両方の登録漏れを検出すること
- [x] CI でテストが実行され、失敗時にジョブが赤くなること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Windows環境で、Visual Studioから単体テストをビルド・実行できるようになりました。
  - DebugやReleaseなど、複数のビルド構成に対応しました。

- **改善**
  - 単体テストの登録状況を、AutotoolsとVisual Studioの両方で確認できるようになりました。
  - 継続的インテグレーションで、MSVCによる再ビルド後に単体テストを実行します。

- **ドキュメント**
  - Windowsでのテスト実行手順、ビルド構成、既知の制限事項を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->