### PR TITLE
[Feature] セーブデータのバージョン比較のユニットテストを追加する

### DIFF
--- a/VisualStudio/Hengband/HengbandTest.vcxproj
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj
@@ -60,6 +60,7 @@
     <ClCompile Include="..\..\src\test\info-reader\test-info-reader-util.cpp" />
     <ClCompile Include="..\..\src\test\info-reader\test-json-reader-util.cpp" />
     <ClCompile Include="..\..\src\test\info-reader\test-skill-reader.cpp" />
+    <ClCompile Include="..\..\src\test\load\test-angband-version-comparer.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-player-stun.cpp" />
     <ClCompile Include="..\..\src\test\timed-effect\test-timed-effect.cpp" />

--- a/VisualStudio/Hengband/HengbandTest.vcxproj.filters
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj.filters
@@ -4,6 +4,9 @@
     <Filter Include="info-reader">
       <UniqueIdentifier>{5a5d0f27-6c1e-4c8b-9f34-2b7d8e1a6c40}</UniqueIdentifier>
     </Filter>
+    <Filter Include="load">
+      <UniqueIdentifier>{3c217089-cb3c-4a88-9b0a-e642a6bf402d}</UniqueIdentifier>
+    </Filter>
     <Filter Include="timed-effect">
       <UniqueIdentifier>{713ac6ea-8881-48d4-beac-cf75e9e6b037}</UniqueIdentifier>
     </Filter>
@@ -22,6 +25,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\test\info-reader\test-skill-reader.cpp">
       <Filter>info-reader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\load\test-angband-version-comparer.cpp">
+      <Filter>load</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\timed-effect\test-player-cut.cpp">
       <Filter>timed-effect</Filter>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1492,6 +1492,7 @@ hengband_test_SOURCES = \
 	test/info-reader/test-info-reader-util.cpp \
 	test/info-reader/test-json-reader-util.cpp \
 	test/info-reader/test-skill-reader.cpp \
+	test/load/test-angband-version-comparer.cpp \
 	test/timed-effect/test-player-cut.cpp \
 	test/timed-effect/test-player-stun.cpp \
 	test/timed-effect/test-timed-effect.cpp \

--- a/src/test/load/test-angband-version-comparer.cpp
+++ b/src/test/load/test-angband-version-comparer.cpp
@@ -1,0 +1,95 @@
+/*!
+ * @brief セーブデータのバージョン比較のテスト
+ */
+
+#include "load/angband-version-comparer.h"
+#include "system/angband-system.h"
+#include "system/angband-version.h"
+#include "util/finalizer.h"
+#include <doctest/doctest.h>
+
+namespace {
+
+struct VersionComparison {
+    AngbandVersion loaded;
+    AngbandVersion threshold;
+    bool older;
+};
+
+}
+
+TEST_CASE("h_older_than compares the loaded version in component order")
+{
+    auto &system = AngbandSystem::get_instance();
+    const auto restore_version = util::make_finalizer([&system, saved = system.get_version()]() { system.set_version(saved); });
+
+    // 下位桁が逆転していても、最初に異なる上位桁で判定する。
+    constexpr VersionComparison cases[] = {
+        { { 3, 2, 4, 6 }, { 3, 2, 4, 6 }, false },
+        { { 2, 255, 255, 255 }, { 3, 0, 0, 0 }, true },
+        { { 3, 0, 0, 0 }, { 2, 255, 255, 255 }, false },
+        { { 3, 1, 255, 255 }, { 3, 2, 0, 0 }, true },
+        { { 3, 2, 0, 0 }, { 3, 1, 255, 255 }, false },
+        { { 3, 2, 3, 255 }, { 3, 2, 4, 0 }, true },
+        { { 3, 2, 4, 0 }, { 3, 2, 3, 255 }, false },
+        { { 3, 2, 4, 5 }, { 3, 2, 4, 6 }, true },
+        { { 3, 2, 4, 7 }, { 3, 2, 4, 6 }, false },
+        { { 0, 0, 0, 0 }, { 0, 0, 0, 0 }, false },
+        { { 255, 255, 255, 255 }, { 255, 255, 255, 255 }, false },
+        { { 0, 0, 0, 0 }, { 0, 0, 0, 255 }, true },
+        { { 0, 0, 0, 255 }, { 0, 0, 0, 0 }, false },
+    };
+
+    for (const auto &entry : cases) {
+        CAPTURE(static_cast<int>(entry.loaded.major));
+        CAPTURE(static_cast<int>(entry.loaded.minor));
+        CAPTURE(static_cast<int>(entry.loaded.patch));
+        CAPTURE(static_cast<int>(entry.loaded.extra));
+        CAPTURE(static_cast<int>(entry.threshold.major));
+        CAPTURE(static_cast<int>(entry.threshold.minor));
+        CAPTURE(static_cast<int>(entry.threshold.patch));
+        CAPTURE(static_cast<int>(entry.threshold.extra));
+        system.set_version(entry.loaded);
+        CHECK(h_older_than(entry.threshold.major, entry.threshold.minor, entry.threshold.patch, entry.threshold.extra) == entry.older);
+    }
+}
+
+TEST_CASE("h_older_than legacy comparison gives priority to major minor and patch")
+{
+    auto &system = AngbandSystem::get_instance();
+    const auto restore_version = util::make_finalizer([&system, saved = system.get_version()]() { system.set_version(saved); });
+
+    constexpr VersionComparison cases[] = {
+        { { 2, 255, 255, 255 }, { 3, 0, 0, 0 }, true },
+        { { 3, 0, 0, 0 }, { 2, 255, 255, 0 }, false },
+        { { 3, 1, 255, 255 }, { 3, 2, 0, 0 }, true },
+        { { 3, 2, 0, 0 }, { 3, 1, 255, 0 }, false },
+        { { 3, 2, 3, 255 }, { 3, 2, 4, 0 }, true },
+        { { 3, 2, 4, 0 }, { 3, 2, 3, 0 }, false },
+        { { 0, 0, 0, 255 }, { 0, 0, 0, 0 }, false },
+        { { 255, 255, 255, 255 }, { 255, 255, 255, 0 }, false },
+    };
+
+    for (const auto &entry : cases) {
+        CAPTURE(static_cast<int>(entry.loaded.major));
+        CAPTURE(static_cast<int>(entry.loaded.minor));
+        CAPTURE(static_cast<int>(entry.loaded.patch));
+        CAPTURE(static_cast<int>(entry.threshold.major));
+        CAPTURE(static_cast<int>(entry.threshold.minor));
+        CAPTURE(static_cast<int>(entry.threshold.patch));
+        system.set_version(entry.loaded);
+        CHECK(h_older_than(entry.threshold.major, entry.threshold.minor, entry.threshold.patch) == entry.older);
+    }
+}
+
+TEST_CASE("h_older_than legacy comparison ignores every extra version")
+{
+    auto &system = AngbandSystem::get_instance();
+    const auto restore_version = util::make_finalizer([&system, saved = system.get_version()]() { system.set_version(saved); });
+
+    for (int extra = 0; extra <= 255; ++extra) {
+        CAPTURE(extra);
+        system.set_version({ 3, 2, 4, static_cast<uint8_t>(extra) });
+        CHECK_FALSE(h_older_than(3, 2, 4));
+    }
+}


### PR DESCRIPTION
## 概要

セーブデータ互換性の判定に使う `h_older_than()` にユニットテストを追加します。ゲーム本体の処理は変更しません。

- 4引数版で、major / minor / patch / extra の優先順位、同一バージョン、0・255の境界値を検証します。
- 旧3引数版の比較順序と、extra の全256値を無視する挙動を検証します。
- 各テストで変更する `AngbandSystem` のバージョンは、スコープ終了時に復元します。
- autotools と Visual Studio の両方にテストを登録します。

## 検証

- Windows Debug: 全93ケース・11,380アサーション成功。
- Linux 日本語版（GCC 13.3、`--disable-pch`）: 増分ビルドと `make check` 成功。全94ケース・11,386アサーション成功。
- Linux 英語版（GCC 13.3、`--disable-pch --disable-japanese`）: 増分ビルドと `make check` 成功。全94ケース・11,385アサーション成功。
- 追加分は全環境で3ケース・277アサーション成功。
- テスト登録チェック・書式チェック成功。Fableによるレビューで要修正の指摘なし。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * バージョン比較機能について、major・minor・patch・extra の各成分を考慮した比較動作を検証するテストを追加しました。
  * レガシー形式のバージョン比較や、extra 成分を無視するケースも検証対象に含めました。
  * 追加したテストを各種ビルド環境で実行できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->