### PR TITLE
[Fix] #5542 召喚に失敗しても summon_named_creature() が成功を返す

### DIFF
--- a/src/monster-floor/monster-summon.cpp
+++ b/src/monster-floor/monster-summon.cpp
@@ -102,16 +102,16 @@ tl::optional<MONSTER_IDX> summon_specific(PlayerType *player_ptr, POSITION y1, P
 tl::optional<MONSTER_IDX> summon_named_creature(PlayerType *player_ptr, MONSTER_IDX src_idx, POSITION oy, POSITION ox, MonraceId r_idx, BIT_FLAGS mode)
 {
     if (!MonraceList::is_valid(r_idx) || (r_idx >= static_cast<MonraceId>(MonraceList::get_instance().size()))) {
-        return false;
+        return tl::nullopt;
     }
 
     if (player_ptr->current_floor_ptr->inside_arena) {
-        return false;
+        return tl::nullopt;
     }
 
     const auto pos = mon_scatter(player_ptr, r_idx, { oy, ox }, 2);
     if (!pos) {
-        return false;
+        return tl::nullopt;
     }
 
     const auto summon_who = is_monster(src_idx) ? tl::make_optional(src_idx) : tl::nullopt;

--- a/src/mspell/mspell-special.cpp
+++ b/src/mspell/mspell-special.cpp
@@ -157,7 +157,9 @@ static MonsterSpellResult spell_RF6_SPECIAL_ROLENTO(PlayerType *player_ptr, POSI
     }
 
     for (k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::GRENADE, mode) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, y, x, MonraceId::GRENADE, mode)) {
+            count++;
+        }
     }
     if (player_ptr->effects()->blindness().is_active() && count) {
         msg_print(_("多くのものが間近にばらまかれる音がする。", "You hear many things scattered nearby."));

--- a/src/mspell/specified-summon.cpp
+++ b/src/mspell/specified-summon.cpp
@@ -56,7 +56,9 @@ MONSTER_NUMBER summon_EDGE(PlayerType *player_ptr, POSITION y, POSITION x, int r
     int count = 0;
     int num = 2 + randint1(1 + rlev / 20);
     for (int k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::EDGE, PM_NONE) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, y, x, MonraceId::EDGE, PM_NONE)) {
+            count++;
+        }
     }
 
     return count;
@@ -113,7 +115,9 @@ MONSTER_NUMBER summon_LOCKE_CLONE(PlayerType *player_ptr, POSITION y, POSITION x
     int count = 0;
     int num = randint1(3);
     for (int k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::LOCKE_CLONE, PM_NONE) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, y, x, MonraceId::LOCKE_CLONE, PM_NONE)) {
+            count++;
+        }
     }
 
     return count;
@@ -160,7 +164,9 @@ MONSTER_NUMBER summon_DEMON_SLAYER(PlayerType *player_ptr, POSITION y, POSITION 
 
     auto count = 0;
     for (auto k = 0; k < MAX_NAZGUL_NUM; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::DEMON_SLAYER_MEMBER, PM_NONE) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, y, x, MonraceId::DEMON_SLAYER_MEMBER, PM_NONE)) {
+            count++;
+        }
     }
 
     if (count == 0) {
@@ -274,7 +280,9 @@ MONSTER_NUMBER summon_EYE_PHORN(PlayerType *player_ptr, POSITION y, POSITION x, 
     int count = 0;
     int num = 2 + randint1(1 + rlev / 20);
     for (int k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::EYE_PHORN, PM_NONE) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, y, x, MonraceId::EYE_PHORN, PM_NONE)) {
+            count++;
+        }
     }
 
     return count;
@@ -318,14 +326,13 @@ MONSTER_NUMBER summon_YENDER_WIZARD(PlayerType *player_ptr, POSITION y, POSITION
         return 0;
     }
 
-    auto count = summon_named_creature(player_ptr, m_idx, y, x, MonraceId::YENDOR_WIZARD_2, PM_NONE) ? 1 : 0;
-    if (count == 0) {
+    if (!summon_named_creature(player_ptr, m_idx, y, x, MonraceId::YENDOR_WIZARD_2, PM_NONE)) {
         msg_print(_("どこからか声が聞こえる…「三重苦は負わぬ。。。」", "Heard a voice from somewhere... 'I will deny the triple suffering...'"));
         return 0;
     }
 
     msg_print(_("二重苦だ。。。", "THIS is double suffering..."));
-    return count;
+    return 1;
 }
 
 MONSTER_NUMBER summon_PLASMA(PlayerType *player_ptr, POSITION y, POSITION x, int rlev, MONSTER_IDX m_idx)
@@ -333,7 +340,9 @@ MONSTER_NUMBER summon_PLASMA(PlayerType *player_ptr, POSITION y, POSITION x, int
     auto count = 0;
     auto num = 2 + randint1(1 + rlev / 20);
     for (auto k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::PLASMA_VORTEX, PM_NONE) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, y, x, MonraceId::PLASMA_VORTEX, PM_NONE)) {
+            count++;
+        }
     }
 
     msg_print(_("プーラーズーマーッ！！", "P--la--s--ma--!!"));
@@ -378,7 +387,9 @@ MONSTER_NUMBER summon_LAFFEY_II(PlayerType *player_ptr, const Pos2D &position, M
         }
     }
     for (auto k = 0; k < real_num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, position.y, position.x, MonraceId::BUNBUN_STRIKERS, PM_NONE) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, position.y, position.x, MonraceId::BUNBUN_STRIKERS, PM_NONE)) {
+            count++;
+        }
     }
     return count;
 }
@@ -388,7 +399,9 @@ MONSTER_NUMBER summon_POLYGON(PlayerType *player_ptr, POSITION y, POSITION x, MO
     auto count = 0;
     auto num = 2 + randint1(3);
     for (auto k = 0; k < num; k++) {
-        count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::POLYGON_SPIN, PM_NONE) ? 1 : 0;
+        if (summon_named_creature(player_ptr, m_idx, y, x, MonraceId::POLYGON_SPIN, PM_NONE)) {
+            count++;
+        }
     }
 
     return count;


### PR DESCRIPTION
#5542 の対応。

## 変更内容

### 1. `summon_named_creature()` の失敗パスを `tl::nullopt` にする

戻り値の型は `tl::optional<MONSTER_IDX>` で Doxygen コメントにも「失敗したら `tl::nullopt`」と書かれているが、実装の失敗パス 3 箇所がすべて `return false;` になっていた。

`MONSTER_IDX` は整数型の typedef なので `bool` から暗黙変換でき、`tl::optional` の変換コンストラクタが非 explicit である。その結果 `return false;` は **値 0 を保持する有効な optional** を構築し、呼び出し側の bool 評価が真になっていた。

闘技場の中にいる場合と、召喚先に空きグリッドが無い場合（水棲モンスターを陸上に召喚しようとした場合など）が該当する。

### 2. 呼び出し側の成否判定を条件分岐にする

```cpp
count += summon_named_creature(player_ptr, m_idx, y, x, MonraceId::EDGE, PM_NONE) ? 1 : 0;
```

この書き方は `tl::optional<MONSTER_IDX>` の真偽と保持している値の区別が付きにくく、今回の不具合が長く残る一因になっていた。召喚に成功したときだけ数える意図が読み取れるよう、`if` 文に書き換えた。

`summon_YENDER_WIZARD()` は 1 体しか召喚しないので、`count` 変数を持たずに早期 return する形に整理した。

## 確認したこと

- `make -j$(nproc)`（日本語版）が警告・エラーなしで通ること
- `make check` が通ること（既存テストのみ、追加なし）
- `clang-format` の差分が出ないこと
- 制御サーバ経由でヘッドレス起動し、ウィザードコマンドの召喚（`summon_named_creature()` を通る経路）で従来どおりモンスターが生成されること

`tl::optional<short>` に `return false;` を書くと `has_value() == true` かつ値 0 になることは、`src/external-lib/include/tl/optional.hpp` を使った単体プログラムで確認した。

グローバル状態への依存が強くユニットテストを書けないため、失敗パスそのものの自動テストは追加していない。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * モンスター召喚に失敗した場合の結果が正しく扱われるようになりました。
  * 各種召喚処理で、召喚成功数が正確にカウントされるようになりました。
  * 召喚に失敗した際の処理を整理し、不要な処理が継続されないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->