### PR TITLE
[Feature] Diceクラスのユニットテストを追加する

### DIFF
--- a/VisualStudio/Hengband/HengbandTest.vcxproj
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj
@@ -60,6 +60,7 @@
     <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-player-stun.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-timed-effect.cpp" />
+    <ClCompile Include="..\..\src\test\util\test-dice.cpp" />
     <ClCompile Include="..\..\src\test\util\test-flag-group.cpp" />
     <ClCompile Include="..\..\src\test\util\test-probability-table.cpp" />
     <ClCompile Include="..\..\src\test\util\test-sha256.cpp" />

--- a/VisualStudio/Hengband/HengbandTest.vcxproj.filters
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClCompile Include="..\..\src\test\timed-effect\test-timed-effect.cpp">
       <Filter>timed-effect</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\util\test-dice.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\util\test-flag-group.cpp">
       <Filter>util</Filter>
     </ClCompile>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1492,6 +1492,7 @@ hengband_test_SOURCES = \
 	test/timed-effect/test-player-cut.cpp \
 	test/timed-effect/test-player-stun.cpp \
 	test/timed-effect/test-timed-effect.cpp \
+	test/util/test-dice.cpp \
 	test/util/test-flag-group.cpp \
 	test/util/test-probability-table.cpp \
 	test/util/test-sha256.cpp

--- a/src/test/util/test-dice.cpp
+++ b/src/test/util/test-dice.cpp
@@ -161,8 +161,10 @@ TEST_CASE("Dice::floored_expected_value multiplies before truncating")
     CHECK(Dice(1, 2).floored_expected_value_multiplied_by(2) == 3);
     CHECK(Dice::floored_expected_value(1, 2, 2) == 3);
 
-    // 倍率1は floored_expected_value() と同じ
-    CHECK(Dice(1, 2).floored_expected_value_multiplied_by(1) == Dice(1, 2).floored_expected_value());
+    // 倍率1は倍率を指定しない場合と同じ。ただし互いを比べると両辺が同じ静的関数へ
+    // 委譲するため、式を壊しても一緒に動いて必ず成立する。リテラルで固定する
+    CHECK(Dice(1, 2).floored_expected_value_multiplied_by(1) == 1);
+    CHECK(Dice(3, 5).floored_expected_value_multiplied_by(1) == 9);
 
     CHECK(Dice(3, 5).floored_expected_value_multiplied_by(10) == 90);
 }

--- a/src/test/util/test-dice.cpp
+++ b/src/test/util/test-dice.cpp
@@ -229,3 +229,23 @@ TEST_CASE("Dice::roll of a single sided dice always returns the number of the di
     CHECK(Dice(5, 1).roll() == 5);
     CHECK(Dice::roll(5, 1) == 5);
 }
+
+TEST_CASE("Dice::roll sums the pips of the dice one by one")
+{
+    const auto restore_rng = test::scoped_rng();
+
+    // 3d5 は「1個の出目を3倍したもの」ではなく「3個の独立した出目の和」。
+    // 前者だと出目は必ず3の倍数 (3, 6, 9, 12, 15) になり、
+    // 合計の範囲は 3〜15 のままなので範囲を見るテストでは区別できない
+    const Dice dice(3, 5);
+
+    auto has_non_multiple = false;
+    for (auto i = 0; i < 1000; i++) {
+        if (dice.roll() % 3 != 0) {
+            has_non_multiple = true;
+            break;
+        }
+    }
+
+    CHECK(has_non_multiple);
+}

--- a/src/test/util/test-dice.cpp
+++ b/src/test/util/test-dice.cpp
@@ -192,6 +192,8 @@ TEST_CASE("Dice::roll stays within the range of the possible sums")
 {
     const auto restore_rng = test::scoped_rng();
 
+    // is_valid() が真になるダイスに限った契約。非正値のダイスは
+    // 出目が maxroll() を超えることがある (後続のテストで固定している)
     for (const auto &dice : { Dice(1, 1), Dice(1, 6), Dice(3, 5), Dice(10, 100) }) {
         CAPTURE(dice.to_string());
 
@@ -248,4 +250,23 @@ TEST_CASE("Dice::roll sums the pips of the dice one by one")
     }
 
     CHECK(has_non_multiple);
+}
+
+TEST_CASE("Dice::roll does not reject a dice which is not valid")
+{
+    const auto restore_rng = test::scoped_rng();
+
+    // parse は "0d0" や "-1d6" を通すため (Dice::parse のテストを参照)、
+    // 振れないダイスが実際に roll() まで届く。振っても例外にはならない
+
+    // ダイス数が0以下なら合計を足し込むループが回らず0
+    CHECK(Dice(0, 0).roll() == 0);
+    CHECK(Dice(0, 6).roll() == 0);
+    CHECK(Dice(-1, 6).roll() == 0);
+
+    // 面数0は randint1(0) が 1 を返す (term/z-rand.h の randnum1) ため、
+    // 出目の合計はダイス数と等しくなる。maxroll() は 0 なので、
+    // このダイスに限り出目が maxroll() を超える
+    CHECK(Dice(6, 0).roll() == 6);
+    CHECK(Dice(6, 0).maxroll() == 0);
 }

--- a/src/test/util/test-dice.cpp
+++ b/src/test/util/test-dice.cpp
@@ -1,0 +1,229 @@
+/*!
+ * @brief Diceクラスのテスト
+ *
+ * ダイスの生成・文字列との相互変換・出目の計算を検証する。
+ * ダメージ計算の土台であり、定義ファイルの読込 (info_set_dice) も
+ * Dice::parse に依存しているため、境界値と異常系を重点的に確かめる。
+ *
+ * @details Dice を返す関数の呼び出しを `== 期待値` と組み合わせて CHECK に直接書くと、
+ * MSVCが評価順序に関する警告 (C4866) を出す。この警告はエラーとして扱われるため、
+ * 呼び出しの結果は一旦変数で受けてから比較する。
+ */
+
+#include "util/dice.h"
+
+#include "test/scoped-rng.h"
+
+#include <doctest/doctest.h>
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+TEST_CASE("Dice is invalid just after default construction")
+{
+    const Dice dice;
+
+    CHECK(dice.num == 0);
+    CHECK(dice.sides == 0);
+    CHECK_FALSE(dice.is_valid());
+}
+
+TEST_CASE("Dice holds the number and the sides given")
+{
+    const Dice dice(3, 5);
+
+    CHECK(dice.num == 3);
+    CHECK(dice.sides == 5);
+    CHECK(dice.is_valid());
+}
+
+TEST_CASE("Dice is valid only when both the number and the sides are positive")
+{
+    // 1個1面が振れる最小のダイス
+    CHECK(Dice(1, 1).is_valid());
+
+    CHECK_FALSE(Dice(0, 6).is_valid());
+    CHECK_FALSE(Dice(6, 0).is_valid());
+    CHECK_FALSE(Dice(-1, 6).is_valid());
+    CHECK_FALSE(Dice(6, -1).is_valid());
+}
+
+TEST_CASE("Dice compares equal only when both the number and the sides match")
+{
+    CHECK(Dice(3, 5) == Dice(3, 5));
+    CHECK(Dice(3, 5) != Dice(5, 3));
+    CHECK(Dice(3, 5) != Dice(3, 6));
+    CHECK(Dice(3, 5) != Dice(4, 5));
+}
+
+TEST_CASE("Dice::parse builds a dice from the NdM notation")
+{
+    const auto parsed = Dice::parse("3d5");
+    CHECK(parsed == Dice(3, 5));
+
+    const auto minimum = Dice::parse("1d1");
+    CHECK(minimum == Dice(1, 1));
+
+    // 複数桁
+    const auto multi_digits = Dice::parse("10d100");
+    CHECK(multi_digits == Dice(10, 100));
+}
+
+TEST_CASE("Dice::parse rejects a malformed string")
+{
+    // 'd' で2つに分割できない
+    CHECK_THROWS_AS(Dice::parse("3"), std::runtime_error);
+    CHECK_THROWS_AS(Dice::parse("35"), std::runtime_error);
+    CHECK_THROWS_AS(Dice::parse("3d5d7"), std::runtime_error);
+
+    // 'd' の前後が整数として読めない
+    CHECK_THROWS_AS(Dice::parse("3d"), std::runtime_error);
+    CHECK_THROWS_AS(Dice::parse("d5"), std::runtime_error);
+    CHECK_THROWS_AS(Dice::parse("d"), std::runtime_error);
+    CHECK_THROWS_AS(Dice::parse("dice"), std::runtime_error);
+
+    // 空文字列
+    CHECK_THROWS_AS(Dice::parse(""), std::runtime_error);
+
+    // intに収まらない値。std::stoi の std::out_of_range も同じく変換される
+    CHECK_THROWS_AS(Dice::parse("99999999999d6"), std::runtime_error);
+}
+
+TEST_CASE("Dice::parse does not check whether the dice is valid")
+{
+    // parse が見るのは 'd' で2つに分割でき、前後がそれぞれ整数として読めることまで。
+    // 振れる値かどうかは is_valid() で別に判定する契約になっている。
+    // 定義ファイルには実際に "0d0" が書かれている (BaseitemDefinitions.jsonc) ため、
+    // parse が非正値を拒否するようにすると定義ファイルの読込が失敗する
+    const auto no_dice = Dice::parse("0d0");
+    CHECK(no_dice == Dice(0, 0));
+    CHECK_FALSE(no_dice.is_valid());
+
+    const auto zero_num = Dice::parse("0d6");
+    CHECK(zero_num == Dice(0, 6));
+    CHECK_FALSE(zero_num.is_valid());
+
+    const auto negative_num = Dice::parse("-1d6");
+    CHECK(negative_num == Dice(-1, 6));
+    CHECK_FALSE(negative_num.is_valid());
+}
+
+TEST_CASE("Dice::to_string builds the NdM notation")
+{
+    CHECK(Dice::to_string(3, 5) == "3d5");
+    CHECK(Dice(10, 100).to_string() == "10d100");
+}
+
+TEST_CASE("Dice survives a round trip through its string notation")
+{
+    for (const auto &dice : { Dice(1, 1), Dice(3, 5), Dice(10, 100) }) {
+        CAPTURE(dice.to_string());
+
+        const auto restored = Dice::parse(dice.to_string());
+        CHECK(restored == dice);
+    }
+}
+
+TEST_CASE("Dice::maxroll returns the sum of the maximum pips")
+{
+    CHECK(Dice::maxroll(3, 5) == 15);
+    CHECK(Dice(3, 5).maxroll() == 15);
+    CHECK(Dice(1, 1).maxroll() == 1);
+}
+
+TEST_CASE("Dice::expected_value returns the average of the sum")
+{
+    // 1d6 の期待値は 3.5 で、整数では表せない
+    CHECK(Dice::expected_value(1, 6) == doctest::Approx(3.5));
+    CHECK(Dice(1, 6).expected_value() == doctest::Approx(3.5));
+
+    CHECK(Dice(3, 5).expected_value() == doctest::Approx(9.0));
+    CHECK(Dice(1, 1).expected_value() == doctest::Approx(1.0));
+}
+
+TEST_CASE("Dice::floored_expected_value truncates the fraction of the average")
+{
+    // 1d2 の期待値 1.5 の小数部を切り捨てて 1
+    CHECK(Dice(1, 2).floored_expected_value() == 1);
+
+    // 割り切れる場合は期待値と一致する
+    CHECK(Dice(3, 5).floored_expected_value() == 9);
+    CHECK(Dice(1, 1).floored_expected_value() == 1);
+}
+
+TEST_CASE("Dice::floored_expected_value multiplies before truncating")
+{
+    // 倍率は切り捨ての前に掛ける。1.5 * 2 = 3 であり、
+    // 切り捨ててから掛けた 1 * 2 = 2 にはならない
+    CHECK(Dice(1, 2).floored_expected_value_multiplied_by(2) == 3);
+    CHECK(Dice::floored_expected_value(1, 2, 2) == 3);
+
+    // 倍率1は floored_expected_value() と同じ
+    CHECK(Dice(1, 2).floored_expected_value_multiplied_by(1) == Dice(1, 2).floored_expected_value());
+
+    CHECK(Dice(3, 5).floored_expected_value_multiplied_by(10) == 90);
+}
+
+namespace {
+
+//! ダイスを指定回数振り、出目の合計の最小値と最大値を返す
+std::pair<int, int> roll_repeatedly(const Dice &dice, int count)
+{
+    auto min_result = std::numeric_limits<int>::max();
+    auto max_result = std::numeric_limits<int>::min();
+
+    for (auto i = 0; i < count; i++) {
+        const auto result = dice.roll();
+        min_result = std::min(min_result, result);
+        max_result = std::max(max_result, result);
+    }
+
+    return { min_result, max_result };
+}
+
+}
+
+TEST_CASE("Dice::roll stays within the range of the possible sums")
+{
+    const auto restore_rng = test::scoped_rng();
+
+    for (const auto &dice : { Dice(1, 1), Dice(1, 6), Dice(3, 5), Dice(10, 100) }) {
+        CAPTURE(dice.to_string());
+
+        // 構造化束縛の変数は CAPTURE (ラムダで対象を包む) に渡せない処理系
+        // (clang 15以前) があるため、通常の変数で受ける
+        const auto results = roll_repeatedly(dice, 1000);
+        const auto min_result = results.first;
+        const auto max_result = results.second;
+
+        CHECK(min_result >= dice.num);
+        CHECK(max_result <= dice.maxroll());
+    }
+}
+
+TEST_CASE("Dice::roll reaches both ends of its range")
+{
+    const auto restore_rng = test::scoped_rng();
+
+    // 十分な回数振れば両端の出目が出る。片方しか出ない場合は
+    // 出目の範囲が1つずれている
+    const Dice dice(1, 6);
+    const auto results = roll_repeatedly(dice, 1000);
+    const auto min_result = results.first;
+    const auto max_result = results.second;
+
+    CHECK(min_result == 1);
+    CHECK(max_result == dice.sides);
+}
+
+TEST_CASE("Dice::roll of a single sided dice always returns the number of the dice")
+{
+    const auto restore_rng = test::scoped_rng();
+
+    CHECK(Dice(1, 1).roll() == 1);
+    CHECK(Dice(5, 1).roll() == 5);
+    CHECK(Dice::roll(5, 1) == 5);
+}


### PR DESCRIPTION
`Dice` クラスのユニットテストを追加します。

ダメージ計算の土台であり、定義ファイルの読込 (`info_set_dice`) も `Dice::parse` に依存しています。`PlayerType` やフロア、`term` を必要としないため、`src/test/README.md` の判断基準どおりユニットテストの対象になります。

#5538 で `info_set_dice` のテストを追加した際、`Dice` 自体の仕様は `test/util/test-dice.cpp` の領分としたので、その回収にあたります。#5538 とは独立した内容なので `develop` から分岐しています。

## 追加したテスト

**生成と判定** — 既定構築直後が `0d0` で `is_valid()` が偽になること、`is_valid()` が数と面数の両方が正のときだけ真になること、等値比較が両方を見ていること

**文字列との相互変換** — `"NdM"` のパースと生成、相互変換で元に戻ること。`'d'` で 2 つに分割できない / 前後が整数として読めない / 空文字列 / `int` に収まらない値を例外とすること

**出目の計算** — `maxroll`、`expected_value` (1d6 で 3.5 のように整数で表せない値)、`floored_expected_value`、`roll`

## 設計上の判断

**`parse` が非正値を許すのは意図的な設計と解釈しました。** `"0d6"` や `"-1d6"` はパースが通り `is_valid()` が偽になります。`lib/edit/BaseitemDefinitions.jsonc` に `"base_dice": "0d0"` が 22 件書かれており、`parse` が拒否すると定義ファイルの読込が失敗します。`cmd-spell.cpp` も `Dice(0, 0)` を「ダイスなし」の番兵として使い `is_valid()` で分岐しています。将来 `parse` を厳格化する変更がこのテストを壊したときにこの前提へ気づけるよう、コメントに残しました。

**`roll` は集計してから検証しています。** ループ内で毎回アサーションを書くと 8000 件になり失敗時の出力が埋もれるため、最小値と最大値に集計しています。あわせて**両端の出目に到達すること**も検証しており、`randint1` の境界が 1 ずれれば検出できます (`rand_range(0, sides-1)` なら最小値、`rand_range(1, sides+1)` なら最大値で落ちます)。

範囲と両端だけでは「num 個の独立した出目の和」であることを固定できない (`return num * randint1(sides);` でも 3d5 の範囲は 3〜15 のまま) ため、**3d5 の標本に 3 の倍数でない出目が現れること**も確かめています。

**非正値のダイスを振ったときの挙動も固定しています。** `parse` が `"0d0"` や `"-1d6"` を通す以上、振れないダイスが `roll()` まで届きます。ダイス数が 0 以下ならループが回らず 0 になる一方、**面数 0 は `randint1(0)` が 1 を返すため出目の合計がダイス数と等しくなり、`maxroll()` の 0 を超えます**。この非対称を明示的に固定しました。出目の範囲を見るテストが `is_valid()` の真なダイスに限った契約であることもコメントに書いています。

**`Dice` を返す関数の呼び出しは一旦変数で受けています。** `== 期待値` と組み合わせて `CHECK` に直接書くと、MSVC が評価順序に関する C4866 を出し `TreatWarningAsError` でビルドが落ちるためです (`operator<<<Dice>` に対する警告として実際に発生しました)。

## 意図的にテストしなかったもの — 実装側の課題として提起します

**`Dice::parse` は末尾の余分な文字を無視します。** `std::stoi` が解析位置を確認しないためで、以下がすべて通ります。

| 入力 | 結果 | `is_valid()` |
|---|---|---|
| `"3d5junk"` | `Dice(3, 5)` | true |
| `"3d5.7"` | `Dice(3, 5)` | true |
| `" 3d5"` / `"3d5 "` / `"3 d 5"` | `Dice(3, 5)` | true |
| `"0x3d5"` | `Dice(0, 5)` | false |

問題は最初の 3 つです。`"0d0"` と違って `is_valid()` で弾けないため、**定義ファイルの誤記が妥当に見えるダイスとして通ってしまいます**。

現状を期待値として固定すると好ましくない挙動を仕様化してしまうため、このテストには含めていません。修正するなら `std::from_chars` で全体を消費したか確認する形が考えられますが、その場合は前後の空白の許容も同時に消えるため、**空白を許すかどうかはメンテナの判断が必要**と考えます。修正は別 PR とし、その際に「例外になる」回帰テストを追加するのが筋だと思います。

## 動作確認

## テストの検出力を実測しました

テストが空振りでないことを確かめるため、実装に意図的な不具合を入れて落ちることを確認しています (実装は変更していません)。

| 埋め込んだ不具合 | 検出したテスト |
|---|---|
| `Dice::roll` を `return num * randint1(sides);` に (出目が退化) | 独立した出目の和 + 非正値のダイス (2 cases) |
| `floored_expected_value` を `mult * num * sides / 2` に | 切り捨て + 倍率 (2 cases / 6 assertions) |

2 つ目は倍率 1 のアサーションを含みます。レビューで指摘されたとおり修正前は実装同士の比較になっており、式を壊しても両辺が一緒に動いて素通りしていました。

## 動作確認

#5541 のマージにより発生したコンフリクト (テストの登録先 3 ファイル) を解消するため、`develop` (c8efc6f489) へリベースしました。以下はリベース後の測定値です。

| 構成 | 文字コード | ケース数 | アサーション数 |
|---|---|---|---|
| MSVC `Debug` (日本語) | Shift_JIS | 68 | 10976 |
| MSVC `English-Debug` | - | 68 | 10976 |
| Linux g++ 13.3.0 日本語版 (autotools) | EUC-JP | 68 | 10976 |
| Linux g++ 13.3.0 英語版 (autotools) | - | 68 | 10976 |

4 構成すべてで全テスト成功し、数値が完全に一致しています。`make check` は日本語版・英語版とも `# TOTAL: 1 / # PASS: 1 / # FAIL: 0 / # ERROR: 0` で exit 0、コンパイル警告はどちらも 0 件です。`Dice` 単体ではどの構成も 18 cases / 72 assertions です。

`check-test-registration.sh` は exit 0、clang-format も差分なしです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * サイコロ機能のテストを拡充しました。
  * 出目の合計、期待値、最大値、乱数結果などを検証します。
  * ダイス数や面数が非正値の場合も、適切に処理されることを確認します。
  * 正常系に加え、`NdM` 形式の不正な入力に対するエラー処理も確認します。
  * 追加したテストを各ビルド環境で実行できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

