### PR TITLE
[Feature] 定義ファイル読込の共通ユーティリティのユニットテストを追加する

### DIFF
--- a/VisualStudio/Hengband/HengbandTest.vcxproj
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj
@@ -57,6 +57,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\src\test\test-main.cpp" />
+    <ClCompile Include="..\..\src\test\info-reader\test-info-reader-util.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-player-stun.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-timed-effect.cpp" />

--- a/VisualStudio/Hengband/HengbandTest.vcxproj
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj
@@ -58,6 +58,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\test\test-main.cpp" />
     <ClCompile Include="..\..\src\test\info-reader\test-info-reader-util.cpp" />
+    <ClCompile Include="..\..\src\test\info-reader\test-json-reader-util.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-player-stun.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-timed-effect.cpp" />

--- a/VisualStudio/Hengband/HengbandTest.vcxproj.filters
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj.filters
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <Filter Include="info-reader">
+      <UniqueIdentifier>{5a5d0f27-6c1e-4c8b-9f34-2b7d8e1a6c40}</UniqueIdentifier>
+    </Filter>
     <Filter Include="timed-effect">
       <UniqueIdentifier>{713ac6ea-8881-48d4-beac-cf75e9e6b037}</UniqueIdentifier>
     </Filter>
@@ -11,6 +14,9 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\stdafx.cpp" />
     <ClCompile Include="..\..\src\test\test-main.cpp" />
+    <ClCompile Include="..\..\src\test\info-reader\test-info-reader-util.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp">
       <Filter>timed-effect</Filter>
     </ClCompile>

--- a/VisualStudio/Hengband/HengbandTest.vcxproj.filters
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="..\..\src\test\info-reader\test-info-reader-util.cpp">
       <Filter>info-reader</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\info-reader\test-json-reader-util.cpp">
+      <Filter>info-reader</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp">
       <Filter>timed-effect</Filter>
     </ClCompile>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1489,6 +1489,7 @@ hengband_test_SOURCES = \
 	test/test-main.cpp \
 	test/scoped-rng.h \
 	\
+	test/info-reader/test-info-reader-util.cpp \
 	test/timed-effect/test-player-cut.cpp \
 	test/timed-effect/test-player-stun.cpp \
 	test/timed-effect/test-timed-effect.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1490,6 +1490,7 @@ hengband_test_SOURCES = \
 	test/scoped-rng.h \
 	\
 	test/info-reader/test-info-reader-util.cpp \
+	test/info-reader/test-json-reader-util.cpp \
 	test/timed-effect/test-player-cut.cpp \
 	test/timed-effect/test-player-stun.cpp \
 	test/timed-effect/test-timed-effect.cpp \

--- a/src/info-reader/json-reader-util.h
+++ b/src/info-reader/json-reader-util.h
@@ -42,11 +42,14 @@ errr info_set_integer(const nlohmann::json &json, T &data, bool is_required, tl:
         return PARSE_ERROR_INVALID_TYPE;
     }
 
-    const auto value = json.get<T>();
-    if (range && (value < static_cast<T>(range->first) || value > static_cast<T>(range->second))) {
+    // 範囲チェックは格納先の型へ変換する前に行う。変換してから比べると、
+    // 格納先の型で表現できない値が切り詰められて範囲内に収まり、チェックをすり抜ける
+    // (例: uint8_t への 300 は 44 になり Range(0, 255) を通ってしまう)
+    const auto value = json.get<nlohmann::json::number_integer_t>();
+    if (range && (value < range->first || value > range->second)) {
         return PARSE_ERROR_INVALID_FLAG;
     }
 
-    data = value;
+    data = static_cast<T>(value);
     return PARSE_ERROR_NONE;
 }

--- a/src/test/info-reader/test-info-reader-util.cpp
+++ b/src/test/info-reader/test-info-reader-util.cpp
@@ -108,13 +108,15 @@ TEST_CASE("info_set_value converts the string into a number")
         CHECK(value == 255);
     }
 
-    SUBCASE("value is converted into the type of the destination")
+    SUBCASE("value which fits is converted into the type of the destination")
     {
+        // 定義ファイル中の値は std::stoi で int として読んでから格納先の型へ変換される。
+        // 格納先の型に収まらない値 (uint8_t への 300 など) は static_cast で黙って折り返されるが、
+        // それは実装側の課題であり、現状を仕様として固定しないためここでは扱わない
         short short_value = 0;
         info_set_value(short_value, "30000");
         CHECK(short_value == 30000);
 
-        // 定義ファイル中の値は std::stoi で int として読んでから格納先の型へ変換される
         char char_value = 0;
         info_set_value(char_value, "65");
         CHECK(char_value == 'A');

--- a/src/test/info-reader/test-info-reader-util.cpp
+++ b/src/test/info-reader/test-info-reader-util.cpp
@@ -1,0 +1,194 @@
+/*!
+ * @brief 定義ファイル読込の共通ユーティリティのテスト
+ *
+ * 定義ファイル中の文字列を定数へ変換する info_get_const / info_grab_one_const、
+ * 数値文字列を格納する info_set_value、英語版のフレーバーテキストを連結する
+ * append_english_text を検証する。
+ * JSON から値を取り出す info_set_* 群は test-json-reader-util.cpp で扱う。
+ *
+ * 同じヘッダで宣言されている grab_one_activation_flag は対象外とした。
+ * 未知のトークンに対する挙動が、非数値なら std::stoi が例外を送出し、"0" や負数なら
+ * msg_format (ターミナルが必要) を呼ぶという状態で、現状を仕様として固定したくないため。
+ */
+
+#include "info-reader/info-reader-util.h"
+
+#include <doctest/doctest.h>
+
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace {
+
+//! 変換対象の定数。実際の定義ファイルと同じく、値が連番でない場合も含める
+enum class TestFlag {
+    FIRST = 1,
+    SECOND = 2,
+    LARGE = 0x40000000,
+};
+
+//! 実際のトークン辞書 (f_info_flags など) と同じ形の辞書
+const std::unordered_map<std::string_view, TestFlag> TEST_FLAGS = {
+    { "FIRST", TestFlag::FIRST },
+    { "SECOND", TestFlag::SECOND },
+    { "LARGE", TestFlag::LARGE },
+};
+
+}
+
+TEST_CASE("info_get_const returns the constant of the token")
+{
+    CHECK(info_get_const(TEST_FLAGS, "FIRST") == TestFlag::FIRST);
+    CHECK(info_get_const(TEST_FLAGS, "SECOND") == TestFlag::SECOND);
+}
+
+TEST_CASE("info_get_const returns nullopt for an unknown token")
+{
+    CHECK_FALSE(info_get_const(TEST_FLAGS, "UNKNOWN").has_value());
+
+    // 大文字小文字は区別され、空文字列も見つからない扱いになる
+    CHECK_FALSE(info_get_const(TEST_FLAGS, "first").has_value());
+    CHECK_FALSE(info_get_const(TEST_FLAGS, "").has_value());
+}
+
+TEST_CASE("info_get_const accepts any dictionary type indexed by the key")
+{
+    // std::string をキーとする std::map でも同じように引ける
+    const std::map<std::string, int> dict = { { "ONE", 1 }, { "TWO", 2 } };
+
+    CHECK(info_get_const(dict, "ONE") == 1);
+    CHECK(info_get_const(dict, std::string("TWO")) == 2);
+    CHECK_FALSE(info_get_const(dict, "THREE").has_value());
+}
+
+TEST_CASE("info_grab_one_const stores the constant only when the token is found")
+{
+    constexpr uint32_t initial_value = 0xdeadbeef;
+    auto buf = initial_value;
+
+    SUBCASE("known token")
+    {
+        CHECK(info_grab_one_const(buf, TEST_FLAGS, "SECOND"));
+        CHECK(buf == static_cast<uint32_t>(TestFlag::SECOND));
+    }
+
+    SUBCASE("value which uses the upper bits")
+    {
+        CHECK(info_grab_one_const(buf, TEST_FLAGS, "LARGE"));
+        CHECK(buf == static_cast<uint32_t>(TestFlag::LARGE));
+    }
+
+    SUBCASE("unknown token leaves the buffer as it is")
+    {
+        CHECK_FALSE(info_grab_one_const(buf, TEST_FLAGS, "UNKNOWN"));
+        CHECK(buf == initial_value);
+    }
+}
+
+TEST_CASE("info_set_value converts the string into a number")
+{
+    SUBCASE("decimal")
+    {
+        int value = 0;
+        info_set_value(value, "100");
+        CHECK(value == 100);
+
+        info_set_value(value, "-100");
+        CHECK(value == -100);
+    }
+
+    SUBCASE("hexadecimal")
+    {
+        int value = 0;
+        info_set_value(value, "ff", 16);
+        CHECK(value == 255);
+    }
+
+    SUBCASE("value is converted into the type of the destination")
+    {
+        short short_value = 0;
+        info_set_value(short_value, "30000");
+        CHECK(short_value == 30000);
+
+        // 定義ファイル中の値は std::stoi で int として読んでから格納先の型へ変換される
+        char char_value = 0;
+        info_set_value(char_value, "65");
+        CHECK(char_value == 'A');
+    }
+
+    SUBCASE("leading spaces are skipped")
+    {
+        int value = 0;
+        info_set_value(value, "  42");
+        CHECK(value == 42);
+    }
+}
+
+TEST_CASE("info_set_value throws an exception for a string which is not a number")
+{
+    // std::stoi の例外はそのまま呼び出し元へ伝わる (info_set_value は捕捉しない)
+    int value = 0;
+    CHECK_THROWS_AS(info_set_value(value, "abc"), std::invalid_argument);
+    CHECK_THROWS_AS(info_set_value(value, ""), std::invalid_argument);
+    CHECK_THROWS_AS(info_set_value(value, "99999999999999999999"), std::out_of_range);
+    CHECK(value == 0);
+}
+
+#ifndef JP
+TEST_CASE("append_english_text joins the texts with a space")
+{
+    std::string text;
+
+    SUBCASE("the first text is appended as it is")
+    {
+        append_english_text(text, "The first sentence");
+        CHECK(text == "The first sentence");
+    }
+
+    SUBCASE("a single space is put between the texts")
+    {
+        append_english_text(text, "The first line");
+        append_english_text(text, "the second line");
+        CHECK(text == "The first line the second line");
+    }
+
+    SUBCASE("two spaces are put after the end of a sentence")
+    {
+        for (const auto *const eos : { "It ends here.", "It ends here!", "It ends here?" }) {
+            CAPTURE(eos);
+            std::string sentences;
+            append_english_text(sentences, eos);
+            append_english_text(sentences, "The next sentence");
+            CHECK(sentences == std::string(eos) + "  The next sentence");
+        }
+    }
+
+    SUBCASE("both ends of the appended text are trimmed")
+    {
+        append_english_text(text, "  The first line \t");
+        append_english_text(text, "\t the second line  ");
+        CHECK(text == "The first line the second line");
+    }
+}
+
+TEST_CASE("append_english_text ignores an empty text")
+{
+    std::string text;
+
+    // 空文字列や空白のみの行を連結しても、末尾に空白が残ってはいけない
+    append_english_text(text, "");
+    CHECK(text.empty());
+
+    append_english_text(text, "   \t ");
+    CHECK(text.empty());
+
+    append_english_text(text, "The first line");
+    append_english_text(text, "");
+    append_english_text(text, "   ");
+    CHECK(text == "The first line");
+}
+#endif

--- a/src/test/info-reader/test-json-reader-util.cpp
+++ b/src/test/info-reader/test-json-reader-util.cpp
@@ -1,0 +1,496 @@
+/*!
+ * @brief 定義ファイル(JSON)読込の共通ユーティリティのテスト
+ *
+ * 各リーダーがJSONから値を取り出すのに使う get_json_value / info_set_* を検証する。
+ * ここが誤ると全ての定義ファイルの読込に影響するため、正常系だけでなく
+ * キー欠落・型不一致・範囲外のときに返すエラーコードと、
+ * そのときに格納先の変数を書き換えないことも確かめる。
+ *
+ * @details 検証対象の関数呼び出しを `== 期待値` と組み合わせて CHECK に直接書くと、
+ * MSVCが評価順序に関する警告 (C4866) を出すことがある。この警告はエラーとして
+ * 扱われるため、呼び出しの結果は一旦変数で受けてから比較する。
+ * (関数呼び出しを CHECK に直接書くこと自体が警告になるわけではない。
+ *  test-info-reader-util.cpp では直接書いて警告なくビルドできている)
+ */
+
+#include "info-reader/json-reader-util.h"
+
+#include "info-reader/parse-error-types.h"
+#include "util/dice.h"
+
+#ifdef JP
+#include "locale/character-encoding.h"
+#endif
+
+#include <doctest/doctest.h>
+#include <nlohmann/json.hpp>
+
+#include <string>
+
+namespace {
+
+//! info_set_integer がenum型を扱えることを確かめるためのenum
+enum class TestKind : int {
+    NONE = 0,
+    FIRST = 1,
+    LAST = 10,
+};
+
+//! 実行中のビルドで info_set_string が読むキーと、読まない方のキー
+#ifdef JP
+constexpr auto LANG_KEY = "ja";
+constexpr auto OTHER_LANG_KEY = "en";
+#else
+constexpr auto LANG_KEY = "en";
+constexpr auto OTHER_LANG_KEY = "ja";
+#endif
+
+//! 値が格納されなかったことを確認するための、テスト内では現れない番兵値
+constexpr auto SENTINEL = -12345;
+
+#ifdef JP
+//! 文字コード変換のテストに使うUTF-8のバイト列 ("テスト")。
+//! ソースの文字コード変換の影響を受けないよう、エスケープでバイト列を直接書く。
+//! const char* にすると失敗時にポインタ値が表示されるため std::string で持つ
+const std::string UTF8_TEST_STRING = "\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88";
+#endif
+
+}
+
+TEST_CASE("get_json_value returns the value of the key")
+{
+    const auto json = nlohmann::json::parse(R"({ "level": 5, "nested": { "inner": 1 } })");
+
+    SUBCASE("existing key")
+    {
+        const auto &value = get_json_value(json, "level");
+        REQUIRE(value.is_number_integer());
+        const auto level = value.get<int>();
+        CHECK(level == 5);
+    }
+
+    SUBCASE("nested object is returned as it is")
+    {
+        const auto &nested = get_json_value(json, "nested");
+        REQUIRE(nested.is_object());
+        const auto &inner = get_json_value(nested, "inner");
+        const auto inner_value = inner.get<int>();
+        CHECK(inner_value == 1);
+    }
+
+    SUBCASE("missing key")
+    {
+        const auto &value = get_json_value(json, "unknown");
+        CHECK(value.is_null());
+    }
+}
+
+TEST_CASE("get_json_value returns null for a key whose value is null")
+{
+    // 定義ファイルにnullと書かれたキーは、書かれていないキーと同じ扱いになる。
+    // info_set_* はいずれもこの性質に依存している
+    const auto json = nlohmann::json::parse(R"({ "key": null })");
+
+    const auto &value = get_json_value(json, "key");
+    CHECK(value.is_null());
+}
+
+TEST_CASE("get_json_value returns null for a non-object JSON")
+{
+    // 定義ファイル側の記述が誤っていても、キー取得は例外ではなくnullになる
+    for (const auto *const json_str : { "[ 1, 2, 3 ]", R"("string")", "42", "null" }) {
+        CAPTURE(json_str);
+
+        const auto json = nlohmann::json::parse(json_str);
+        const auto &value = get_json_value(json, "key");
+        CHECK(value.is_null());
+    }
+}
+
+TEST_CASE("info_set_integer stores the value")
+{
+    auto data = SENTINEL;
+
+    SUBCASE("positive value")
+    {
+        const auto result = info_set_integer(nlohmann::json(100), data, true);
+        CHECK(result == PARSE_ERROR_NONE);
+        CHECK(data == 100);
+    }
+
+    SUBCASE("negative value")
+    {
+        const auto result = info_set_integer(nlohmann::json(-100), data, true);
+        CHECK(result == PARSE_ERROR_NONE);
+        CHECK(data == -100);
+    }
+
+    SUBCASE("optional key is stored as well")
+    {
+        // 必須でないキーでも、値が書かれていれば格納する
+        const auto result = info_set_integer(nlohmann::json(100), data, false);
+        CHECK(result == PARSE_ERROR_NONE);
+        CHECK(data == 100);
+    }
+
+    SUBCASE("value stored into a short")
+    {
+        short short_data = 0;
+        const auto result = info_set_integer(nlohmann::json(30000), short_data, true);
+        CHECK(result == PARSE_ERROR_NONE);
+        CHECK(short_data == 30000);
+    }
+
+    SUBCASE("enum value")
+    {
+        auto kind = TestKind::NONE;
+        const auto result = info_set_integer(nlohmann::json(1), kind, true);
+        CHECK(result == PARSE_ERROR_NONE);
+        CHECK(kind == TestKind::FIRST);
+    }
+}
+
+TEST_CASE("info_set_integer treats a null JSON as an unwritten key")
+{
+    auto data = SENTINEL;
+    const nlohmann::json null_json;
+
+    SUBCASE("required key is an error")
+    {
+        const auto result = info_set_integer(null_json, data, true);
+        CHECK(result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+    }
+
+    SUBCASE("optional key is not an error")
+    {
+        const auto result = info_set_integer(null_json, data, false);
+        CHECK(result == PARSE_ERROR_NONE);
+    }
+
+    // どちらの場合も格納先は元の値のままにしておく必要がある
+    CHECK(data == SENTINEL);
+}
+
+TEST_CASE("info_set_integer rejects a non-integer JSON")
+{
+    auto data = SENTINEL;
+
+    SUBCASE("string")
+    {
+        const auto result = info_set_integer(nlohmann::json("100"), data, true);
+        CHECK(result == PARSE_ERROR_INVALID_TYPE);
+    }
+
+    SUBCASE("floating point number")
+    {
+        const auto result = info_set_integer(nlohmann::json(1.5), data, true);
+        CHECK(result == PARSE_ERROR_INVALID_TYPE);
+    }
+
+    SUBCASE("boolean")
+    {
+        const auto result = info_set_integer(nlohmann::json(true), data, true);
+        CHECK(result == PARSE_ERROR_INVALID_TYPE);
+    }
+
+    SUBCASE("optional key is an error too")
+    {
+        // 必須でなくても、書かれている値の型が誤っていれば見逃さない
+        const auto result = info_set_integer(nlohmann::json("100"), data, false);
+        CHECK(result == PARSE_ERROR_INVALID_TYPE);
+    }
+
+    CHECK(data == SENTINEL);
+}
+
+TEST_CASE("info_set_integer checks the value range")
+{
+    auto data = SENTINEL;
+
+    SUBCASE("both ends of the range are valid")
+    {
+        const auto lower_result = info_set_integer(nlohmann::json(0), data, true, Range(0, 128));
+        CHECK(lower_result == PARSE_ERROR_NONE);
+        CHECK(data == 0);
+
+        const auto upper_result = info_set_integer(nlohmann::json(128), data, true, Range(0, 128));
+        CHECK(upper_result == PARSE_ERROR_NONE);
+        CHECK(data == 128);
+    }
+
+    SUBCASE("below the range")
+    {
+        const auto result = info_set_integer(nlohmann::json(-1), data, true, Range(0, 128));
+        CHECK(result == PARSE_ERROR_INVALID_FLAG);
+        CHECK(data == SENTINEL);
+    }
+
+    SUBCASE("above the range")
+    {
+        const auto result = info_set_integer(nlohmann::json(129), data, true, Range(0, 128));
+        CHECK(result == PARSE_ERROR_INVALID_FLAG);
+        CHECK(data == SENTINEL);
+    }
+
+    SUBCASE("range containing negative numbers")
+    {
+        const auto valid_result = info_set_integer(nlohmann::json(-99), data, true, Range(-99, 99));
+        CHECK(valid_result == PARSE_ERROR_NONE);
+        CHECK(data == -99);
+
+        const auto invalid_result = info_set_integer(nlohmann::json(-100), data, true, Range(-99, 99));
+        CHECK(invalid_result == PARSE_ERROR_INVALID_FLAG);
+        CHECK(data == -99);
+    }
+
+    SUBCASE("enum value out of the range")
+    {
+        auto kind = TestKind::NONE;
+        const auto invalid_result = info_set_integer(nlohmann::json(11), kind, true, Range(0, 10));
+        CHECK(invalid_result == PARSE_ERROR_INVALID_FLAG);
+        CHECK(kind == TestKind::NONE);
+
+        const auto valid_result = info_set_integer(nlohmann::json(10), kind, true, Range(0, 10));
+        CHECK(valid_result == PARSE_ERROR_NONE);
+        CHECK(kind == TestKind::LAST);
+    }
+}
+
+TEST_CASE("info_set_string picks the string of the language of the build")
+{
+    nlohmann::json json;
+    json[LANG_KEY] = "name-of-this-build";
+    json[OTHER_LANG_KEY] = "name-of-the-other-build";
+
+    std::string data;
+    const auto result = info_set_string(json, data, true);
+    CHECK(result == PARSE_ERROR_NONE);
+    CHECK(data == "name-of-this-build");
+}
+
+#ifdef JP
+TEST_CASE("info_set_string converts the UTF-8 string into the system encoding")
+{
+    nlohmann::json json;
+    json["ja"] = UTF8_TEST_STRING;
+
+    std::string data;
+    const auto result = info_set_string(json, data, true);
+    REQUIRE(result == PARSE_ERROR_NONE);
+
+    // 日本語版のシステム文字コード(EUC-JP/Shift_JIS)はUTF-8と異なるので、
+    // 変換されていれば元のバイト列とは一致しない
+    CHECK(data != UTF8_TEST_STRING);
+
+    // 変換結果の内容まで確かめる。期待するバイト列はEUC-JPとShift_JISで異なるため、
+    // UTF-8へ戻して元の文字列と一致することを見る
+    const auto restored = sys_to_utf8(data);
+    REQUIRE(restored.has_value());
+    CHECK(*restored == UTF8_TEST_STRING);
+}
+#endif
+
+#if defined(JP) && defined(EUC)
+TEST_CASE("info_set_string cannot convert a character missing from EUC-JP")
+{
+    // U+1F600 (GRINNING FACE)。EUC-JPに対応する文字がないため変換に失敗する。
+    // Windows版(Shift_JIS)は MultiByteToWideChar/WideCharToMultiByte をエラー指定なしで
+    // 呼ぶので置換文字になって成功してしまう。そのためEUC版限定のテストとする。
+    // なお変換不能文字でiconvがエラーを返すのは glibc/GNU libiconv での挙動で、
+    // musl のiconvは '*' に置換して成功扱いにする
+    nlohmann::json json;
+    json["ja"] = "\xf0\x9f\x98\x80";
+
+    std::string data = "unchanged";
+
+    // 変換失敗は必須かどうかによらずエラーになり、格納先は書き換えない
+    const auto required_result = info_set_string(json, data, true);
+    CHECK(required_result == PARSE_ERROR_INVALID_FLAG);
+
+    const auto optional_result = info_set_string(json, data, false);
+    CHECK(optional_result == PARSE_ERROR_INVALID_FLAG);
+
+    CHECK(data == "unchanged");
+
+    // 変換に失敗しても後続の変換に影響しないことを確かめる。
+    // utf8_to_euc の iconv_t は関数内staticで、変換失敗後にリセットされないため
+    nlohmann::json valid_json;
+    valid_json["ja"] = UTF8_TEST_STRING;
+
+    const auto result_after_failure = info_set_string(valid_json, data, true);
+    REQUIRE(result_after_failure == PARSE_ERROR_NONE);
+    const auto restored = sys_to_utf8(data);
+    REQUIRE(restored.has_value());
+    CHECK(*restored == UTF8_TEST_STRING);
+}
+#endif
+
+TEST_CASE("info_set_string treats a missing string as an unwritten key")
+{
+    std::string data = "unchanged";
+
+    SUBCASE("null JSON")
+    {
+        const nlohmann::json null_json;
+
+        const auto required_result = info_set_string(null_json, data, true);
+        CHECK(required_result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+
+        const auto optional_result = info_set_string(null_json, data, false);
+        CHECK(optional_result == PARSE_ERROR_NONE);
+    }
+
+    SUBCASE("object which has only the key of the other language")
+    {
+        nlohmann::json json;
+        json[OTHER_LANG_KEY] = "name-of-the-other-build";
+
+        const auto required_result = info_set_string(json, data, true);
+        CHECK(required_result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+
+        const auto optional_result = info_set_string(json, data, false);
+        CHECK(optional_result == PARSE_ERROR_NONE);
+    }
+
+    CHECK(data == "unchanged");
+}
+
+TEST_CASE("info_set_string rejects a JSON of an invalid type")
+{
+    std::string data = "unchanged";
+
+    SUBCASE("string written directly instead of an object")
+    {
+        // 言語別のオブジェクトではなく文字列が直接書かれている場合
+        const auto required_result = info_set_string(nlohmann::json("name"), data, true);
+        CHECK(required_result == PARSE_ERROR_INVALID_TYPE);
+
+        const auto optional_result = info_set_string(nlohmann::json("name"), data, false);
+        CHECK(optional_result == PARSE_ERROR_INVALID_TYPE);
+    }
+
+    SUBCASE("the value of the language key is not a string")
+    {
+        nlohmann::json json;
+        json[LANG_KEY] = 100;
+
+        const auto required_result = info_set_string(json, data, true);
+        CHECK(required_result == PARSE_ERROR_INVALID_TYPE);
+
+        const auto optional_result = info_set_string(json, data, false);
+        CHECK(optional_result == PARSE_ERROR_INVALID_TYPE);
+    }
+
+    CHECK(data == "unchanged");
+}
+
+TEST_CASE("info_set_dice parses the dice string")
+{
+    Dice dice;
+
+    SUBCASE("single digit")
+    {
+        const auto result = info_set_dice(nlohmann::json("3d5"), dice, true);
+        CHECK(result == PARSE_ERROR_NONE);
+        CHECK(dice == Dice(3, 5));
+    }
+
+    SUBCASE("multiple digits")
+    {
+        const auto result = info_set_dice(nlohmann::json("10d100"), dice, true);
+        CHECK(result == PARSE_ERROR_NONE);
+        CHECK(dice == Dice(10, 100));
+    }
+}
+
+TEST_CASE("info_set_dice treats a null JSON as an unwritten key")
+{
+    Dice dice(1, 1);
+    const nlohmann::json null_json;
+
+    const auto required_result = info_set_dice(null_json, dice, true);
+    CHECK(required_result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+
+    const auto optional_result = info_set_dice(null_json, dice, false);
+    CHECK(optional_result == PARSE_ERROR_NONE);
+
+    CHECK(dice == Dice(1, 1));
+}
+
+TEST_CASE("info_set_dice rejects an invalid dice notation")
+{
+    Dice dice(1, 1);
+
+    SUBCASE("non-string JSON is a type error")
+    {
+        const auto required_result = info_set_dice(nlohmann::json(3), dice, true);
+        CHECK(required_result == PARSE_ERROR_INVALID_TYPE);
+
+        const auto optional_result = info_set_dice(nlohmann::json(3), dice, false);
+        CHECK(optional_result == PARSE_ERROR_INVALID_TYPE);
+    }
+
+    SUBCASE("malformed dice string")
+    {
+        // Dice::parse が投げる例外は捕捉され、必須かどうかによらずエラーになる
+        for (const auto *const dice_str : { "3", "3d", "dice", "" }) {
+            CAPTURE(dice_str);
+
+            const auto required_result = info_set_dice(nlohmann::json(dice_str), dice, true);
+            CHECK(required_result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+
+            const auto optional_result = info_set_dice(nlohmann::json(dice_str), dice, false);
+            CHECK(optional_result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+        }
+    }
+
+    CHECK(dice == Dice(1, 1));
+}
+
+TEST_CASE("info_set_bool stores the value")
+{
+    auto data = false;
+
+    const auto true_result = info_set_bool(nlohmann::json(true), data, true);
+    CHECK(true_result == PARSE_ERROR_NONE);
+    CHECK(data);
+
+    const auto false_result = info_set_bool(nlohmann::json(false), data, true);
+    CHECK(false_result == PARSE_ERROR_NONE);
+    CHECK_FALSE(data);
+}
+
+TEST_CASE("info_set_bool treats a non-boolean JSON as an unwritten key")
+{
+    // 格納先を書き換えないことを確かめるため、既定値の false ではなく true から始める。
+    // false で始めると、誤って false を書き込む実装でもテストが通ってしまう
+    auto data = true;
+
+    SUBCASE("null JSON")
+    {
+        const nlohmann::json null_json;
+
+        const auto required_result = info_set_bool(null_json, data, true);
+        CHECK(required_result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+
+        const auto optional_result = info_set_bool(null_json, data, false);
+        CHECK(optional_result == PARSE_ERROR_NONE);
+    }
+
+    SUBCASE("JSON of another type")
+    {
+        // 他の info_set_* と異なり、型が違っても PARSE_ERROR_INVALID_TYPE ではなく
+        // キーが書かれていない場合と同じ扱いになる
+        for (const auto &json : { nlohmann::json("true"), nlohmann::json(1) }) {
+            CAPTURE(json.type_name());
+
+            const auto required_result = info_set_bool(json, data, true);
+            CHECK(required_result == PARSE_ERROR_TOO_FEW_ARGUMENTS);
+
+            const auto optional_result = info_set_bool(json, data, false);
+            CHECK(optional_result == PARSE_ERROR_NONE);
+        }
+    }
+
+    CHECK(data);
+}

--- a/src/test/info-reader/test-json-reader-util.cpp
+++ b/src/test/info-reader/test-json-reader-util.cpp
@@ -25,6 +25,7 @@
 #include <doctest/doctest.h>
 #include <nlohmann/json.hpp>
 
+#include <cstdint>
 #include <string>
 
 namespace {
@@ -253,6 +254,28 @@ TEST_CASE("info_set_integer checks the value range")
         const auto valid_result = info_set_integer(nlohmann::json(10), kind, true, Range(0, 10));
         CHECK(valid_result == PARSE_ERROR_NONE);
         CHECK(kind == TestKind::LAST);
+    }
+
+    SUBCASE("value which does not fit in the destination type")
+    {
+        // 範囲外の値が格納先の型で表現できない場合も範囲チェックで弾く。
+        // 格納先の型へ変換してから範囲を見ると、uint8_t への 300 は 44 に切り詰められて
+        // Range(0, 255) を通ってしまう (terrain の "power" がこの形で読まれている)。
+        // 番兵値は切り詰め後の値 (44, 255) と重ならないものにする
+        constexpr uint8_t uint8_sentinel = 123;
+        auto uint8_data = uint8_sentinel;
+
+        const auto above_result = info_set_integer(nlohmann::json(300), uint8_data, true, Range(0, 255));
+        CHECK(above_result == PARSE_ERROR_INVALID_FLAG);
+        CHECK(uint8_data == uint8_sentinel);
+
+        const auto below_result = info_set_integer(nlohmann::json(-1), uint8_data, true, Range(0, 255));
+        CHECK(below_result == PARSE_ERROR_INVALID_FLAG);
+        CHECK(uint8_data == uint8_sentinel);
+
+        const auto valid_result = info_set_integer(nlohmann::json(255), uint8_data, true, Range(0, 255));
+        CHECK(valid_result == PARSE_ERROR_NONE);
+        CHECK(uint8_data == 255);
     }
 }
 

--- a/src/test/info-reader/test-json-reader-util.cpp
+++ b/src/test/info-reader/test-json-reader-util.cpp
@@ -28,6 +28,11 @@
 #include <cstdint>
 #include <string>
 
+#if defined(JP) && defined(EUC)
+// _LIBICONV_VERSION (GNU libiconv の判定に使う) を参照するため
+#include <iconv.h>
+#endif
+
 namespace {
 
 //! info_set_integer がenum型を扱えることを確かめるためのenum
@@ -313,14 +318,15 @@ TEST_CASE("info_set_string converts the UTF-8 string into the system encoding")
 }
 #endif
 
-#if defined(JP) && defined(EUC)
+#if defined(JP) && defined(EUC) && (defined(__GLIBC__) || defined(_LIBICONV_VERSION))
 TEST_CASE("info_set_string cannot convert a character missing from EUC-JP")
 {
     // U+1F600 (GRINNING FACE)。EUC-JPに対応する文字がないため変換に失敗する。
     // Windows版(Shift_JIS)は MultiByteToWideChar/WideCharToMultiByte をエラー指定なしで
     // 呼ぶので置換文字になって成功してしまう。そのためEUC版限定のテストとする。
-    // なお変換不能文字でiconvがエラーを返すのは glibc/GNU libiconv での挙動で、
-    // musl のiconvは '*' に置換して成功扱いにする
+    // さらに、変換不能文字でiconvがエラーを返すのは glibc/GNU libiconv での挙動で、
+    // musl のiconvは '*' に置換して成功扱いにする。そのため glibc (__GLIBC__) か
+    // GNU libiconv (_LIBICONV_VERSION) のときに限定し、musl 系ではこのテストごと除外する
     nlohmann::json json;
     json["ja"] = "\xf0\x9f\x98\x80";
 


### PR DESCRIPTION
定義ファイル読込の共通ユーティリティ (`src/info-reader/info-reader-util.*` と `src/info-reader/json-reader-util.*`) のユニットテストを追加します。

各リーダーがJSONから値を取り出すのに使う土台であり、ここが誤ると全ての定義ファイルの読込に影響するため、まずこの層を固めました。いずれも `PlayerType` やフロア、`term` を必要としない純粋な関数・関数テンプレートなので、`src/test/README.md` の判断基準どおりユニットテストの対象になります。

## 追加したテスト

テスト対象のファイルごとに2コミットに分けています。各コミットが自身のテストと、`src/Makefile.am` / `HengbandTest.vcxproj` / `.vcxproj.filters` への登録を同時に含むため、途中のコミットでも `check_test_registration` が通ります。

### `test/info-reader/test-info-reader-util.cpp`

- `info_get_const` / `info_grab_one_const` — トークン辞書からの定数取得、未知トークン時に格納先を書き換えないこと、`unordered_map<string_view, enum>` と `map<string, int>` の両方で引けること (`DictIndexedBy` コンセプトの確認)
- `info_set_value` — 10進数・16進数、格納先の型への変換、`std::stoi` の例外が呼び出し元へ伝わること
- `append_english_text` (英語版のみ) — 空白1つ/`.!?` の後は2つの連結、両端のトリム、空文字列の無視

### `test/info-reader/test-json-reader-util.cpp`

- `get_json_value` — キーの取得、入れ子、キーの欠落、値が `null` のキーが未記述と同じ扱いになること、オブジェクトでないJSONでも例外にならないこと
- `info_set_integer` — 正負の値、`short` や enum への格納、必須/任意でのnullの扱い、型不一致、範囲指定の両端と範囲外、格納先の型に収まらない範囲外の値 (`uint8_t` への `300` / `-1`)
- `info_set_string` — ビルドの言語に応じた `"ja"`/`"en"` の選択、他方の言語のキーしかない場合、型エラー、日本語版でのシステム文字コードへの変換
- `info_set_dice` / `info_set_bool` — ダイス文字列のパースと不正な記法、bool値の格納と他の型の扱い

## テストで見つかった実装の不具合の修正

レビューで指摘を受け、`info_set_integer()` の範囲チェックを修正しました (036f48762d)。

`info_set_integer()` は `json.get<T>()` で格納先の型へ変換してから範囲を比べていたため、範囲外の値が格納先の型で表現できないとき、切り詰めで範囲内の別の値になり範囲チェックをすり抜けていました。`terrain-reader.cpp` の `set_terrain_power` (`uint8_t`, `Range(0, 255)`) がこの形で、地形定義に `"power": 300` や `-1` と書いてもエラーにならず、黙って `44` や `255` になっていました。

JSONの整数値 (`int64_t`) のまま範囲を確かめてから格納先の型へ変換するようにしています。範囲は格納先の型に収まる前提なので、範囲内の値の挙動は変わりません。この修正は独立したコミットにしてあるので、別PRに分けた方がよければ切り出します。

## 設計上の判断

**格納先を書き換えないことの確認に番兵値を使っています。** 既定値を初期値にすると、誤ってその値を書き込む実装でもテストが通ってしまうためです。

**文字コード変換は往復で検証しています。** 期待するバイト列はEUC-JPとShift_JISで異なるため、`sys_to_utf8()` でUTF-8へ戻して元の文字列と一致することを確認しています。「変換前と異なる」だけの検証では、変換結果が壊れていても通ってしまいます。

**EUC版かつ glibc / GNU libiconv 限定で変換失敗の分岐も検証しています。** EUC-JPに変換できない文字 (U+1F600) を与えると `PARSE_ERROR_INVALID_FLAG` が返り格納先が変わらないことを確認します。Windows版(Shift_JIS)は `MultiByteToWideChar`/`WideCharToMultiByte` をエラー指定なしで呼ぶため置換文字になって成功してしまい、musl の iconv も `'*'` に置換して成功扱いにするので、`#if defined(JP) && defined(EUC) && (defined(__GLIBC__) || defined(_LIBICONV_VERSION))` で囲んでいます。`utf8_to_euc` の `iconv_t` は関数内 `static` で変換失敗後にリセットされないため、同じテストケース内で失敗の直後に正常な変換を行い、後続に影響しないことも確かめています。

**検証対象の関数呼び出しは一旦変数で受けてから比較しています。** `== 期待値` と組み合わせてCHECKに直接書くと、MSVCが評価順序に関する C4866 を出すことがあり、`TreatWarningAsError` でビルドが落ちるためです。理由はファイル先頭のコメントに残しました。

## 意図的に対象外としたもの

- **`Dice::parse` の受理範囲** — `"3d5junk"` が通るなどの緩さは実装側の課題であり、テストで現状を仕様として固定したくないため。`Dice` 自体の仕様は `test/util/test-dice.cpp` の領分と考えています
- **`info_set_value` で格納先の型に収まらない値** — `uint8_t` への `300` などは `static_cast` で黙って折り返されますが、これも実装側の課題であり現状を仕様として固定したくないため。SUBCASE 名とコメントで、収まる値だけを扱うことを明記しています
- **`grab_one_activation_flag`** — 未知トークンに対して、非数値なら `std::stoi` が例外を送出し、`"0"` や負数なら `msg_format` (term が必要) を呼ぶ状態のため

## 動作確認

| 構成 | 文字コード | ケース数 | アサーション数 |
|---|---|---|---|
| MSVC `Debug` (日本語) | Shift_JIS | 44 | 10885 |
| MSVC `English-Debug` | - | 45 | 10890 |
| Linux g++ 13.3 日本語版 (autotools) | EUC-JP | 45 | 10891 |
| Linux g++ 13.3 英語版 (autotools) | - | 45 | 10890 |

いずれも全テスト成功、警告なし。Linux版は `make check` が `# PASS: 1 / # FAIL: 0 / # ERROR: 0` で exit 0、日本語版は `--order-by=name` / `--order-by=rand` でテストの実行順序を変えても成功します (`utf8_to_euc` の関数内 static な `iconv_t` への順序依存なし)。

EUC変換失敗のテストを囲む `#if` が glibc 環境で意図せずテストを除外していないことも確認しています (Ubuntu 24.04 / glibc 2.39、`--list-test-cases` に当該テストが現れ、日本語版のケース数が英語版と同じ 45 になること)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - JSON形式の整数値について、変換先の型で扱える範囲を確認してから変換するよう改善しました。範囲外の値による予期しない変換を防ぎます。

- **テスト**
  - 定義ファイルおよびJSON読み込み処理の検証を拡充しました。
  - 不正な値、キー不足、型不一致、文字コード変換エラーなどの異常ケースを確認できるようにしました。
  - テスト環境ごとの文字コード差異にも対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->