### PR TITLE
[Refactor] string-processor の整理とユニットテストの追加

### DIFF
--- a/VisualStudio/Hengband/HengbandTest.vcxproj
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj
@@ -68,6 +68,7 @@
     <ClCompile Include="..\..\src\test\util\test-flag-group.cpp" />
     <ClCompile Include="..\..\src\test\util\test-probability-table.cpp" />
     <ClCompile Include="..\..\src\test\util\test-sha256.cpp" />
+    <ClCompile Include="..\..\src\test\util\test-string-processor.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\stdafx.h" />

--- a/VisualStudio/Hengband/HengbandTest.vcxproj.filters
+++ b/VisualStudio/Hengband/HengbandTest.vcxproj.filters
@@ -50,6 +50,9 @@
     <ClCompile Include="..\..\src\test\util\test-sha256.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\util\test-string-processor.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\stdafx.h" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1499,7 +1499,8 @@ hengband_test_SOURCES = \
 	test/util/test-dice.cpp \
 	test/util/test-flag-group.cpp \
 	test/util/test-probability-table.cpp \
-	test/util/test-sha256.cpp
+	test/util/test-sha256.cpp \
+	test/util/test-string-processor.cpp
 
 hengband_test_LDADD = libhengband.a
 

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -10,7 +10,6 @@
 #include "system/monrace/monrace-message.h"
 #include "system/system-variables.h"
 #include "util/enum-converter.h"
-#include "util/string-processor.h"
 #include "world/world.h"
 #include <algorithm>
 #ifdef JP
@@ -580,7 +579,7 @@ bool MonraceDefinition::is_catchable_for_fishing() const
 {
     auto is_catchable = this->feature_flags.has(MonsterFeatureType::AQUATIC);
     is_catchable &= this->kind_flags.has_not(MonsterKindType::UNIQUE);
-    is_catchable &= str_find("Jjlw", &this->symbol_definition.character);
+    is_catchable &= this->symbol_char_is_any_of("Jjlw");
     return is_catchable;
 }
 

--- a/src/test/util/test-string-processor.cpp
+++ b/src/test/util/test-string-processor.cpp
@@ -46,14 +46,12 @@ std::string cat(const Args &...args)
     return result;
 }
 
-#ifdef JP
-#ifdef SJIS
+#if defined(JP) && defined(SJIS)
 constexpr std::string_view KANJI_KAN = "\x8a\xbf"; //!< 漢
 constexpr std::string_view KANJI_JI = "\x8e\x9a"; //!< 字
-#else
+#elif defined(JP)
 constexpr std::string_view KANJI_KAN = "\xb4\xc1"; //!< 漢
 constexpr std::string_view KANJI_JI = "\xbb\xfa"; //!< 字
-#endif
 #endif
 
 #if defined(JP) && defined(SJIS)
@@ -125,25 +123,27 @@ TEST_CASE("angband_strcpy truncates the string to fit the buffer")
     CHECK(std::string_view(buf) == "abc");
 }
 
-TEST_CASE("angband_strcpy terminates the buffer even with an empty source")
+TEST_CASE("angband_strcpy does not write beyond the buffer size")
 {
-    char buf[4] = "xyz";
-    CHECK(angband_strcpy(buf, "", sizeof(buf)) == 0);
-    CHECK(std::string_view(buf).empty());
-}
+    char buf[4] = "xyz"; // 各SUBCASEごとに作り直される
 
-TEST_CASE("angband_strcpy writes nothing when the buffer size is one")
-{
-    char buf[4] = "xyz";
-    CHECK(angband_strcpy(buf, "abc", 1) == 3);
-    CHECK(std::string_view(buf).empty());
-}
+    SUBCASE("an empty source only terminates the buffer")
+    {
+        CHECK(angband_strcpy(buf, "", sizeof(buf)) == 0);
+        CHECK(std::string_view(buf).empty());
+    }
 
-TEST_CASE("angband_strcpy writes nothing when the buffer size is zero")
-{
-    char buf[4] = "xyz";
-    CHECK(angband_strcpy(buf, "abc", 0) == 3);
-    CHECK(std::string_view(buf) == "xyz");
+    SUBCASE("a buffer size of one writes only the terminator")
+    {
+        CHECK(angband_strcpy(buf, "abc", 1) == 3);
+        CHECK(std::string_view(buf).empty());
+    }
+
+    SUBCASE("a buffer size of zero writes nothing")
+    {
+        CHECK(angband_strcpy(buf, "abc", 0) == 3);
+        CHECK(std::string_view(buf) == "xyz");
+    }
 }
 
 TEST_CASE("angband_strcpy looks only at the range of the given view")
@@ -169,16 +169,15 @@ TEST_CASE("angband_strcat truncates the appended string")
     CHECK(std::string_view(buf) == "abcd");
 }
 
-TEST_CASE("angband_strcat leaves the buffer untouched when it is already full")
+TEST_CASE("angband_strcat leaves the buffer untouched when it cannot append")
 {
     char buf[4] = "abc";
+
+    // バッファが既に一杯の場合
     CHECK(angband_strcat(buf, "def", sizeof(buf)) == 6);
     CHECK(std::string_view(buf) == "abc");
-}
 
-TEST_CASE("angband_strcat writes nothing when the buffer size is zero")
-{
-    char buf[4] = "abc";
+    // バッファサイズが0の場合
     CHECK(angband_strcat(buf, "def", 0) == 6);
     CHECK(std::string_view(buf) == "abc");
 }

--- a/src/test/util/test-string-processor.cpp
+++ b/src/test/util/test-string-processor.cpp
@@ -16,6 +16,11 @@
  * 日本語版のビルドはソースの文字列リテラルを変換する (autotoolsは gcc-wrap が nkf で
  * EUC-JPへ、MSVCは /execution-charset:shift-jis でShift_JISへ) が、英語版では変換されない。
  * ソースに日本語をそのまま書くと、ビルド構成によってバイト列が変わってしまう。
+ *
+ * @details 引数に暗黙の型変換を伴う関数呼び出し (文字列リテラルを std::string_view や
+ * std::string を取る引数へ渡すものなど) を CHECK に直接書くと、MSVCが評価順序に関する
+ * 警告 (C4866) を出す。この警告はエラーとして扱われるため、呼び出しの結果は一旦変数で
+ * 受けてから比較する。
  */
 
 #include "util/string-processor.h"
@@ -70,47 +75,67 @@ constexpr std::string_view DAME_SPACE = "\x81\x40"; //!< 全角スペース (後
 
 TEST_CASE("str_to_num converts a decimal string")
 {
-    CHECK(str_to_num<int>("123") == 123);
-    CHECK(str_to_num<int>("-123") == -123);
-    CHECK(str_to_num<int>("0") == 0);
+    const auto positive = str_to_num<int>("123");
+    CHECK(positive == 123);
+
+    const auto negative = str_to_num<int>("-123");
+    CHECK(negative == -123);
+
+    const auto zero = str_to_num<int>("0");
+    CHECK(zero == 0);
 }
 
 TEST_CASE("str_to_num converts a string in the specified base")
 {
-    CHECK(str_to_num<int>("ff", 16) == 255);
-    CHECK(str_to_num<int>("1010", 2) == 10);
-    CHECK(str_to_num<int>("z", 36) == 35);
+    const auto hexadecimal = str_to_num<int>("ff", 16);
+    CHECK(hexadecimal == 255);
+
+    const auto binary = str_to_num<int>("1010", 2);
+    CHECK(binary == 10);
+
+    const auto base36 = str_to_num<int>("z", 36);
+    CHECK(base36 == 35);
 }
 
 TEST_CASE("str_to_num rejects a string which is not entirely a number")
 {
-    CHECK_FALSE(str_to_num<int>("").has_value());
-    CHECK_FALSE(str_to_num<int>("12a").has_value());
-    CHECK_FALSE(str_to_num<int>("12 ").has_value());
-    CHECK_FALSE(str_to_num<int>(" 12").has_value());
+    // 先頭の空白や + 、基数の接頭辞は解釈しない
+    for (const auto *const text : { "", "12a", "12 ", " 12", "+12" }) {
+        CAPTURE(text);
+        const auto value = str_to_num<int>(text);
+        CHECK_FALSE(value.has_value());
+    }
 
-    // 先頭の + や基数の接頭辞は解釈しない
-    CHECK_FALSE(str_to_num<int>("+12").has_value());
-    CHECK_FALSE(str_to_num<int>("0x10", 16).has_value());
+    const auto prefixed = str_to_num<int>("0x10", 16);
+    CHECK_FALSE(prefixed.has_value());
 }
 
 TEST_CASE("str_to_num rejects a base out of range")
 {
-    CHECK_FALSE(str_to_num<int>("1", 1).has_value());
-    CHECK_FALSE(str_to_num<int>("1", 37).has_value());
+    const auto too_small = str_to_num<int>("1", 1);
+    CHECK_FALSE(too_small.has_value());
+
+    const auto too_large = str_to_num<int>("1", 37);
+    CHECK_FALSE(too_large.has_value());
 }
 
 TEST_CASE("str_to_num rejects a value which does not fit in the type")
 {
-    CHECK(str_to_num<uint8_t>("255") == 255);
-    CHECK_FALSE(str_to_num<uint8_t>("256").has_value());
-    CHECK_FALSE(str_to_num<uint8_t>("-1").has_value());
+    const auto max = str_to_num<uint8_t>("255");
+    CHECK(max == 255);
+
+    const auto overflow = str_to_num<uint8_t>("256");
+    CHECK_FALSE(overflow.has_value());
+
+    const auto negative = str_to_num<uint8_t>("-1");
+    CHECK_FALSE(negative.has_value());
 }
 
 TEST_CASE("angband_strcpy copies the whole string when it fits")
 {
     char buf[16] = {};
-    CHECK(angband_strcpy(buf, "abc", sizeof(buf)) == 3);
+    const auto length = angband_strcpy(buf, "abc", sizeof(buf));
+    CHECK(length == 3);
     CHECK(std::string_view(buf) == "abc");
 }
 
@@ -119,7 +144,8 @@ TEST_CASE("angband_strcpy truncates the string to fit the buffer")
     char buf[4] = {};
 
     // 戻り値は切り詰める前のバイト数なので、bufsize と比べて切り詰めの有無が分かる
-    CHECK(angband_strcpy(buf, "abcdef", sizeof(buf)) == 6);
+    const auto length = angband_strcpy(buf, "abcdef", sizeof(buf));
+    CHECK(length == 6);
     CHECK(std::string_view(buf) == "abc");
 }
 
@@ -129,19 +155,22 @@ TEST_CASE("angband_strcpy does not write beyond the buffer size")
 
     SUBCASE("an empty source only terminates the buffer")
     {
-        CHECK(angband_strcpy(buf, "", sizeof(buf)) == 0);
+        const auto length = angband_strcpy(buf, "", sizeof(buf));
+        CHECK(length == 0);
         CHECK(std::string_view(buf).empty());
     }
 
     SUBCASE("a buffer size of one writes only the terminator")
     {
-        CHECK(angband_strcpy(buf, "abc", 1) == 3);
+        const auto length = angband_strcpy(buf, "abc", 1);
+        CHECK(length == 3);
         CHECK(std::string_view(buf).empty());
     }
 
     SUBCASE("a buffer size of zero writes nothing")
     {
-        CHECK(angband_strcpy(buf, "abc", 0) == 3);
+        const auto length = angband_strcpy(buf, "abc", 0);
+        CHECK(length == 3);
         CHECK(std::string_view(buf) == "xyz");
     }
 }
@@ -151,21 +180,24 @@ TEST_CASE("angband_strcpy looks only at the range of the given view")
     // NUL終端されていない部分ビューを渡しても、ビューの範囲を越えて読まない
     constexpr std::string_view src = "abcdef";
     char buf[16] = {};
-    CHECK(angband_strcpy(buf, src.substr(0, 3), sizeof(buf)) == 3);
+    const auto length = angband_strcpy(buf, src.substr(0, 3), sizeof(buf));
+    CHECK(length == 3);
     CHECK(std::string_view(buf) == "abc");
 }
 
 TEST_CASE("angband_strcat appends to the existing string")
 {
     char buf[16] = "abc";
-    CHECK(angband_strcat(buf, "def", sizeof(buf)) == 6);
+    const auto length = angband_strcat(buf, "def", sizeof(buf));
+    CHECK(length == 6);
     CHECK(std::string_view(buf) == "abcdef");
 }
 
 TEST_CASE("angband_strcat truncates the appended string")
 {
     char buf[5] = "abc";
-    CHECK(angband_strcat(buf, "def", sizeof(buf)) == 6);
+    const auto length = angband_strcat(buf, "def", sizeof(buf));
+    CHECK(length == 6);
     CHECK(std::string_view(buf) == "abcd");
 }
 
@@ -174,34 +206,51 @@ TEST_CASE("angband_strcat leaves the buffer untouched when it cannot append")
     char buf[4] = "abc";
 
     // バッファが既に一杯の場合
-    CHECK(angband_strcat(buf, "def", sizeof(buf)) == 6);
+    const auto full_length = angband_strcat(buf, "def", sizeof(buf));
+    CHECK(full_length == 6);
     CHECK(std::string_view(buf) == "abc");
 
     // バッファサイズが0の場合
-    CHECK(angband_strcat(buf, "def", 0) == 6);
+    const auto zero_length = angband_strcat(buf, "def", 0);
+    CHECK(zero_length == 6);
     CHECK(std::string_view(buf) == "abc");
 }
 
 TEST_CASE("angband_strstr finds the first occurrence of the needle")
 {
     constexpr const char *haystack = "abcabc";
-    CHECK(angband_strstr(haystack, "abc") == haystack);
-    CHECK(angband_strstr(haystack, "bc") == haystack + 1);
-    CHECK(angband_strstr(haystack, "c") == haystack + 2);
+
+    const auto *at_head = angband_strstr(haystack, "abc");
+    CHECK(at_head == haystack);
+
+    const auto *at_middle = angband_strstr(haystack, "bc");
+    CHECK(at_middle == haystack + 1);
+
+    const auto *at_tail = angband_strstr(haystack, "c");
+    CHECK(at_tail == haystack + 2);
 }
 
 TEST_CASE("angband_strstr returns nullptr when the needle is not found")
 {
     constexpr const char *haystack = "abc";
-    CHECK(angband_strstr(haystack, "d") == nullptr);
-    CHECK(angband_strstr(haystack, "abcd") == nullptr);
-    CHECK(angband_strstr("", "a") == nullptr);
+
+    const auto *absent = angband_strstr(haystack, "d");
+    CHECK(absent == nullptr);
+
+    // needle の方が長い場合
+    const auto *too_long = angband_strstr(haystack, "abcd");
+    CHECK(too_long == nullptr);
+
+    const auto *in_empty = angband_strstr("", "a");
+    CHECK(in_empty == nullptr);
 }
 
 TEST_CASE("angband_strstr returns the head of the haystack for an empty needle")
 {
     constexpr const char *haystack = "abc";
-    CHECK(angband_strstr(haystack, "") == haystack);
+
+    const auto *found = angband_strstr(haystack, "");
+    CHECK(found == haystack);
 }
 
 TEST_CASE("angband_strchr finds the first occurrence of the character")
@@ -263,42 +312,64 @@ TEST_CASE("rtrim accepts a string which consists of spaces or is empty")
 
 TEST_CASE("str_find tells whether the string contains the substring")
 {
-    CHECK(str_find("abcdef", "cde"));
-    CHECK(str_find("abcdef", "abcdef"));
-    CHECK_FALSE(str_find("abcdef", "cdf"));
-    CHECK_FALSE(str_find("", "a"));
-
     // 空文字列はどの文字列にも含まれる
-    CHECK(str_find("abcdef", ""));
+    for (const auto *const find : { "cde", "abcdef", "" }) {
+        CAPTURE(find);
+        const auto found = str_find("abcdef", find);
+        CHECK(found);
+    }
+
+    const auto absent = str_find("abcdef", "cdf");
+    CHECK_FALSE(absent);
+
+    const auto in_empty = str_find("", "a");
+    CHECK_FALSE(in_empty);
 }
 
 TEST_CASE("str_trim removes the spaces and tabs at both ends")
 {
-    CHECK(str_trim(" \t abc \t ") == "abc");
-    CHECK(str_trim("abc") == "abc");
+    const auto trimmed = str_trim(" \t abc \t ");
+    CHECK(trimmed == "abc");
+
+    const auto unchanged = str_trim("abc");
+    CHECK(unchanged == "abc");
 
     // 内側の空白は残る
-    CHECK(str_trim(" a b ") == "a b");
+    const auto inner_kept = str_trim(" a b ");
+    CHECK(inner_kept == "a b");
 }
 
 TEST_CASE("str_trim returns an empty string when the whole string is blank")
 {
-    CHECK(str_trim(" \t ").empty());
-    CHECK(str_trim("").empty());
+    const auto blank = str_trim(" \t ");
+    CHECK(blank.empty());
+
+    const auto empty = str_trim("");
+    CHECK(empty.empty());
 }
 
 TEST_CASE("str_rtrim removes the spaces and tabs at the right end only")
 {
-    CHECK(str_rtrim(" \t abc \t ") == " \t abc");
-    CHECK(str_rtrim(" \t ").empty());
-    CHECK(str_rtrim("").empty());
+    const auto trimmed = str_rtrim(" \t abc \t ");
+    CHECK(trimmed == " \t abc");
+
+    const auto blank = str_rtrim(" \t ");
+    CHECK(blank.empty());
+
+    const auto empty = str_rtrim("");
+    CHECK(empty.empty());
 }
 
 TEST_CASE("str_ltrim removes the spaces and tabs at the left end only")
 {
-    CHECK(str_ltrim(" \t abc \t ") == "abc \t ");
-    CHECK(str_ltrim(" \t ").empty());
-    CHECK(str_ltrim("").empty());
+    const auto trimmed = str_ltrim(" \t abc \t ");
+    CHECK(trimmed == "abc \t ");
+
+    const auto blank = str_ltrim(" \t ");
+    CHECK(blank.empty());
+
+    const auto empty = str_ltrim("");
+    CHECK(empty.empty());
 }
 
 TEST_CASE("str_split splits the string at the delimiter")
@@ -343,7 +414,8 @@ TEST_CASE("str_split trims each element when requested")
 TEST_CASE("str_split does not pad the result up to the reserve hint")
 {
     // num は領域確保のヒントであり、要素数を揃えるものではない
-    CHECK(str_split("a:b", ':', false, 10).size() == 2);
+    const auto tokens = str_split("a:b", ':', false, 10);
+    CHECK(tokens.size() == 2);
 }
 
 TEST_CASE("str_separate splits the string into chunks of the given size")
@@ -364,48 +436,70 @@ TEST_CASE("str_separate puts the remainder into the last chunk")
 
 TEST_CASE("str_separate returns an empty vector for an empty string")
 {
-    CHECK(str_separate("", 2).empty());
+    const auto parts = str_separate("", 2);
+    CHECK(parts.empty());
 }
 
 TEST_CASE("str_separate gives up when it cannot take even one byte")
 {
     // 幅0では1バイトも取り出せない。無限ループせずに打ち切る
-    CHECK(str_separate("abc", 0).empty());
+    const auto parts = str_separate("abc", 0);
+    CHECK(parts.empty());
 }
 
 TEST_CASE("str_erase removes every specified character")
 {
-    CHECK(str_erase("abcabc", "a") == "bcbc");
-    CHECK(str_erase("abcabc", "ac") == "bb");
-    CHECK(str_erase("abc", "abc").empty());
+    const auto one_char = str_erase("abcabc", "a");
+    CHECK(one_char == "bcbc");
+
+    const auto two_chars = str_erase("abcabc", "ac");
+    CHECK(two_chars == "bb");
+
+    const auto all_chars = str_erase("abc", "abc");
+    CHECK(all_chars.empty());
 }
 
 TEST_CASE("str_erase leaves the string as it is when nothing matches")
 {
-    CHECK(str_erase("abc", "xyz") == "abc");
-    CHECK(str_erase("abc", "") == "abc");
-    CHECK(str_erase("", "abc").empty());
+    const auto no_match = str_erase("abc", "xyz");
+    CHECK(no_match == "abc");
+
+    const auto no_chars = str_erase("abc", "");
+    CHECK(no_chars == "abc");
+
+    const auto empty = str_erase("", "abc");
+    CHECK(empty.empty());
 }
 
 TEST_CASE("str_replace replaces every occurrence")
 {
-    CHECK(str_replace("abcabc", "a", "X") == "XbcXbc");
-    CHECK(str_replace("abc", "abc", "X") == "X");
-    CHECK(str_replace("abc", "b", "") == "ac");
+    const auto twice = str_replace("abcabc", "a", "X");
+    CHECK(twice == "XbcXbc");
+
+    const auto whole = str_replace("abc", "abc", "X");
+    CHECK(whole == "X");
+
+    const auto removed = str_replace("abc", "b", "");
+    CHECK(removed == "ac");
 }
 
 TEST_CASE("str_replace prefers the earlier match when the matches overlap")
 {
-    CHECK(str_replace("aaa", "aa", "X") == "Xa");
+    const auto replaced = str_replace("aaa", "aa", "X");
+    CHECK(replaced == "Xa");
 }
 
 TEST_CASE("str_replace leaves the string as it is when nothing matches")
 {
-    CHECK(str_replace("abc", "x", "y") == "abc");
-    CHECK(str_replace("", "x", "y").empty());
+    const auto no_match = str_replace("abc", "x", "y");
+    CHECK(no_match == "abc");
+
+    const auto in_empty = str_replace("", "x", "y");
+    CHECK(in_empty.empty());
 
     // 置き換え元が空文字列なら何もしない
-    CHECK(str_replace("abc", "", "X") == "abc");
+    const auto empty_old = str_replace("abc", "", "X");
+    CHECK(empty_old == "abc");
 }
 
 TEST_CASE("str_substr takes the substring at the given position")
@@ -434,27 +528,41 @@ TEST_CASE("str_substr accepts a rvalue string and a pointer to a string")
 
 TEST_CASE("str_toupper converts the alphabets to upper case")
 {
-    CHECK(str_toupper("abcXYZ 123!") == "ABCXYZ 123!");
-    CHECK(str_toupper("").empty());
+    const auto converted = str_toupper("abcXYZ 123!");
+    CHECK(converted == "ABCXYZ 123!");
+
+    const auto empty = str_toupper("");
+    CHECK(empty.empty());
 }
 
 TEST_CASE("str_tolower converts the alphabets to lower case")
 {
-    CHECK(str_tolower("abcXYZ 123!") == "abcxyz 123!");
-    CHECK(str_tolower("").empty());
+    const auto converted = str_tolower("abcXYZ 123!");
+    CHECK(converted == "abcxyz 123!");
+
+    const auto empty = str_tolower("");
+    CHECK(empty.empty());
 }
 
 TEST_CASE("str_upcase_first converts only the first character")
 {
-    CHECK(str_upcase_first("abc def") == "Abc def");
-    CHECK(str_upcase_first("Abc") == "Abc");
+    const auto converted = str_upcase_first("abc def");
+    CHECK(converted == "Abc def");
+
+    const auto already_upper = str_upcase_first("Abc");
+    CHECK(already_upper == "Abc");
 }
 
 TEST_CASE("str_upcase_first leaves a string which does not start with an alphabet")
 {
-    CHECK(str_upcase_first("1abc") == "1abc");
-    CHECK(str_upcase_first(" abc") == " abc");
-    CHECK(str_upcase_first("").empty());
+    const auto digit = str_upcase_first("1abc");
+    CHECK(digit == "1abc");
+
+    const auto space = str_upcase_first(" abc");
+    CHECK(space == " abc");
+
+    const auto empty = str_upcase_first("");
+    CHECK(empty.empty());
 }
 
 TEST_CASE("extract_suffix extracts the substring from the found character")
@@ -467,8 +575,11 @@ TEST_CASE("extract_suffix extracts the substring from the found character")
     REQUIRE(at_head.has_value());
     CHECK(*at_head == "@abc");
 
-    CHECK_FALSE(extract_suffix("abc", '@').has_value());
-    CHECK_FALSE(extract_suffix("", '@').has_value());
+    const auto absent = extract_suffix("abc", '@');
+    CHECK_FALSE(absent.has_value());
+
+    const auto in_empty = extract_suffix("", '@');
+    CHECK_FALSE(in_empty.has_value());
 }
 
 TEST_CASE("extract_suffix extracts the substring from the found string")
@@ -477,7 +588,8 @@ TEST_CASE("extract_suffix extracts the substring from the found string")
     REQUIRE(found.has_value());
     CHECK(*found == "cdef");
 
-    CHECK_FALSE(extract_suffix("abcdef", "xy").has_value());
+    const auto absent = extract_suffix("abcdef", "xy");
+    CHECK_FALSE(absent.has_value());
 
     // 空文字列は先頭で見つかる
     const auto empty_needle = extract_suffix("abc", "");
@@ -613,7 +725,9 @@ TEST_CASE("str_find_all_multibyte_chars returns the index of each leading byte")
 {
     const std::set<int> expected = { 1, 4 };
     CHECK(str_find_all_multibyte_chars(cat("a", KANJI_KAN, "b", KANJI_JI)) == expected);
-    CHECK(str_find_all_multibyte_chars("abc").empty());
+
+    const auto ascii_only = str_find_all_multibyte_chars("abc");
+    CHECK(ascii_only.empty());
 }
 
 TEST_CASE("string-processor accepts a two byte character which lacks its trailing byte")
@@ -625,15 +739,25 @@ TEST_CASE("string-processor accepts a two byte character which lacks its trailin
     CHECK(str_toupper(str) == cat("A", KANJI_KAN.substr(0, 1)));
     CHECK(str_tolower(str) == str);
 
-    CHECK(str_erase(str, "x") == str);
+    const auto erased = str_erase(str, "x");
+    CHECK(erased == str);
+
+    const auto replaced = str_replace(str, "x", "y");
+    CHECK(replaced == str);
+
+    const auto found = str_find(str, "x");
+    CHECK_FALSE(found);
+
     CHECK(str_substr(std::string_view(str), 2).empty());
-    CHECK(str_replace(str, "x", "y") == str);
     CHECK(str_split(str, ':').size() == 1);
-    CHECK_FALSE(str_find(str, "x"));
 
     // 終端を越えて読まずに、見つからないと答えて終わる
-    CHECK(angband_strchr(str.data(), 'x') == nullptr);
-    CHECK(angband_strstr(str.data(), "x") == nullptr);
+    const auto *absent_char = angband_strchr(str.data(), 'x');
+    CHECK(absent_char == nullptr);
+
+    const auto *absent_str = angband_strstr(str.data(), "x");
+    CHECK(absent_str == nullptr);
+
     CHECK(angband_strchr(str.data(), 'a') == str.data());
 
     const std::set<int> expected = { 1 };
@@ -659,13 +783,19 @@ TEST_CASE("angband_strstr does not match from the trailing byte of a two byte ch
 {
     // 単純なバイト列としては "\\a" が一致するが、2バイト文字の途中なのでマッチしない
     const auto str = cat(DAME_SO, "a");
-    CHECK(angband_strstr(str.data(), "\\a") == nullptr);
+    const auto *found = angband_strstr(str.data(), "\\a");
+    CHECK(found == nullptr);
 }
 
 TEST_CASE("str_find does not match from the trailing byte of a two byte character")
 {
-    CHECK_FALSE(str_find(cat(DAME_SO, "a"), "\\a"));
-    CHECK(str_find(cat(DAME_SO, "a"), "a"));
+    const auto str = cat(DAME_SO, "a");
+
+    const auto across_char = str_find(str, "\\a");
+    CHECK_FALSE(across_char);
+
+    const auto ascii_only = str_find(str, "a");
+    CHECK(ascii_only);
 }
 
 TEST_CASE("str_split does not split at the trailing byte of a two byte character")
@@ -680,17 +810,22 @@ TEST_CASE("str_split does not split at the trailing byte of a two byte character
 TEST_CASE("str_replace does not replace the trailing byte of a two byte character")
 {
     const auto str = cat("a", DAME_SO, "b");
-    CHECK(str_replace(str, "\\", "X") == str);
+    const auto kept = str_replace(str, "\\", "X");
+    CHECK(kept == str);
 
     // 2バイト文字の一部でない '\' は置き換えられる
-    CHECK(str_replace(cat("\\", DAME_SO), "\\", "X") == cat("X", DAME_SO));
+    const auto replaced = str_replace(cat("\\", DAME_SO), "\\", "X");
+    CHECK(replaced == cat("X", DAME_SO));
 }
 
 TEST_CASE("str_erase does not break a two byte character")
 {
     const auto str = cat("a", DAME_SO, "b");
-    CHECK(str_erase(str, "\\") == str);
-    CHECK(str_erase(cat(DAME_KANA_A, "A"), "A") == DAME_KANA_A);
+    const auto kept = str_erase(str, "\\");
+    CHECK(kept == str);
+
+    const auto kana_kept = str_erase(cat(DAME_KANA_A, "A"), "A");
+    CHECK(kana_kept == DAME_KANA_A);
 }
 
 TEST_CASE("str_substr does not split a two byte character whose trailing byte is ASCII")

--- a/src/test/util/test-string-processor.cpp
+++ b/src/test/util/test-string-processor.cpp
@@ -1,0 +1,702 @@
+/*!
+ * @brief 文字列処理の汎用ユーティリティのテスト
+ *
+ * util/string-processor.h で宣言されている関数を検証する。
+ *
+ * 日本語版では2バイト文字を含む文字列の扱いが加わるため、テストを3層に分けている。
+ * - 文字コードに依存しないもの (全ビルドで実行する)
+ * - 2バイト文字を分断しないことの検証 (#ifdef JP。EUC-JPでもShift_JISでも成立する)
+ * - ダメ文字の検証 (#if defined(JP) && defined(SJIS)。Windows版でのみ実行する)
+ *
+ * ダメ文字とは、Shift_JISの2バイト文字のうち後半バイトがASCIIの範囲と重なるものを指す。
+ * EUC-JPでは後半バイトがASCIIの範囲と重ならないため、Linux/macOSのビルドでは再現できない。
+ * ダメ文字のテストはMSVCのCI (Debug構成は JP + SJIS) で実行される。
+ *
+ * 2バイト文字のテストデータは必ず16進エスケープで書くこと。
+ * 日本語版のビルドはソースの文字列リテラルを変換する (autotoolsは gcc-wrap が nkf で
+ * EUC-JPへ、MSVCは /execution-charset:shift-jis でShift_JISへ) が、英語版では変換されない。
+ * ソースに日本語をそのまま書くと、ビルド構成によってバイト列が変わってしまう。
+ */
+
+#include "util/string-processor.h"
+
+#include "system/h-basic.h"
+
+#include <doctest/doctest.h>
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+/*!
+ * @brief テストデータの文字列を連結する
+ *
+ * 16進エスケープは後続の文字まで貪欲に取り込むため ("\x83\x5c" の直後に "A" を
+ * 隣接させると "\x5cA" と解釈される)、リテラルの隣接連結を使わずにこの関数で連結する。
+ */
+template <typename... Args>
+std::string cat(const Args &...args)
+{
+    std::string result;
+    (result.append(args), ...);
+    return result;
+}
+
+#ifdef JP
+#ifdef SJIS
+constexpr std::string_view KANJI_KAN = "\x8a\xbf"; //!< 漢
+constexpr std::string_view KANJI_JI = "\x8e\x9a"; //!< 字
+#else
+constexpr std::string_view KANJI_KAN = "\xb4\xc1"; //!< 漢
+constexpr std::string_view KANJI_JI = "\xbb\xfa"; //!< 字
+#endif
+#endif
+
+#if defined(JP) && defined(SJIS)
+constexpr std::string_view DAME_SO = "\x83\x5c"; //!< ソ (後半バイトが 0x5c、ASCIIの '\')
+constexpr std::string_view DAME_HYOU = "\x95\x5c"; //!< 表 (後半バイトが 0x5c、ASCIIの '\')
+constexpr std::string_view DAME_KANA_A = "\x83\x41"; //!< ア (後半バイトが 0x41、ASCIIの 'A')
+constexpr std::string_view DAME_CHOON = "\x81\x5b"; //!< ー (後半バイトが 0x5b、ASCIIの '[')
+constexpr std::string_view DAME_SPACE = "\x81\x40"; //!< 全角スペース (後半バイトが 0x40、ASCIIの '@')
+#endif
+
+}
+
+//
+// 文字コードに依存しないテスト
+//
+
+TEST_CASE("str_to_num converts a decimal string")
+{
+    CHECK(str_to_num<int>("123") == 123);
+    CHECK(str_to_num<int>("-123") == -123);
+    CHECK(str_to_num<int>("0") == 0);
+}
+
+TEST_CASE("str_to_num converts a string in the specified base")
+{
+    CHECK(str_to_num<int>("ff", 16) == 255);
+    CHECK(str_to_num<int>("1010", 2) == 10);
+    CHECK(str_to_num<int>("z", 36) == 35);
+}
+
+TEST_CASE("str_to_num rejects a string which is not entirely a number")
+{
+    CHECK_FALSE(str_to_num<int>("").has_value());
+    CHECK_FALSE(str_to_num<int>("12a").has_value());
+    CHECK_FALSE(str_to_num<int>("12 ").has_value());
+    CHECK_FALSE(str_to_num<int>(" 12").has_value());
+
+    // 先頭の + や基数の接頭辞は解釈しない
+    CHECK_FALSE(str_to_num<int>("+12").has_value());
+    CHECK_FALSE(str_to_num<int>("0x10", 16).has_value());
+}
+
+TEST_CASE("str_to_num rejects a base out of range")
+{
+    CHECK_FALSE(str_to_num<int>("1", 1).has_value());
+    CHECK_FALSE(str_to_num<int>("1", 37).has_value());
+}
+
+TEST_CASE("str_to_num rejects a value which does not fit in the type")
+{
+    CHECK(str_to_num<uint8_t>("255") == 255);
+    CHECK_FALSE(str_to_num<uint8_t>("256").has_value());
+    CHECK_FALSE(str_to_num<uint8_t>("-1").has_value());
+}
+
+TEST_CASE("angband_strcpy copies the whole string when it fits")
+{
+    char buf[16] = {};
+    CHECK(angband_strcpy(buf, "abc", sizeof(buf)) == 3);
+    CHECK(std::string_view(buf) == "abc");
+}
+
+TEST_CASE("angband_strcpy truncates the string to fit the buffer")
+{
+    char buf[4] = {};
+
+    // 戻り値は切り詰める前のバイト数なので、bufsize と比べて切り詰めの有無が分かる
+    CHECK(angband_strcpy(buf, "abcdef", sizeof(buf)) == 6);
+    CHECK(std::string_view(buf) == "abc");
+}
+
+TEST_CASE("angband_strcpy terminates the buffer even with an empty source")
+{
+    char buf[4] = "xyz";
+    CHECK(angband_strcpy(buf, "", sizeof(buf)) == 0);
+    CHECK(std::string_view(buf).empty());
+}
+
+TEST_CASE("angband_strcpy writes nothing when the buffer size is one")
+{
+    char buf[4] = "xyz";
+    CHECK(angband_strcpy(buf, "abc", 1) == 3);
+    CHECK(std::string_view(buf).empty());
+}
+
+TEST_CASE("angband_strcpy writes nothing when the buffer size is zero")
+{
+    char buf[4] = "xyz";
+    CHECK(angband_strcpy(buf, "abc", 0) == 3);
+    CHECK(std::string_view(buf) == "xyz");
+}
+
+TEST_CASE("angband_strcpy looks only at the range of the given view")
+{
+    // NUL終端されていない部分ビューを渡しても、ビューの範囲を越えて読まない
+    constexpr std::string_view src = "abcdef";
+    char buf[16] = {};
+    CHECK(angband_strcpy(buf, src.substr(0, 3), sizeof(buf)) == 3);
+    CHECK(std::string_view(buf) == "abc");
+}
+
+TEST_CASE("angband_strcat appends to the existing string")
+{
+    char buf[16] = "abc";
+    CHECK(angband_strcat(buf, "def", sizeof(buf)) == 6);
+    CHECK(std::string_view(buf) == "abcdef");
+}
+
+TEST_CASE("angband_strcat truncates the appended string")
+{
+    char buf[5] = "abc";
+    CHECK(angband_strcat(buf, "def", sizeof(buf)) == 6);
+    CHECK(std::string_view(buf) == "abcd");
+}
+
+TEST_CASE("angband_strcat leaves the buffer untouched when it is already full")
+{
+    char buf[4] = "abc";
+    CHECK(angband_strcat(buf, "def", sizeof(buf)) == 6);
+    CHECK(std::string_view(buf) == "abc");
+}
+
+TEST_CASE("angband_strcat writes nothing when the buffer size is zero")
+{
+    char buf[4] = "abc";
+    CHECK(angband_strcat(buf, "def", 0) == 6);
+    CHECK(std::string_view(buf) == "abc");
+}
+
+TEST_CASE("angband_strstr finds the first occurrence of the needle")
+{
+    constexpr const char *haystack = "abcabc";
+    CHECK(angband_strstr(haystack, "abc") == haystack);
+    CHECK(angband_strstr(haystack, "bc") == haystack + 1);
+    CHECK(angband_strstr(haystack, "c") == haystack + 2);
+}
+
+TEST_CASE("angband_strstr returns nullptr when the needle is not found")
+{
+    constexpr const char *haystack = "abc";
+    CHECK(angband_strstr(haystack, "d") == nullptr);
+    CHECK(angband_strstr(haystack, "abcd") == nullptr);
+    CHECK(angband_strstr("", "a") == nullptr);
+}
+
+TEST_CASE("angband_strstr returns the head of the haystack for an empty needle")
+{
+    constexpr const char *haystack = "abc";
+    CHECK(angband_strstr(haystack, "") == haystack);
+}
+
+TEST_CASE("angband_strchr finds the first occurrence of the character")
+{
+    constexpr const char *str = "abcabc";
+    CHECK(angband_strchr(str, 'a') == str);
+    CHECK(angband_strchr(str, 'c') == str + 2);
+    CHECK(angband_strchr(str, 'd') == nullptr);
+    CHECK(angband_strchr("", 'a') == nullptr);
+}
+
+TEST_CASE("angband_strchr cannot find the terminating NUL")
+{
+    // strchr と異なり、終端のNUL文字は見つけられない
+    CHECK(angband_strchr("abc", '\0') == nullptr);
+}
+
+TEST_CASE("ltrim skips the leading spaces")
+{
+    char buf[] = "  abc ";
+    CHECK(std::string_view(ltrim(buf)) == "abc ");
+}
+
+TEST_CASE("ltrim does not skip a tab")
+{
+    char buf[] = "\tabc";
+    CHECK(std::string_view(ltrim(buf)) == "\tabc");
+}
+
+TEST_CASE("ltrim accepts a string which consists of spaces or is empty")
+{
+    char spaces[] = "   ";
+    CHECK(std::string_view(ltrim(spaces)).empty());
+
+    char empty[] = "";
+    CHECK(std::string_view(ltrim(empty)).empty());
+}
+
+TEST_CASE("rtrim removes the trailing spaces")
+{
+    char buf[] = " abc  ";
+    CHECK(std::string_view(rtrim(buf)) == " abc");
+}
+
+TEST_CASE("rtrim does not remove a tab")
+{
+    char buf[] = "abc\t";
+    CHECK(std::string_view(rtrim(buf)) == "abc\t");
+}
+
+TEST_CASE("rtrim accepts a string which consists of spaces or is empty")
+{
+    char spaces[] = "   ";
+    CHECK(std::string_view(rtrim(spaces)).empty());
+
+    char empty[] = "";
+    CHECK(std::string_view(rtrim(empty)).empty());
+}
+
+TEST_CASE("str_find tells whether the string contains the substring")
+{
+    CHECK(str_find("abcdef", "cde"));
+    CHECK(str_find("abcdef", "abcdef"));
+    CHECK_FALSE(str_find("abcdef", "cdf"));
+    CHECK_FALSE(str_find("", "a"));
+
+    // 空文字列はどの文字列にも含まれる
+    CHECK(str_find("abcdef", ""));
+}
+
+TEST_CASE("str_trim removes the spaces and tabs at both ends")
+{
+    CHECK(str_trim(" \t abc \t ") == "abc");
+    CHECK(str_trim("abc") == "abc");
+
+    // 内側の空白は残る
+    CHECK(str_trim(" a b ") == "a b");
+}
+
+TEST_CASE("str_trim returns an empty string when the whole string is blank")
+{
+    CHECK(str_trim(" \t ").empty());
+    CHECK(str_trim("").empty());
+}
+
+TEST_CASE("str_rtrim removes the spaces and tabs at the right end only")
+{
+    CHECK(str_rtrim(" \t abc \t ") == " \t abc");
+    CHECK(str_rtrim(" \t ").empty());
+    CHECK(str_rtrim("").empty());
+}
+
+TEST_CASE("str_ltrim removes the spaces and tabs at the left end only")
+{
+    CHECK(str_ltrim(" \t abc \t ") == "abc \t ");
+    CHECK(str_ltrim(" \t ").empty());
+    CHECK(str_ltrim("").empty());
+}
+
+TEST_CASE("str_split splits the string at the delimiter")
+{
+    const auto tokens = str_split("a:bb:ccc", ':');
+    REQUIRE(tokens.size() == 3);
+    CHECK(tokens[0] == "a");
+    CHECK(tokens[1] == "bb");
+    CHECK(tokens[2] == "ccc");
+}
+
+TEST_CASE("str_split always returns at least one element")
+{
+    const auto without_delim = str_split("abc", ':');
+    REQUIRE(without_delim.size() == 1);
+    CHECK(without_delim[0] == "abc");
+
+    const auto empty = str_split("", ':');
+    REQUIRE(empty.size() == 1);
+    CHECK(empty[0].empty());
+}
+
+TEST_CASE("str_split makes an empty element for each extra delimiter")
+{
+    const auto tokens = str_split(":a::b:", ':');
+    REQUIRE(tokens.size() == 5);
+    CHECK(tokens[0].empty());
+    CHECK(tokens[1] == "a");
+    CHECK(tokens[2].empty());
+    CHECK(tokens[3] == "b");
+    CHECK(tokens[4].empty());
+}
+
+TEST_CASE("str_split trims each element when requested")
+{
+    const auto tokens = str_split(" a :\tb\t", ':', true);
+    REQUIRE(tokens.size() == 2);
+    CHECK(tokens[0] == "a");
+    CHECK(tokens[1] == "b");
+}
+
+TEST_CASE("str_split does not pad the result up to the reserve hint")
+{
+    // num は領域確保のヒントであり、要素数を揃えるものではない
+    CHECK(str_split("a:b", ':', false, 10).size() == 2);
+}
+
+TEST_CASE("str_separate splits the string into chunks of the given size")
+{
+    const auto parts = str_separate("abcdef", 2);
+    REQUIRE(parts.size() == 3);
+    CHECK(parts[0] == "ab");
+    CHECK(parts[1] == "cd");
+    CHECK(parts[2] == "ef");
+}
+
+TEST_CASE("str_separate puts the remainder into the last chunk")
+{
+    const auto parts = str_separate("abcde", 2);
+    REQUIRE(parts.size() == 3);
+    CHECK(parts[2] == "e");
+}
+
+TEST_CASE("str_separate returns an empty vector for an empty string")
+{
+    CHECK(str_separate("", 2).empty());
+}
+
+TEST_CASE("str_separate gives up when it cannot take even one byte")
+{
+    // 幅0では1バイトも取り出せない。無限ループせずに打ち切る
+    CHECK(str_separate("abc", 0).empty());
+}
+
+TEST_CASE("str_erase removes every specified character")
+{
+    CHECK(str_erase("abcabc", "a") == "bcbc");
+    CHECK(str_erase("abcabc", "ac") == "bb");
+    CHECK(str_erase("abc", "abc").empty());
+}
+
+TEST_CASE("str_erase leaves the string as it is when nothing matches")
+{
+    CHECK(str_erase("abc", "xyz") == "abc");
+    CHECK(str_erase("abc", "") == "abc");
+    CHECK(str_erase("", "abc").empty());
+}
+
+TEST_CASE("str_replace replaces every occurrence")
+{
+    CHECK(str_replace("abcabc", "a", "X") == "XbcXbc");
+    CHECK(str_replace("abc", "abc", "X") == "X");
+    CHECK(str_replace("abc", "b", "") == "ac");
+}
+
+TEST_CASE("str_replace prefers the earlier match when the matches overlap")
+{
+    CHECK(str_replace("aaa", "aa", "X") == "Xa");
+}
+
+TEST_CASE("str_replace leaves the string as it is when nothing matches")
+{
+    CHECK(str_replace("abc", "x", "y") == "abc");
+    CHECK(str_replace("", "x", "y").empty());
+
+    // 置き換え元が空文字列なら何もしない
+    CHECK(str_replace("abc", "", "X") == "abc");
+}
+
+TEST_CASE("str_substr takes the substring at the given position")
+{
+    constexpr std::string_view str = "abcdef";
+    CHECK(str_substr(str, 2, 3) == "cde");
+    CHECK(str_substr(str, 2) == "cdef");
+    CHECK(str_substr(str) == "abcdef");
+}
+
+TEST_CASE("str_substr clamps the range to the length of the string")
+{
+    constexpr std::string_view str = "abc";
+    CHECK(str_substr(str, 1, 100) == "bc");
+    CHECK(str_substr(str, 3).empty());
+    CHECK(str_substr(str, 100).empty());
+    CHECK(str_substr(str, 1, 0).empty());
+}
+
+TEST_CASE("str_substr accepts a rvalue string and a pointer to a string")
+{
+    CHECK(str_substr(std::string("abcdef"), 1, 2) == "bc");
+    CHECK(str_substr(std::string("abc"), 100).empty());
+    CHECK(str_substr("abcdef", 1, 2) == "bc");
+}
+
+TEST_CASE("str_toupper converts the alphabets to upper case")
+{
+    CHECK(str_toupper("abcXYZ 123!") == "ABCXYZ 123!");
+    CHECK(str_toupper("").empty());
+}
+
+TEST_CASE("str_tolower converts the alphabets to lower case")
+{
+    CHECK(str_tolower("abcXYZ 123!") == "abcxyz 123!");
+    CHECK(str_tolower("").empty());
+}
+
+TEST_CASE("str_upcase_first converts only the first character")
+{
+    CHECK(str_upcase_first("abc def") == "Abc def");
+    CHECK(str_upcase_first("Abc") == "Abc");
+}
+
+TEST_CASE("str_upcase_first leaves a string which does not start with an alphabet")
+{
+    CHECK(str_upcase_first("1abc") == "1abc");
+    CHECK(str_upcase_first(" abc") == " abc");
+    CHECK(str_upcase_first("").empty());
+}
+
+TEST_CASE("extract_suffix extracts the substring from the found character")
+{
+    const auto found = extract_suffix("abc@def", '@');
+    REQUIRE(found.has_value());
+    CHECK(*found == "@def");
+
+    const auto at_head = extract_suffix("@abc", '@');
+    REQUIRE(at_head.has_value());
+    CHECK(*at_head == "@abc");
+
+    CHECK_FALSE(extract_suffix("abc", '@').has_value());
+    CHECK_FALSE(extract_suffix("", '@').has_value());
+}
+
+TEST_CASE("extract_suffix extracts the substring from the found string")
+{
+    const auto found = extract_suffix("abcdef", "cd");
+    REQUIRE(found.has_value());
+    CHECK(*found == "cdef");
+
+    CHECK_FALSE(extract_suffix("abcdef", "xy").has_value());
+
+    // 空文字列は先頭で見つかる
+    const auto empty_needle = extract_suffix("abc", "");
+    REQUIRE(empty_needle.has_value());
+    CHECK(*empty_needle == "abc");
+}
+
+TEST_CASE("count_digits counts the digits of the value")
+{
+    CHECK(count_digits(0) == 1);
+    CHECK(count_digits(7) == 1);
+    CHECK(count_digits(10) == 2);
+    CHECK(count_digits(999) == 3);
+}
+
+TEST_CASE("count_digits does not count the sign")
+{
+    CHECK(count_digits(-1) == 1);
+    CHECK(count_digits(-123) == 3);
+}
+
+TEST_CASE("count_digits counts in the specified base")
+{
+    CHECK(count_digits(255, 16) == 2);
+    CHECK(count_digits(256, 16) == 3);
+    CHECK(count_digits(8, 2) == 4);
+}
+
+TEST_CASE("count_digits returns zero for an invalid base")
+{
+    CHECK(count_digits(123, 1) == 0);
+    CHECK(count_digits(123, 0) == 0);
+    CHECK(count_digits(123, -1) == 0);
+}
+
+TEST_CASE("hexify_upper returns the upper digit of the hexadecimal notation")
+{
+    CHECK(hexify_upper(0x00) == '0');
+    CHECK(hexify_upper(0x5a) == '5');
+    CHECK(hexify_upper(0xa0) == 'A');
+    CHECK(hexify_upper(0xff) == 'F');
+}
+
+TEST_CASE("hexify_lower returns the lower digit of the hexadecimal notation")
+{
+    CHECK(hexify_lower(0x00) == '0');
+    CHECK(hexify_lower(0x5a) == 'A');
+    CHECK(hexify_lower(0xa9) == '9');
+    CHECK(hexify_lower(0xff) == 'F');
+}
+
+TEST_CASE("octify returns the octal digit")
+{
+    CHECK(octify(0) == '0');
+    CHECK(octify(7) == '7');
+
+    // 8以上の値は8で割った余りを変換する
+    CHECK(octify(8) == '0');
+    CHECK(octify(255) == '7');
+}
+
+TEST_CASE("is_numeric accepts only the ASCII digits")
+{
+    CHECK(is_numeric('0'));
+    CHECK(is_numeric('5'));
+    CHECK(is_numeric('9'));
+
+    CHECK_FALSE(is_numeric('/'));
+    CHECK_FALSE(is_numeric(':'));
+    CHECK_FALSE(is_numeric('a'));
+    CHECK_FALSE(is_numeric('\0'));
+}
+
+#ifdef JP
+
+//
+// 2バイト文字を分断しないことのテスト (EUC-JP / Shift_JIS 共通)
+//
+
+TEST_CASE("angband_strcpy does not truncate in the middle of a two byte character")
+{
+    // 「漢」しか入らない大きさのバッファに「漢字」を書き込む
+    char buf[4] = {};
+    CHECK(angband_strcpy(buf, cat(KANJI_KAN, KANJI_JI), sizeof(buf)) == 4);
+    CHECK(std::string_view(buf) == KANJI_KAN);
+}
+
+TEST_CASE("angband_strcpy drops a two byte character which lacks its trailing byte")
+{
+    char buf[16] = {};
+    CHECK(angband_strcpy(buf, cat("a", KANJI_KAN.substr(0, 1)), sizeof(buf)) == 2);
+    CHECK(std::string_view(buf) == "a");
+}
+
+TEST_CASE("str_substr does not split a two byte character")
+{
+    const auto str = cat(KANJI_KAN, KANJI_JI);
+
+    // 終了位置が2バイト文字の前半バイトなので手前で区切る
+    CHECK(str_substr(std::string_view(str), 0, 3) == KANJI_KAN);
+
+    // 開始位置が2バイト文字の後半バイトなので次のバイトから始める
+    CHECK(str_substr(std::string_view(str), 1, 3) == KANJI_JI);
+}
+
+TEST_CASE("str_separate does not split a two byte character")
+{
+    const auto parts = str_separate(cat(KANJI_KAN, KANJI_JI, "ab"), 3);
+    REQUIRE(parts.size() == 3);
+    CHECK(parts[0] == KANJI_KAN);
+    CHECK(parts[1] == cat(KANJI_JI, "a"));
+    CHECK(parts[2] == "b");
+}
+
+TEST_CASE("str_separate gives up when the width is too small for a two byte character")
+{
+    CHECK(str_separate(KANJI_KAN, 1).empty());
+}
+
+TEST_CASE("str_toupper and str_tolower leave a two byte character as it is")
+{
+    CHECK(str_tolower(cat(KANJI_KAN, "ABC")) == cat(KANJI_KAN, "abc"));
+    CHECK(str_toupper(cat(KANJI_KAN, "abc")) == cat(KANJI_KAN, "ABC"));
+}
+
+TEST_CASE("str_upcase_first leaves a leading two byte character as it is")
+{
+    const auto str = cat(KANJI_KAN, "abc");
+    CHECK(str_upcase_first(str) == str);
+}
+
+TEST_CASE("str_find_all_multibyte_chars returns the index of each leading byte")
+{
+    const std::set<int> expected = { 1, 4 };
+    CHECK(str_find_all_multibyte_chars(cat("a", KANJI_KAN, "b", KANJI_JI)) == expected);
+    CHECK(str_find_all_multibyte_chars("abc").empty());
+}
+
+TEST_CASE("string-processor accepts a two byte character which lacks its trailing byte")
+{
+    // 前半バイトだけで終わる壊れた文字列を渡しても、範囲外を読まずに処理を終える
+    const auto str = cat("a", KANJI_KAN.substr(0, 1));
+
+    // 欠けた前半バイトも2バイト文字の一部として扱い、変換の対象にしない
+    CHECK(str_toupper(str) == cat("A", KANJI_KAN.substr(0, 1)));
+    CHECK(str_tolower(str) == str);
+
+    CHECK(str_erase(str, "x") == str);
+    CHECK(str_substr(std::string_view(str), 2).empty());
+
+    const std::set<int> expected = { 1 };
+    CHECK(str_find_all_multibyte_chars(str) == expected);
+}
+
+#endif
+
+#if defined(JP) && defined(SJIS)
+
+//
+// ダメ文字のテスト (Shift_JISのみ)
+//
+
+TEST_CASE("angband_strchr does not match the trailing byte of a two byte character")
+{
+    const auto str = cat(DAME_SO, "a");
+    CHECK(angband_strchr(str.data(), '\\') == nullptr);
+    CHECK(angband_strchr(str.data(), 'a') == str.data() + 2);
+}
+
+TEST_CASE("angband_strstr does not match from the trailing byte of a two byte character")
+{
+    // 単純なバイト列としては "\\a" が一致するが、2バイト文字の途中なのでマッチしない
+    const auto str = cat(DAME_SO, "a");
+    CHECK(angband_strstr(str.data(), "\\a") == nullptr);
+}
+
+TEST_CASE("str_find does not match from the trailing byte of a two byte character")
+{
+    CHECK_FALSE(str_find(cat(DAME_SO, "a"), "\\a"));
+    CHECK(str_find(cat(DAME_SO, "a"), "a"));
+}
+
+TEST_CASE("str_split does not split at the trailing byte of a two byte character")
+{
+    // 全角スペースの後半バイトは '@' と同じ 0x40
+    const auto str = cat("a", DAME_SPACE, "b");
+    const auto tokens = str_split(str, '@');
+    REQUIRE(tokens.size() == 1);
+    CHECK(tokens[0] == str);
+}
+
+TEST_CASE("str_replace does not replace the trailing byte of a two byte character")
+{
+    const auto str = cat("a", DAME_SO, "b");
+    CHECK(str_replace(str, "\\", "X") == str);
+
+    // 2バイト文字の一部でない '\' は置き換えられる
+    CHECK(str_replace(cat("\\", DAME_SO), "\\", "X") == cat("X", DAME_SO));
+}
+
+TEST_CASE("str_erase does not break a two byte character")
+{
+    const auto str = cat("a", DAME_SO, "b");
+    CHECK(str_erase(str, "\\") == str);
+    CHECK(str_erase(cat(DAME_KANA_A, "A"), "A") == DAME_KANA_A);
+}
+
+TEST_CASE("str_substr does not split a two byte character whose trailing byte is ASCII")
+{
+    const auto str = cat(DAME_SO, DAME_HYOU);
+    CHECK(str_substr(std::string_view(str), 0, 3) == DAME_SO);
+    CHECK(str_substr(std::string_view(str), 1, 3) == DAME_HYOU);
+}
+
+TEST_CASE("str_find_all_multibyte_chars finds a character whose trailing byte is ASCII")
+{
+    const std::set<int> expected = { 0, 2, 4 };
+    CHECK(str_find_all_multibyte_chars(cat(DAME_SO, DAME_CHOON, DAME_KANA_A)) == expected);
+}
+
+#endif

--- a/src/test/util/test-string-processor.cpp
+++ b/src/test/util/test-string-processor.cpp
@@ -628,6 +628,14 @@ TEST_CASE("string-processor accepts a two byte character which lacks its trailin
 
     CHECK(str_erase(str, "x") == str);
     CHECK(str_substr(std::string_view(str), 2).empty());
+    CHECK(str_replace(str, "x", "y") == str);
+    CHECK(str_split(str, ':').size() == 1);
+    CHECK_FALSE(str_find(str, "x"));
+
+    // 終端を越えて読まずに、見つからないと答えて終わる
+    CHECK(angband_strchr(str.data(), 'x') == nullptr);
+    CHECK(angband_strstr(str.data(), "x") == nullptr);
+    CHECK(angband_strchr(str.data(), 'a') == str.data());
 
     const std::set<int> expected = { 1 };
     CHECK(str_find_all_multibyte_chars(str) == expected);

--- a/src/test/util/test-string-processor.cpp
+++ b/src/test/util/test-string-processor.cpp
@@ -715,6 +715,18 @@ TEST_CASE("str_toupper and str_tolower leave a two byte character as it is")
     CHECK(str_toupper(cat(KANJI_KAN, "abc")) == cat(KANJI_KAN, "ABC"));
 }
 
+TEST_CASE("str_erase does not erase a two byte character")
+{
+    // erase_chars は1バイト文字の集合として扱うため、2バイト文字は削除されない
+    const auto str = cat(KANJI_KAN, "a");
+
+    const auto kept = str_erase(str, KANJI_KAN);
+    CHECK(kept == str);
+
+    const auto ascii_erased = str_erase(str, "a");
+    CHECK(ascii_erased == KANJI_KAN);
+}
+
 TEST_CASE("str_upcase_first leaves a leading two byte character as it is")
 {
     const auto str = cat(KANJI_KAN, "abc");
@@ -826,6 +838,10 @@ TEST_CASE("str_erase does not break a two byte character")
 
     const auto kana_kept = str_erase(cat(DAME_KANA_A, "A"), "A");
     CHECK(kana_kept == DAME_KANA_A);
+
+    // 「ソ」の前半バイトは「ア」の前半バイトと同じ 0x83 だが、前半バイトだけを削除しない
+    const auto lead_kept = str_erase(cat(DAME_KANA_A, "b"), DAME_SO);
+    CHECK(lead_kept == cat(DAME_KANA_A, "b"));
 }
 
 TEST_CASE("str_substr does not split a two byte character whose trailing byte is ASCII")

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -189,14 +189,17 @@ char *angband_strstr(const char *haystack, std::string_view needle)
  */
 char *angband_strchr(const char *ptr, char ch)
 {
-    for (; *ptr != '\0'; ptr++) {
-        if (*ptr == ch) {
-            return const_cast<char *>(ptr);
+    // ポインタを進める形だと、末尾が2バイト文字の前半バイトだけのときに
+    // 後半バイトの読み飛ばしで終端を跨いでしまうため、添字で走査する
+    const std::string_view sv(ptr);
+    for (size_t i = 0; i < sv.length(); ++i) {
+        if (sv[i] == ch) {
+            return const_cast<char *>(ptr) + i;
         }
 
 #ifdef JP
-        if (iskanji(*ptr)) {
-            ptr++;
+        if (iskanji(sv[i])) {
+            ++i;
         }
 #endif
     }

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -23,51 +23,33 @@ constexpr auto trim_back = ranges::views::reverse | trim_front | ranges::views::
  */
 size_t angband_strcpy(char *buf, std::string_view src, size_t bufsize)
 {
-#ifdef JP
-    char *d = buf;
-    const char *s = src.data();
+    if (bufsize == 0) {
+        return src.length();
+    }
+
+    // NUL終端の分を除いた、実際にコピーできるバイト数
+    const auto capacity = bufsize - 1;
     size_t len = 0;
 
-    if (bufsize > 0) {
-        /* reserve for NUL termination */
-        bufsize--;
-
-        /* Copy as many bytes as will fit */
-        while (*s && (len < bufsize)) {
-            if (iskanji(*s)) {
-                if (len + 1 >= bufsize || !*(s + 1)) {
-                    break;
-                }
-                *d++ = *s++;
-                *d++ = *s++;
-                len += 2;
-            } else {
-                *d++ = *s++;
-                len++;
+    while ((len < src.length()) && (len < capacity)) {
+#ifdef JP
+        if (iskanji(src[len])) {
+            // 2バイト文字は後半バイトまで収まる場合だけコピーし、途中で分断しない
+            if ((len + 2 > capacity) || (len + 1 >= src.length())) {
+                break;
             }
+            buf[len] = src[len];
+            buf[len + 1] = src[len + 1];
+            len += 2;
+            continue;
         }
-        *d = '\0';
+#endif
+        buf[len] = src[len];
+        ++len;
     }
 
-    while (*s++) {
-        len++;
-    }
-    return len;
-
-#else
-    auto len = src.length();
-    if (bufsize == 0) {
-        return len;
-    }
-
-    if (len >= bufsize) {
-        len = bufsize - 1;
-    }
-
-    (void)src.copy(buf, len);
     buf[len] = '\0';
     return src.length();
-#endif
 }
 
 /*
@@ -83,12 +65,14 @@ size_t angband_strcpy(char *buf, std::string_view src, size_t bufsize)
  */
 size_t angband_strcat(char *buf, std::string_view src, size_t bufsize)
 {
-    size_t dlen = strlen(buf);
-    if (dlen < bufsize - 1) {
-        return dlen + angband_strcpy(buf + dlen, src, bufsize - dlen);
-    } else {
+    const auto dlen = strlen(buf);
+
+    // bufsize - 1 は bufsize が 0 のとき桁溢れするため、加算の形で比較する
+    if (dlen + 1 >= bufsize) {
         return dlen + src.length();
     }
+
+    return dlen + angband_strcpy(buf + dlen, src, bufsize - dlen);
 }
 
 /*
@@ -163,10 +147,10 @@ char *ltrim(char *p)
  */
 char *rtrim(char *p)
 {
-    int i = strlen(p) - 1;
-    while (p[i] == ' ') {
-        p[i--] = '\0';
+    for (auto i = strlen(p); (i > 0) && (p[i - 1] == ' '); --i) {
+        p[i - 1] = '\0';
     }
+
     return p;
 }
 
@@ -284,8 +268,14 @@ std::vector<std::string> str_separate(std::string_view str, size_t len)
     std::vector<std::string> result;
 
     while (!str.empty()) {
-        result.push_back(str_substr(str, 0, len));
-        str.remove_prefix(result.back().size());
+        auto separated = str_substr(str, 0, len);
+        if (separated.empty()) {
+            // len が小さすぎて1文字も取り出せない。これ以上分割できないので打ち切る
+            break;
+        }
+
+        str.remove_prefix(separated.size());
+        result.push_back(std::move(separated));
     }
 
     return result;
@@ -309,7 +299,7 @@ std::string str_erase(std::string str, std::string_view erase_chars)
             continue;
         }
 #ifdef JP
-        if (iskanji(*it)) {
+        if (iskanji(*it) && (it + 1 != str.end())) {
             ++it;
         }
 #endif
@@ -362,13 +352,16 @@ static std::pair<size_t, size_t> adjust_substr_pos(std::string_view sv, size_t p
     const auto end = n == std::string_view::npos ? sv.length() : std::min(pos + n, sv.length());
 
 #ifdef JP
-    auto seek_pos = 0U;
+    size_t seek_pos = 0;
     while (seek_pos < start) {
         if (iskanji(sv[seek_pos])) {
             ++seek_pos;
         }
         ++seek_pos;
     }
+
+    // 文字列の末尾が2バイト文字の前半バイトだけの場合、seek_pos が文字列長を超えうる
+    seek_pos = std::min(seek_pos, sv.length());
     const auto mb_pos = seek_pos;
 
     while (seek_pos < end) {
@@ -445,13 +438,16 @@ std::string str_toupper(std::string_view str)
     for (size_t i = 0; i < str.length(); ++i) {
         const auto ch = str[i];
 #ifdef JP
+        // 2バイト文字は変換せずそのまま通す。後半バイトを欠いている場合も同じ
         if (iskanji(ch)) {
             uc_str.push_back(ch);
-            uc_str.push_back(str[++i]);
+            if (i + 1 < str.length()) {
+                uc_str.push_back(str[++i]);
+            }
             continue;
         }
 #endif
-        uc_str.push_back(static_cast<char>(toupper(ch)));
+        uc_str.push_back(static_cast<char>(toupper(static_cast<unsigned char>(ch))));
     }
 
     return uc_str;
@@ -469,13 +465,16 @@ std::string str_tolower(std::string_view str)
     for (size_t i = 0; i < str.length(); ++i) {
         const auto ch = str[i];
 #ifdef JP
+        // 2バイト文字は変換せずそのまま通す。後半バイトを欠いている場合も同じ
         if (iskanji(ch)) {
             lc_str.push_back(ch);
-            lc_str.push_back(str[++i]);
+            if (i + 1 < str.length()) {
+                lc_str.push_back(str[++i]);
+            }
             continue;
         }
 #endif
-        lc_str.push_back(static_cast<char>(tolower(ch)));
+        lc_str.push_back(static_cast<char>(tolower(static_cast<unsigned char>(ch))));
     }
 
     return lc_str;
@@ -496,6 +495,13 @@ std::string str_upcase_first(std::string_view str)
     std::string result_str(str);
 
     const auto first_char = static_cast<unsigned char>(result_str[0]);
+#ifdef JP
+    // 2バイト文字の前半バイトをロケール依存の変換にかけない
+    if (iskanji(first_char)) {
+        return result_str;
+    }
+#endif
+
     if (isalpha(first_char)) {
         result_str[0] = static_cast<char>(toupper(first_char));
     }

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -1,352 +1,45 @@
+/*!
+ * @file string-processor.cpp
+ * @brief 文字列処理の汎用ユーティリティ
+ * @details
+ * 日本語版が扱う文字コードは、Unix系ではEUC-JP、WindowsではShift_JISである。
+ * Shift_JISでは2バイト文字の後半バイトがASCIIの範囲(0x40-0x7e)と重なるため、
+ * 単純にバイト単位で検索すると、2バイト文字の後半バイトを独立した文字と誤認する。
+ * 後半バイトが 0x5c (バックスラッシュ)になる「ソ」「表」などがその代表で、
+ * いわゆるダメ文字と呼ばれる。
+ *
+ * このファイルの関数のうち文字や文字列を検索・分割するものは、文字列を先頭から
+ * 1文字ずつ走査して2バイト文字の後半バイトを読み飛ばすことで、この問題を回避する。
+ * EUC-JPは後半バイトがASCIIの範囲と重ならないため同じ問題は起きないが、
+ * 処理は文字コードによらず共通である。
+ */
+
 #include "util/string-processor.h"
-#include "system/angband.h"
+#include "system/h-basic.h"
+#include <algorithm>
 #include <array>
-#include <charconv>
-#include <range/v3/all.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view.hpp>
+#include <utility>
 
 namespace {
-constexpr std::array<char, 16> hex_symbol_table = { { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' } }; //!< 10進数から16進数への変換テーブル
+constexpr std::array<char, 16> hex_symbol_table = { { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' } }; //!< 数値から16進数(8進数にも流用する)の文字への変換テーブル
 
 constexpr auto trim_front = ranges::views::drop_while([](char c) { return c == ' ' || c == '\t'; });
 constexpr auto trim_back = ranges::views::reverse | trim_front | ranges::views::reverse;
-}
-
-/*
- * The angband_strcpy() function copies up to 'bufsize'-1 characters from 'src'
- * to 'buf' and NUL-terminates the result.  The 'buf' and 'src' strings may
- * not overlap.
- *
- * angband_strcpy() returns strlen(src).  This makes checking for truncation
- * easy.  Example: if (angband_strcpy(buf, src, sizeof(buf)) >= sizeof(buf)) ...;
- *
- * This function should be equivalent to the strlcpy() function in BSD.
- */
-size_t angband_strcpy(char *buf, std::string_view src, size_t bufsize)
-{
-    if (bufsize == 0) {
-        return src.length();
-    }
-
-    // NUL終端の分を除いた、実際にコピーできるバイト数
-    const auto capacity = bufsize - 1;
-    size_t len = 0;
-
-    while ((len < src.length()) && (len < capacity)) {
-#ifdef JP
-        if (iskanji(src[len])) {
-            // 2バイト文字は後半バイトまで収まる場合だけコピーし、途中で分断しない
-            if ((len + 2 > capacity) || (len + 1 >= src.length())) {
-                break;
-            }
-            buf[len] = src[len];
-            buf[len + 1] = src[len + 1];
-            len += 2;
-            continue;
-        }
-#endif
-        buf[len] = src[len];
-        ++len;
-    }
-
-    buf[len] = '\0';
-    return src.length();
-}
-
-/*
- * The angband_strcat() tries to append a string to an existing NUL-terminated string.
- * It never writes more characters into the buffer than indicated by 'bufsize' and
- * NUL-terminates the buffer.  The 'buf' and 'src' strings may not overlap.
- *
- * angband_strcat() returns strlen(buf) + strlen(src).  This makes checking for
- * truncation easy.  Example:
- * if (angband_strcat(buf, src, sizeof(buf)) >= sizeof(buf)) ...;
- *
- * This function should be equivalent to the strlcat() function in BSD.
- */
-size_t angband_strcat(char *buf, std::string_view src, size_t bufsize)
-{
-    const auto dlen = strlen(buf);
-
-    // bufsize - 1 は bufsize が 0 のとき桁溢れするため、加算の形で比較する
-    if (dlen + 1 >= bufsize) {
-        return dlen + src.length();
-    }
-
-    return dlen + angband_strcpy(buf + dlen, src, bufsize - dlen);
-}
-
-/*
- * A copy of ANSI strstr()
- *
- * angband_strstr() can handle Kanji strings correctly.
- */
-char *angband_strstr(const char *haystack, std::string_view needle)
-{
-    std::string_view haystack_view(haystack);
-    auto l1 = haystack_view.length();
-    auto l2 = needle.length();
-    if (l1 < l2) {
-        return nullptr;
-    }
-
-    for (size_t i = 0; i <= l1 - l2; i++) {
-        const auto part = haystack_view.substr(i);
-        if (part.starts_with(needle)) {
-            return const_cast<char *>(haystack) + i;
-        }
-
-#ifdef JP
-        if (iskanji(*(haystack + i))) {
-            i++;
-        }
-#endif
-    }
-
-    return nullptr;
-}
-
-/*
- * A copy of ANSI strchr()
- *
- * angband_strchr() can handle Kanji strings correctly.
- */
-char *angband_strchr(const char *ptr, char ch)
-{
-    for (; *ptr != '\0'; ptr++) {
-        if (*ptr == ch) {
-            return const_cast<char *>(ptr);
-        }
-
-#ifdef JP
-        if (iskanji(*ptr)) {
-            ptr++;
-        }
-#endif
-    }
-
-    return nullptr;
-}
 
 /*!
- * @brief 左側の空白を除去
- * @param p char型のポインタ
- * @return 除去後のポインタ
+ * @brief 2バイト文字を分断しないように部分文字列の範囲を補正する
+ * @param sv 対象の文字列
+ * @param pos 補正前の開始位置(バイト)
+ * @param n 補正前の長さ(バイト)
+ * @return 補正後の開始位置と長さの組
+ * @details
+ * 開始位置が2バイト文字の後半バイトを指す場合は次のバイトまで進め、
+ * 終了位置が2バイト文字の前半バイトを指す場合は手前のバイトまで戻す。
+ * pos や pos + n が文字列の長さを超える場合は、文字列の末尾に丸める。
  */
-char *ltrim(char *p)
-{
-    while (p[0] == ' ') {
-        p++;
-    }
-    return p;
-}
-
-/*!
- * @brief 右側の空白を除去
- * @param p char型のポインタ
- * @return 除去後のポインタ
- */
-char *rtrim(char *p)
-{
-    for (auto i = strlen(p); (i > 0) && (p[i - 1] == ' '); --i) {
-        p[i - 1] = '\0';
-    }
-
-    return p;
-}
-
-/*
- * @brief マルチバイト文字のダメ文字('\')を考慮しつつ文字列比較を行う
- * @param src 比較元の文字列
- * @param find 比較したい文字列
- */
-bool str_find(const std::string &src, std::string_view find)
-{
-    return angband_strstr(src.data(), find) != nullptr;
-}
-
-/**
- * @brief 文字列の両端の空白を削除する
- *
- * 文字列 str の両端にある空白(スペースおよびタブ)を削除し、
- * 削除した文字列を std::string 型のオブジェクトとして返す。
- * 文字列全体が空白の場合は空文字列を返す。
- *
- * @param str 操作の対象とする文字列
- * @return std::string strの両端の空白を削除した文字列
- */
-std::string str_trim(std::string_view str)
-{
-    return str | trim_front | trim_back | ranges::to<std::string>();
-}
-
-/**
- * @brief 文字列の右端の空白を削除する
- *
- * 文字列 str の右端にある空白(スペースおよびタブ)を削除し、
- * 削除した文字列を std::string 型のオブジェクトとして返す。
- * 文字列全体が空白の場合は空文字列を返す。
- *
- * @param str 操作の対象とする文字列
- * @return std::string strの右端の空白を削除した文字列
- */
-std::string str_rtrim(std::string_view str)
-{
-    return str | trim_back | ranges::to<std::string>();
-}
-
-/**
- * @brief 文字列の左端の空白を削除する
- *
- * 文字列 str の左端にある空白(スペースおよびタブ)を削除し、
- * 削除した文字列を std::string 型のオブジェクトとして返す。
- * 文字列全体が空白の場合は空文字列を返す。
- *
- * @param str 操作の対象とする文字列
- * @return std::string strの左端の空白を削除した文字列
- */
-std::string str_ltrim(std::string_view str)
-{
-    return str | trim_front | ranges::to<std::string>();
-}
-
-/**
- * @brief 文字列を指定した文字で分割する
- *
- * 文字列 str を delim で指定した文字で分割し、分割した文字列を要素とする配列を
- * std::vector<std::string> 型のオブジェクトとして返す。
- *
- * @param str 操作の対象とする文字列
- * @param delim 文字列を分割する文字
- * @param trim trueの場合、分割した文字列の両端の空白を削除する
- * @param num 1以上の場合、事前にvectorサイズを予約しておく(速度向上)
- * @return std::vector<std::string> 分割した文字列を要素とする配列
- */
-std::vector<std::string> str_split(std::string_view str, char delim, bool trim, int num)
-{
-    std::vector<std::string> result;
-    if (num > 0) {
-        result.reserve(num);
-    }
-
-    auto make_str = [trim](std::string_view sv) { return trim ? str_trim(sv) : std::string(sv); };
-
-    while (true) {
-        bool found = false;
-        for (size_t i = 0; i < str.size(); ++i) {
-            if (str[i] == delim) {
-                result.push_back(make_str(str.substr(0, i)));
-                str.remove_prefix(i + 1);
-                found = true;
-                break;
-            }
-#ifdef JP
-            if (iskanji(str[i])) {
-                ++i;
-            }
-#endif
-        }
-        if (!found) {
-            result.push_back(make_str(str));
-            return result;
-        }
-    }
-}
-
-/**
- * @brief 文字列を指定した文字数で分割する
- *
- * 文字列 str を len で指定した文字数で分割し、分割した文字列を要素とする配列を
- * std::vector<std::string> 型のオブジェクトとして返す。
- * 全角文字は2文字分として扱い、全角文字の前半で分割されてしまわないように処理される。
- *
- * @param str 操作の対象とする文字列
- * @param len 分割する文字数
- * @return std::vector<std::string> 分割した文字列を要素とする配列
- */
-std::vector<std::string> str_separate(std::string_view str, size_t len)
-{
-    std::vector<std::string> result;
-
-    while (!str.empty()) {
-        auto separated = str_substr(str, 0, len);
-        if (separated.empty()) {
-            // len が小さすぎて1文字も取り出せない。これ以上分割できないので打ち切る
-            break;
-        }
-
-        str.remove_prefix(separated.size());
-        result.push_back(std::move(separated));
-    }
-
-    return result;
-}
-
-/**
- * @brief 文字列から指定した文字を取り除く
- *
- * 文字列 str から文字列 erase_chars に含まれる文字をすべて削除し、
- * 削除した文字列を std::string 型のオブジェクトとして返す。
- *
- * @param str 操作の対象とする文字列
- * @param erase_chars 削除する文字を指定する文字列
- * @return std::string 指定した文字をすべて削除した文字列
- */
-std::string str_erase(std::string str, std::string_view erase_chars)
-{
-    for (auto it = str.begin(); it != str.end();) {
-        if (erase_chars.find(*it) != std::string_view::npos) {
-            it = str.erase(it);
-            continue;
-        }
-#ifdef JP
-        if (iskanji(*it) && (it + 1 != str.end())) {
-            ++it;
-        }
-#endif
-        ++it;
-    }
-
-    return str;
-}
-
-/**
- * @brief 文字列 str に含まれる文字列 old_str をすべて new_str に置き換える
- *
- * 一致する文字列が重複している場合は、前方を優先する。
- *
- * @param str 操作の対象とする文字列
- * @param old_str 置き換える文字列
- * @param new_str 置き換え後の文字列
- * @return std::string old_str をすべて new_str で置き換えた文字列
- */
-std::string str_replace(std::string_view str, std::string_view old_str, std::string_view new_str)
-{
-    if (old_str.empty()) {
-        return std::string(str);
-    }
-
-    const auto mb_char_indexes = str_find_all_multibyte_chars(str);
-    std::stringstream ss;
-
-    for (size_t start_pos = 0;;) {
-        const auto found_pos = str.find(old_str, start_pos);
-        if (found_pos == std::string_view::npos) {
-            ss << str.substr(start_pos);
-            return ss.str();
-        }
-
-        if (found_pos > 0 && mb_char_indexes.contains(found_pos - 1)) {
-            ss << str.substr(start_pos, found_pos + 1 - start_pos);
-            start_pos = found_pos + 1;
-            continue;
-        }
-
-        ss << str.substr(start_pos, found_pos - start_pos) << new_str;
-        start_pos = found_pos + old_str.length();
-    }
-}
-
-static std::pair<size_t, size_t> adjust_substr_pos(std::string_view sv, size_t pos, size_t n)
+std::pair<size_t, size_t> adjust_substr_pos(std::string_view sv, size_t pos, size_t n)
 {
     const auto start = std::min(pos, sv.length());
     const auto end = n == std::string_view::npos ? sv.length() : std::min(pos + n, sv.length());
@@ -380,19 +73,408 @@ static std::pair<size_t, size_t> adjust_substr_pos(std::string_view sv, size_t p
     return { start, end - start };
 #endif
 }
+}
+
+/*!
+ * @brief 文字列をバッファへコピーする (BSDのstrlcpy相当)
+ * @param buf コピー先のバッファ。src と領域が重なっていてはならない
+ * @param src コピー元の文字列
+ * @param bufsize コピー先のバッファのサイズ(NUL終端の分を含む)。0の場合 buf には一切書き込まない
+ * @return src のバイト数
+ * @details
+ * 最大 bufsize - 1 バイトまでコピーし、必ずNUL終端する。
+ * 戻り値と bufsize を比較することで切り詰めが起きたかどうかを判定できる。
+ * 例: if (angband_strcpy(buf, src, sizeof(buf)) >= sizeof(buf)) ...
+ *
+ * 日本語版では2バイト文字を途中で切り詰めないよう、後半バイトまで収まらない場合は
+ * その文字ごとコピーしない。
+ */
+size_t angband_strcpy(char *buf, std::string_view src, size_t bufsize)
+{
+    if (bufsize == 0) {
+        return src.length();
+    }
+
+    // NUL終端の分を除いた、実際にコピーできるバイト数
+    const auto capacity = bufsize - 1;
+    size_t len = 0;
+
+    while ((len < src.length()) && (len < capacity)) {
+#ifdef JP
+        if (iskanji(src[len])) {
+            // 2バイト文字は後半バイトまで収まる場合だけコピーし、途中で分断しない
+            if ((len + 2 > capacity) || (len + 1 >= src.length())) {
+                break;
+            }
+            buf[len] = src[len];
+            buf[len + 1] = src[len + 1];
+            len += 2;
+            continue;
+        }
+#endif
+        buf[len] = src[len];
+        ++len;
+    }
+
+    buf[len] = '\0';
+    return src.length();
+}
+
+/*!
+ * @brief NUL終端された文字列の末尾へ文字列を追記する (BSDのstrlcat相当)
+ * @param buf 追記先のNUL終端された文字列。src と領域が重なっていてはならない
+ * @param src 追記する文字列
+ * @param bufsize 追記先のバッファのサイズ(NUL終端の分を含む)。
+ *                buf に追記する余地が無い場合は buf を書き換えない
+ * @return 追記しようとした結果のバイト数 (buf の元のバイト数 + src のバイト数)
+ * @details
+ * bufsize を超えて書き込むことはない。1バイトでも追記した場合は必ずNUL終端する。
+ * 戻り値と bufsize を比較することで切り詰めが起きたかどうかを判定できる。
+ * 例: if (angband_strcat(buf, src, sizeof(buf)) >= sizeof(buf)) ...
+ */
+size_t angband_strcat(char *buf, std::string_view src, size_t bufsize)
+{
+    const auto dlen = strlen(buf);
+
+    // bufsize - 1 は bufsize が 0 のとき桁溢れするため、加算の形で比較する
+    if (dlen + 1 >= bufsize) {
+        return dlen + src.length();
+    }
+
+    return dlen + angband_strcpy(buf + dlen, src, bufsize - dlen);
+}
+
+/*!
+ * @brief 2バイト文字を考慮しつつ文字列を検索する (ANSIのstrstr相当)
+ * @param haystack 検索対象のNUL終端された文字列
+ * @param needle 検索する文字列
+ * @return 最初に見つかった位置へのポインタ。見つからなければnullptr
+ * @details
+ * 2バイト文字の後半バイトから始まる位置にはマッチしない。
+ * needle が空文字列の場合は haystack の先頭を返す。
+ */
+char *angband_strstr(const char *haystack, std::string_view needle)
+{
+    std::string_view haystack_view(haystack);
+    auto l1 = haystack_view.length();
+    auto l2 = needle.length();
+    if (l1 < l2) {
+        return nullptr;
+    }
+
+    for (size_t i = 0; i <= l1 - l2; i++) {
+        const auto part = haystack_view.substr(i);
+        if (part.starts_with(needle)) {
+            return const_cast<char *>(haystack) + i;
+        }
+
+#ifdef JP
+        if (iskanji(*(haystack + i))) {
+            i++;
+        }
+#endif
+    }
+
+    return nullptr;
+}
+
+/*!
+ * @brief 2バイト文字を考慮しつつ文字を検索する (ANSIのstrchr相当)
+ * @param ptr 検索対象のNUL終端された文字列
+ * @param ch 検索する文字
+ * @return 最初に見つかった位置へのポインタ。見つからなければnullptr
+ * @details
+ * 2バイト文字の後半バイトにはマッチしない。
+ * strchrと異なり、終端のNUL文字は検索できない(nullptrを返す)。
+ */
+char *angband_strchr(const char *ptr, char ch)
+{
+    for (; *ptr != '\0'; ptr++) {
+        if (*ptr == ch) {
+            return const_cast<char *>(ptr);
+        }
+
+#ifdef JP
+        if (iskanji(*ptr)) {
+            ptr++;
+        }
+#endif
+    }
+
+    return nullptr;
+}
+
+/*!
+ * @brief 文字列の左端の半角スペースを読み飛ばす
+ * @param p NUL終端された文字列
+ * @return 左端の半角スペースを読み飛ばした位置へのポインタ
+ * @details
+ * 元の文字列は書き換えない。タブや全角スペースは対象外。
+ * タブも含めて取り除きたい場合や新しい文字列が欲しい場合は str_ltrim() を使う。
+ */
+char *ltrim(char *p)
+{
+    while (p[0] == ' ') {
+        p++;
+    }
+    return p;
+}
+
+/*!
+ * @brief 文字列の右端の半角スペースをNUL文字で潰す
+ * @param p NUL終端された文字列。この文字列自体が書き換えられる
+ * @return p と同じポインタ
+ * @details
+ * 2バイト文字の後半バイトが 0x20 になる文字コードは無いため、2バイト文字を壊すことはない。
+ * タブや全角スペースは対象外。
+ * 元の文字列を書き換えたくない場合は str_rtrim() を使う。
+ */
+char *rtrim(char *p)
+{
+    for (auto i = strlen(p); (i > 0) && (p[i - 1] == ' '); --i) {
+        p[i - 1] = '\0';
+    }
+
+    return p;
+}
+
+/*!
+ * @brief 2バイト文字を考慮しつつ文字列が含まれるかどうかを調べる
+ * @param src 検索対象の文字列
+ * @param find 検索する文字列
+ * @return src に find が含まれるならtrue
+ * @details
+ * 2バイト文字の後半バイトから始まる位置にはマッチしない。
+ * find には正しい長さを持つ文字列を渡すこと。NUL終端されていない char の配列や
+ * char 単体のアドレスを渡すと、std::string_view への変換で範囲外を読む。
+ */
+bool str_find(const std::string &src, std::string_view find)
+{
+    return angband_strstr(src.data(), find) != nullptr;
+}
+
+/*!
+ * @brief 文字列の両端の空白を削除する
+ *
+ * 文字列 str の両端にある空白(スペースおよびタブ)を削除し、
+ * 削除した文字列を std::string 型のオブジェクトとして返す。
+ * 文字列全体が空白の場合は空文字列を返す。
+ *
+ * @param str 操作の対象とする文字列
+ * @return std::string strの両端の空白を削除した文字列
+ * @details
+ * 2バイト文字の後半バイトが 0x20 や 0x09 になる文字コードは無いため、2バイト文字を壊すことはない。
+ */
+std::string str_trim(std::string_view str)
+{
+    return str | trim_front | trim_back | ranges::to<std::string>();
+}
+
+/*!
+ * @brief 文字列の右端の空白を削除する
+ *
+ * 文字列 str の右端にある空白(スペースおよびタブ)を削除し、
+ * 削除した文字列を std::string 型のオブジェクトとして返す。
+ * 文字列全体が空白の場合は空文字列を返す。
+ *
+ * @param str 操作の対象とする文字列
+ * @return std::string strの右端の空白を削除した文字列
+ * @details
+ * 2バイト文字の後半バイトが 0x20 や 0x09 になる文字コードは無いため、2バイト文字を壊すことはない。
+ */
+std::string str_rtrim(std::string_view str)
+{
+    return str | trim_back | ranges::to<std::string>();
+}
+
+/*!
+ * @brief 文字列の左端の空白を削除する
+ *
+ * 文字列 str の左端にある空白(スペースおよびタブ)を削除し、
+ * 削除した文字列を std::string 型のオブジェクトとして返す。
+ * 文字列全体が空白の場合は空文字列を返す。
+ *
+ * @param str 操作の対象とする文字列
+ * @return std::string strの左端の空白を削除した文字列
+ * @details
+ * 2バイト文字の後半バイトが 0x20 や 0x09 になる文字コードは無いため、2バイト文字を壊すことはない。
+ */
+std::string str_ltrim(std::string_view str)
+{
+    return str | trim_front | ranges::to<std::string>();
+}
+
+/*!
+ * @brief 文字列を指定した文字で分割する
+ *
+ * 文字列 str を delim で指定した文字で分割し、分割した文字列を要素とする配列を
+ * std::vector<std::string> 型のオブジェクトとして返す。
+ *
+ * @param str 操作の対象とする文字列
+ * @param delim 文字列を分割する文字
+ * @param trim trueの場合、分割した文字列の両端の空白を削除する
+ * @param num 1以上の場合、その要素数だけvectorの領域を事前に確保する(速度向上が目的)
+ * @return std::vector<std::string> 分割した文字列を要素とする配列
+ * @details
+ * 戻り値の要素数は必ず1以上になる。str が空文字列の場合は、空文字列1個を要素とする配列を返す。
+ * 区切り文字が先頭・末尾にある場合や連続する場合は、その分だけ空文字列の要素が生まれる。
+ * num は領域確保のヒントに過ぎず、戻り値の要素数を num に揃えるものではない。
+ *
+ * 2バイト文字の後半バイトは読み飛ばすため、delim にダメ文字と重なる文字を指定しても
+ * 2バイト文字の途中で分割することはない。
+ */
+std::vector<std::string> str_split(std::string_view str, char delim, bool trim, int num)
+{
+    std::vector<std::string> result;
+    if (num > 0) {
+        result.reserve(num);
+    }
+
+    auto make_str = [trim](std::string_view sv) { return trim ? str_trim(sv) : std::string(sv); };
+
+    while (true) {
+        bool found = false;
+        for (size_t i = 0; i < str.size(); ++i) {
+            if (str[i] == delim) {
+                result.push_back(make_str(str.substr(0, i)));
+                str.remove_prefix(i + 1);
+                found = true;
+                break;
+            }
+#ifdef JP
+            if (iskanji(str[i])) {
+                ++i;
+            }
+#endif
+        }
+        if (!found) {
+            result.push_back(make_str(str));
+            return result;
+        }
+    }
+}
+
+/*!
+ * @brief 文字列を指定したバイト数ごとに分割する
+ *
+ * 文字列 str を len バイトずつに分割し、分割した文字列を要素とする配列を
+ * std::vector<std::string> 型のオブジェクトとして返す。
+ *
+ * @param str 操作の対象とする文字列
+ * @param len 分割するバイト数。全角文字を含む文字列には2以上を指定すること
+ * @return std::vector<std::string> 分割した文字列を要素とする配列
+ * @details
+ * 全角文字は2バイトを占める。分割位置に全角文字がかかる場合はその手前で区切るため、
+ * 各要素が len バイトちょうどになるとは限らない。
+ * str が空文字列の場合は空の配列を返す。
+ *
+ * len が 0 の場合や、len が 1 で分割位置に全角文字が来る場合は1バイトも取り出せず
+ * 分割が進まないため、そこで打ち切る(残りの文字列は戻り値に含まれない)。
+ */
+std::vector<std::string> str_separate(std::string_view str, size_t len)
+{
+    std::vector<std::string> result;
+
+    while (!str.empty()) {
+        auto separated = str_substr(str, 0, len);
+        if (separated.empty()) {
+            // len が小さすぎて1文字も取り出せない。これ以上分割できないので打ち切る
+            break;
+        }
+
+        str.remove_prefix(separated.size());
+        result.push_back(std::move(separated));
+    }
+
+    return result;
+}
+
+/*!
+ * @brief 文字列から指定した文字を取り除く
+ *
+ * 文字列 str から文字列 erase_chars に含まれる文字をすべて削除し、
+ * 削除した文字列を std::string 型のオブジェクトとして返す。
+ *
+ * @param str 操作の対象とする文字列
+ * @param erase_chars 削除する文字を指定する文字列
+ * @return std::string 指定した文字をすべて削除した文字列
+ * @details
+ * 2バイト文字の後半バイトは削除の対象にしない。erase_chars にダメ文字と重なる文字を
+ * 指定しても2バイト文字を壊すことはない。
+ */
+std::string str_erase(std::string str, std::string_view erase_chars)
+{
+    for (auto it = str.begin(); it != str.end();) {
+        if (erase_chars.find(*it) != std::string_view::npos) {
+            it = str.erase(it);
+            continue;
+        }
+#ifdef JP
+        if (iskanji(*it) && (it + 1 != str.end())) {
+            ++it;
+        }
+#endif
+        ++it;
+    }
+
+    return str;
+}
+
+/*!
+ * @brief 文字列 str に含まれる文字列 old_str をすべて new_str に置き換える
+ *
+ * 一致する文字列が重複している場合は、前方を優先する。
+ *
+ * @param str 操作の対象とする文字列
+ * @param old_str 置き換える文字列。空文字列の場合は str をそのまま返す
+ * @param new_str 置き換え後の文字列
+ * @return std::string old_str をすべて new_str で置き換えた文字列
+ * @details
+ * 2バイト文字の後半バイトから始まる位置にはマッチしない。
+ */
+std::string str_replace(std::string_view str, std::string_view old_str, std::string_view new_str)
+{
+    if (old_str.empty()) {
+        return std::string(str);
+    }
+
+    const auto mb_char_indexes = str_find_all_multibyte_chars(str);
+    std::string result;
+
+    for (size_t start_pos = 0;;) {
+        const auto found_pos = str.find(old_str, start_pos);
+        if (found_pos == std::string_view::npos) {
+            result.append(str.substr(start_pos));
+            return result;
+        }
+
+        if ((found_pos > 0) && mb_char_indexes.contains(found_pos - 1)) {
+            // 2バイト文字の後半バイトから始まる位置に一致したので、置き換えずに読み進める
+            result.append(str.substr(start_pos, found_pos + 1 - start_pos));
+            start_pos = found_pos + 1;
+            continue;
+        }
+
+        result.append(str.substr(start_pos, found_pos - start_pos)).append(new_str);
+        start_pos = found_pos + old_str.length();
+    }
+}
 
 /*!
  * @brief 2バイト文字を考慮して部分文字列を取得する
  *
- * 引数で与えられた文字列から pos バイト目から n バイトの部分文字列を取得する。
+ * 引数で与えられた文字列の pos バイト目から n バイトの部分文字列を取得する。
  * 但し、以下の通り2バイト文字の途中で分断されないようにする。
  * - 開始位置 pos バイト目が2バイト文字の後半バイトの場合は pos+1 バイト目を開始位置とする。
  * - 終了位置 pos+n バイト目が2バイト文字の前半バイトの場合は pos+n-1 バイト目を終了位置とする。
  *
  * @param sv 文字列
- * @param pos 部分文字列の開始位置
- * @param n 部分文字列の長さ
+ * @param pos 部分文字列の開始位置(バイト)
+ * @param n 部分文字列の長さ(バイト)
  * @return 部分文字列
+ * @details
+ * pos が文字列の長さ以上の場合は空文字列を返す。pos + n が文字列の長さを超える場合は
+ * 文字列の末尾までを返す。例外は送出しない。
  */
 std::string str_substr(std::string_view sv, size_t pos, size_t n)
 {
@@ -401,17 +483,17 @@ std::string str_substr(std::string_view sv, size_t pos, size_t n)
 }
 
 /*!
- * @brief 2バイト文字を考慮して部分文字列を取得する
+ * @brief 2バイト文字を考慮して部分文字列を取得する (ムーブ版)
  *
  * 引数で与えられた文字列を pos バイト目から n バイトの部分文字列にして返す。
- * 但し、以下の通り2バイト文字の途中で分断されないようにする。
- * - 開始位置 pos バイト目が2バイト文字の後半バイトの場合は pos+1 バイト目を開始位置とする。
- * - 終了位置 pos+n バイト目が2バイト文字の前半バイトの場合は pos+n-1 バイト目を終了位置とする。
+ * 範囲の補正の仕方は std::string_view を取る版と同じ。
  *
- * @param str 文字列
- * @param pos 部分文字列の開始位置
- * @param n 部分文字列の長さ
+ * @param str 文字列。中身はムーブされる
+ * @param pos 部分文字列の開始位置(バイト)
+ * @param n 部分文字列の長さ(バイト)
  * @return 部分文字列
+ * @details
+ * 引数の文字列を縮めて返すため、新たな領域を確保しない。
  */
 std::string str_substr(std::string &&str, size_t pos, size_t n)
 {
@@ -421,6 +503,17 @@ std::string str_substr(std::string &&str, size_t pos, size_t n)
     return std::move(str);
 }
 
+/*!
+ * @brief 2バイト文字を考慮して部分文字列を取得する (const char * 版)
+ * @param str NUL終端された文字列
+ * @param pos 部分文字列の開始位置(バイト)
+ * @param n 部分文字列の長さ(バイト)
+ * @return 部分文字列
+ * @details
+ * const char * は std::string_view にも std::string にも同じだけの変換で到達できるため、
+ * このオーバーロードが無いと std::string_view 版と std::string && 版の解決が曖昧になる。
+ * それを解消するために用意している。
+ */
 std::string str_substr(const char *str, size_t pos, size_t n)
 {
     return str_substr(std::string_view(str), pos, n);
@@ -430,6 +523,9 @@ std::string str_substr(const char *str, size_t pos, size_t n)
  * @brief 文字列を大文字に変換する
  * @param str 変換元の文字列
  * @return 大文字に変換した文字列
+ * @details
+ * 変換は1バイトずつ行い、英字以外の文字は変換されない。
+ * 日本語版では2バイト文字を変換の対象とせず、そのまま通す。
  */
 std::string str_toupper(std::string_view str)
 {
@@ -457,6 +553,9 @@ std::string str_toupper(std::string_view str)
  * @brief 文字列を小文字に変換する
  * @param str 変換元の文字列
  * @return 小文字に変換した文字列
+ * @details
+ * 変換は1バイトずつ行い、英字以外の文字は変換されない。
+ * 日本語版では2バイト文字を変換の対象とせず、そのまま通す。
  */
 std::string str_tolower(std::string_view str)
 {
@@ -485,6 +584,9 @@ std::string str_tolower(std::string_view str)
  *
  * @param str 変換元の文字列
  * @return 変換後の文字列
+ * @details
+ * 最初の文字が英字でない場合は何も変換しない。空文字列を渡した場合は空文字列を返す。
+ * 日本語版では最初の文字が2バイト文字の場合も変換しない。
  */
 std::string str_upcase_first(std::string_view str)
 {
@@ -510,10 +612,13 @@ std::string str_upcase_first(std::string_view str)
 }
 
 /*!
- * @brief 文字列に含まれるすべてのマルチバイト文字のインデックスを取得する
+ * @brief 文字列に含まれるすべての2バイト文字の位置を取得する
  *
  * @param str 文字列
- * @return std::set<int> マルチバイト文字のインデックスの集合
+ * @return std::set<int> 2バイト文字の前半バイトのインデックスの集合
+ * @details
+ * 英語版では常に空の集合を返す。
+ * 文字列の末尾が2バイト文字の前半バイトだけで終わっている場合も、その位置を集合に含める。
  */
 std::set<int> str_find_all_multibyte_chars([[maybe_unused]] std::string_view str)
 {
@@ -536,8 +641,10 @@ std::set<int> str_find_all_multibyte_chars([[maybe_unused]] std::string_view str
  * @brief 文字列から指定した文字以降の部分文字列を抽出する
  * @param str 抽出対象の文字列
  * @param find 検索する文字
- * @return 部分文字列
- * @details 現時点ではシフトJISのダメ文字は考慮しない (必要に応じて拡張する)
+ * @return 見つかった位置から末尾までの部分文字列。見つからなければtl::nullopt
+ * @details
+ * 戻り値は str の一部を指すビューであり、str より長生きさせてはならない。
+ * 現時点ではシフトJISのダメ文字は考慮しない (必要に応じて拡張する)。
  */
 tl::optional<std::string_view> extract_suffix(std::string_view str, char find)
 {
@@ -552,8 +659,10 @@ tl::optional<std::string_view> extract_suffix(std::string_view str, char find)
  * @brief 文字列から指定した文字列以降の部分文字列を抽出する
  * @param str 抽出対象の文字列
  * @param find 検索する文字列
- * @return 部分文字列
- * @details 現時点ではシフトJISのダメ文字は考慮しない (必要に応じて拡張する)
+ * @return 見つかった位置から末尾までの部分文字列。見つからなければtl::nullopt
+ * @details
+ * 戻り値は str の一部を指すビューであり、str より長生きさせてはならない。
+ * 現時点ではシフトJISのダメ文字は考慮しない (必要に応じて拡張する)。
  */
 tl::optional<std::string_view> extract_suffix(std::string_view str, std::string_view find)
 {
@@ -570,6 +679,8 @@ tl::optional<std::string_view> extract_suffix(std::string_view str, std::string_
  * @param value 数える整数
  * @param base 桁数を数える基数(省略した場合のデフォルト値は10)
  * @return 整数の桁数。基数が不正(2未満)な場合は0を返す。
+ * @details
+ * 符号は桁数に数えない(-123 は 3 を返す)。0 は 1 桁として数える。
  */
 int count_digits(int value, int base)
 {
@@ -587,21 +698,43 @@ int count_digits(int value, int base)
     return count;
 }
 
+/*!
+ * @brief 1バイトの値を16進数2桁で表したときの上位桁の文字を返す
+ * @param value 変換する値
+ * @return 上位4ビットを表す16進数の大文字('0'-'9', 'A'-'F')
+ */
 char hexify_upper(uint8_t value)
 {
     return hex_symbol_table.at(value / 16);
 }
 
+/*!
+ * @brief 1バイトの値を16進数2桁で表したときの下位桁の文字を返す
+ * @param value 変換する値
+ * @return 下位4ビットを表す16進数の大文字('0'-'9', 'A'-'F')
+ */
 char hexify_lower(uint8_t value)
 {
     return hex_symbol_table.at(value % 16);
 }
 
+/*!
+ * @brief 値を8進数1桁の文字に変換する
+ * @param i 変換する値。8以上の場合は8で割った余りを変換する
+ * @return 8進数の文字('0'-'7')
+ */
 char octify(uint8_t i)
 {
     return hex_symbol_table.at(i % 8);
 }
 
+/*!
+ * @brief 文字がASCIIの数字かどうかを判定する
+ * @param c 判定する文字
+ * @return '0'から'9'のいずれかならtrue
+ * @details
+ * std::isdigit と異なりロケールの影響を受けず、負の値の char を渡しても未定義動作にならない。
+ */
 bool is_numeric(char c)
 {
     return (c >= '0') && (c <= '9');

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -406,21 +406,25 @@ std::vector<std::string> str_separate(std::string_view str, size_t len)
  * 削除した文字列を std::string 型のオブジェクトとして返す。
  *
  * @param str 操作の対象とする文字列
- * @param erase_chars 削除する文字を指定する文字列
+ * @param erase_chars 削除する文字を指定する文字列。1バイト文字の集合として扱う
  * @return std::string 指定した文字をすべて削除した文字列
  * @details
- * 2バイト文字の後半バイトは削除の対象にしない。erase_chars にダメ文字と重なる文字を
- * 指定しても2バイト文字を壊すことはない。
+ * str 中の2バイト文字は前半バイト・後半バイトのどちらも削除の対象にしない。
+ * erase_chars にダメ文字と重なる文字や2バイト文字を指定しても、2バイト文字を壊すことはない。
+ * 裏を返せば、erase_chars に2バイト文字を指定しても、その文字は削除されない。
  */
 std::string str_erase(std::string str, std::string_view erase_chars)
 {
     for (size_t i = 0; i < str.length();) {
-        if (erase_chars.find(str[i]) != std::string_view::npos) {
+        const auto char_length = char_byte_length(str, i);
+
+        // 2バイト文字は、前半バイトが erase_chars のバイト列と一致しても削除しない
+        if ((char_length == 1) && (erase_chars.find(str[i]) != std::string_view::npos)) {
             str.erase(i, 1);
             continue;
         }
 
-        i += char_byte_length(str, i);
+        i += char_length;
     }
 
     return str;

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -19,7 +19,8 @@
 #include <algorithm>
 #include <array>
 #include <range/v3/range/conversion.hpp>
-#include <range/v3/view.hpp>
+#include <range/v3/view/drop_while.hpp>
+#include <range/v3/view/reverse.hpp>
 #include <utility>
 
 namespace {
@@ -27,6 +28,54 @@ constexpr std::array<char, 16> hex_symbol_table = { { '0', '1', '2', '3', '4', '
 
 constexpr auto trim_front = ranges::views::drop_while([](char c) { return c == ' ' || c == '\t'; });
 constexpr auto trim_back = ranges::views::reverse | trim_front | ranges::views::reverse;
+
+/*!
+ * @brief 位置 i から始まる文字のバイト数を返す
+ * @param sv 対象の文字列
+ * @param i 文字の開始位置(バイト)。sv の範囲内であること
+ * @return 2バイト文字の前半バイトなら2、そうでなければ1
+ * @details
+ * 文字列の末尾が2バイト文字の前半バイトだけで終わっている場合も2を返す。
+ * 戻り値を足した位置が文字列の長さを超えうるため、添字を進める用途では
+ * ループの継続条件で範囲を確かめること。
+ */
+size_t char_byte_length([[maybe_unused]] std::string_view sv, [[maybe_unused]] size_t i)
+{
+#ifdef JP
+    return iskanji(sv[i]) ? 2 : 1;
+#else
+    return 1;
+#endif
+}
+
+/*!
+ * @brief 1バイト文字だけに変換関数を適用した文字列を作る
+ * @param str 変換元の文字列
+ * @param convert 1バイト文字に適用する変換関数
+ * @return 変換後の文字列
+ * @details
+ * 2バイト文字は変換せずそのまま通す。後半バイトを欠いている場合も同じ。
+ */
+template <typename F>
+std::string convert_each_char(std::string_view str, F convert)
+{
+    std::string result;
+    result.reserve(str.length());
+
+    for (size_t i = 0; i < str.length();) {
+        const auto char_length = char_byte_length(str, i);
+        if (char_length > 1) {
+            result.append(str.substr(i, char_length));
+            i += char_length;
+            continue;
+        }
+
+        result.push_back(static_cast<char>(convert(static_cast<unsigned char>(str[i]))));
+        ++i;
+    }
+
+    return result;
+}
 
 /*!
  * @brief 2バイト文字を分断しないように部分文字列の範囲を補正する
@@ -45,30 +94,23 @@ std::pair<size_t, size_t> adjust_substr_pos(std::string_view sv, size_t pos, siz
     const auto end = n == std::string_view::npos ? sv.length() : std::min(pos + n, sv.length());
 
 #ifdef JP
-    size_t seek_pos = 0;
-    while (seek_pos < start) {
-        if (iskanji(sv[seek_pos])) {
-            ++seek_pos;
-        }
-        ++seek_pos;
+    // 開始位置が2バイト文字の後半バイトを指す場合は、次の文字の先頭まで進める
+    size_t mb_pos = 0;
+    while (mb_pos < start) {
+        mb_pos = std::min(mb_pos + char_byte_length(sv, mb_pos), sv.length());
     }
 
-    // 文字列の末尾が2バイト文字の前半バイトだけの場合、seek_pos が文字列長を超えうる
-    seek_pos = std::min(seek_pos, sv.length());
-    const auto mb_pos = seek_pos;
-
-    while (seek_pos < end) {
-        if (iskanji(sv[seek_pos])) {
-            if (seek_pos == end - 1) {
-                break;
-            }
-            ++seek_pos;
+    // 2バイト文字は後半バイトまで範囲に収まる場合だけ含める
+    auto mb_end = mb_pos;
+    while (mb_end < end) {
+        const auto char_length = char_byte_length(sv, mb_end);
+        if (mb_end + char_length > end) {
+            break;
         }
-        ++seek_pos;
+        mb_end += char_length;
     }
-    const auto mb_n = seek_pos - mb_pos;
 
-    return { mb_pos, mb_n };
+    return { mb_pos, mb_end - mb_pos };
 #else
     return { start, end - start };
 #endif
@@ -95,28 +137,11 @@ size_t angband_strcpy(char *buf, std::string_view src, size_t bufsize)
         return src.length();
     }
 
-    // NUL終端の分を除いた、実際にコピーできるバイト数
-    const auto capacity = bufsize - 1;
-    size_t len = 0;
-
-    while ((len < src.length()) && (len < capacity)) {
-#ifdef JP
-        if (iskanji(src[len])) {
-            // 2バイト文字は後半バイトまで収まる場合だけコピーし、途中で分断しない
-            if ((len + 2 > capacity) || (len + 1 >= src.length())) {
-                break;
-            }
-            buf[len] = src[len];
-            buf[len + 1] = src[len + 1];
-            len += 2;
-            continue;
-        }
-#endif
-        buf[len] = src[len];
-        ++len;
-    }
-
+    // NUL終端の分を除いた範囲に収まるよう、2バイト文字を分断しない位置で切り詰める
+    const auto len = adjust_substr_pos(src, 0, bufsize - 1).second;
+    src.copy(buf, len);
     buf[len] = '\0';
+
     return src.length();
 }
 
@@ -155,24 +180,16 @@ size_t angband_strcat(char *buf, std::string_view src, size_t bufsize)
  */
 char *angband_strstr(const char *haystack, std::string_view needle)
 {
-    std::string_view haystack_view(haystack);
-    auto l1 = haystack_view.length();
-    auto l2 = needle.length();
-    if (l1 < l2) {
+    const std::string_view haystack_view(haystack);
+    if (haystack_view.length() < needle.length()) {
         return nullptr;
     }
 
-    for (size_t i = 0; i <= l1 - l2; i++) {
-        const auto part = haystack_view.substr(i);
-        if (part.starts_with(needle)) {
+    const auto last_pos = haystack_view.length() - needle.length();
+    for (size_t i = 0; i <= last_pos; i += char_byte_length(haystack_view, i)) {
+        if (haystack_view.substr(i).starts_with(needle)) {
             return const_cast<char *>(haystack) + i;
         }
-
-#ifdef JP
-        if (iskanji(*(haystack + i))) {
-            i++;
-        }
-#endif
     }
 
     return nullptr;
@@ -189,19 +206,11 @@ char *angband_strstr(const char *haystack, std::string_view needle)
  */
 char *angband_strchr(const char *ptr, char ch)
 {
-    // ポインタを進める形だと、末尾が2バイト文字の前半バイトだけのときに
-    // 後半バイトの読み飛ばしで終端を跨いでしまうため、添字で走査する
     const std::string_view sv(ptr);
-    for (size_t i = 0; i < sv.length(); ++i) {
+    for (size_t i = 0; i < sv.length(); i += char_byte_length(sv, i)) {
         if (sv[i] == ch) {
             return const_cast<char *>(ptr) + i;
         }
-
-#ifdef JP
-        if (iskanji(sv[i])) {
-            ++i;
-        }
-#endif
     }
 
     return nullptr;
@@ -283,7 +292,7 @@ std::string str_trim(std::string_view str)
  * @param str 操作の対象とする文字列
  * @return std::string strの右端の空白を削除した文字列
  * @details
- * 2バイト文字の後半バイトが 0x20 や 0x09 になる文字コードは無いため、2バイト文字を壊すことはない。
+ * 2バイト文字の扱いは str_trim() と同じ。
  */
 std::string str_rtrim(std::string_view str)
 {
@@ -300,7 +309,7 @@ std::string str_rtrim(std::string_view str)
  * @param str 操作の対象とする文字列
  * @return std::string strの左端の空白を削除した文字列
  * @details
- * 2バイト文字の後半バイトが 0x20 や 0x09 になる文字コードは無いため、2バイト文字を壊すことはない。
+ * 2バイト文字の扱いは str_trim() と同じ。
  */
 std::string str_ltrim(std::string_view str)
 {
@@ -333,23 +342,21 @@ std::vector<std::string> str_split(std::string_view str, char delim, bool trim, 
         result.reserve(num);
     }
 
-    auto make_str = [trim](std::string_view sv) { return trim ? str_trim(sv) : std::string(sv); };
+    const auto make_str = [trim](std::string_view sv) { return trim ? str_trim(sv) : std::string(sv); };
 
     while (true) {
-        bool found = false;
-        for (size_t i = 0; i < str.size(); ++i) {
-            if (str[i] == delim) {
-                result.push_back(make_str(str.substr(0, i)));
-                str.remove_prefix(i + 1);
-                found = true;
-                break;
+        auto found = false;
+        for (size_t i = 0; i < str.length(); i += char_byte_length(str, i)) {
+            if (str[i] != delim) {
+                continue;
             }
-#ifdef JP
-            if (iskanji(str[i])) {
-                ++i;
-            }
-#endif
+
+            result.push_back(make_str(str.substr(0, i)));
+            str.remove_prefix(i + 1);
+            found = true;
+            break;
         }
+
         if (!found) {
             result.push_back(make_str(str));
             return result;
@@ -407,17 +414,13 @@ std::vector<std::string> str_separate(std::string_view str, size_t len)
  */
 std::string str_erase(std::string str, std::string_view erase_chars)
 {
-    for (auto it = str.begin(); it != str.end();) {
-        if (erase_chars.find(*it) != std::string_view::npos) {
-            it = str.erase(it);
+    for (size_t i = 0; i < str.length();) {
+        if (erase_chars.find(str[i]) != std::string_view::npos) {
+            str.erase(i, 1);
             continue;
         }
-#ifdef JP
-        if (iskanji(*it) && (it + 1 != str.end())) {
-            ++it;
-        }
-#endif
-        ++it;
+
+        i += char_byte_length(str, i);
     }
 
     return str;
@@ -441,8 +444,11 @@ std::string str_replace(std::string_view str, std::string_view old_str, std::str
         return std::string(str);
     }
 
+    // 文字境界は置き換え前の文字列から決める。置き換えで2バイト文字が崩れた場合も、
+    // 残った後半バイトを新たな文字の先頭と見なして誤って置き換えることがない
     const auto mb_char_indexes = str_find_all_multibyte_chars(str);
     std::string result;
+    result.reserve(str.length());
 
     for (size_t start_pos = 0;;) {
         const auto found_pos = str.find(old_str, start_pos);
@@ -508,14 +514,10 @@ std::string str_substr(std::string &&str, size_t pos, size_t n)
 
 /*!
  * @brief 2バイト文字を考慮して部分文字列を取得する (const char * 版)
- * @param str NUL終端された文字列
- * @param pos 部分文字列の開始位置(バイト)
- * @param n 部分文字列の長さ(バイト)
- * @return 部分文字列
  * @details
  * const char * は std::string_view にも std::string にも同じだけの変換で到達できるため、
  * このオーバーロードが無いと std::string_view 版と std::string && 版の解決が曖昧になる。
- * それを解消するために用意している。
+ * それを解消するために用意している。引数と戻り値の意味は std::string_view 版と同じ。
  */
 std::string str_substr(const char *str, size_t pos, size_t n)
 {
@@ -532,24 +534,7 @@ std::string str_substr(const char *str, size_t pos, size_t n)
  */
 std::string str_toupper(std::string_view str)
 {
-    std::string uc_str;
-    uc_str.reserve(str.size());
-    for (size_t i = 0; i < str.length(); ++i) {
-        const auto ch = str[i];
-#ifdef JP
-        // 2バイト文字は変換せずそのまま通す。後半バイトを欠いている場合も同じ
-        if (iskanji(ch)) {
-            uc_str.push_back(ch);
-            if (i + 1 < str.length()) {
-                uc_str.push_back(str[++i]);
-            }
-            continue;
-        }
-#endif
-        uc_str.push_back(static_cast<char>(toupper(static_cast<unsigned char>(ch))));
-    }
-
-    return uc_str;
+    return convert_each_char(str, toupper);
 }
 
 /*!
@@ -562,24 +547,7 @@ std::string str_toupper(std::string_view str)
  */
 std::string str_tolower(std::string_view str)
 {
-    std::string lc_str;
-    lc_str.reserve(str.size());
-    for (size_t i = 0; i < str.length(); ++i) {
-        const auto ch = str[i];
-#ifdef JP
-        // 2バイト文字は変換せずそのまま通す。後半バイトを欠いている場合も同じ
-        if (iskanji(ch)) {
-            lc_str.push_back(ch);
-            if (i + 1 < str.length()) {
-                lc_str.push_back(str[++i]);
-            }
-            continue;
-        }
-#endif
-        lc_str.push_back(static_cast<char>(tolower(static_cast<unsigned char>(ch))));
-    }
-
-    return lc_str;
+    return convert_each_char(str, tolower);
 }
 
 /*!
@@ -627,11 +595,13 @@ std::set<int> str_find_all_multibyte_chars([[maybe_unused]] std::string_view str
 {
 #ifdef JP
     std::set<int> mb_chars;
-    for (auto i = 0; std::cmp_less(i, str.length()); ++i) {
-        if (iskanji(str[i])) {
-            mb_chars.insert(mb_chars.end(), i);
-            ++i;
+    for (size_t i = 0; i < str.length();) {
+        const auto char_length = char_byte_length(str, i);
+        if (char_length > 1) {
+            mb_chars.insert(mb_chars.end(), static_cast<int>(i));
         }
+
+        i += char_length;
     }
 
     return mb_chars;

--- a/src/util/string-processor.cpp
+++ b/src/util/string-processor.cpp
@@ -170,49 +170,6 @@ char *rtrim(char *p)
     return p;
 }
 
-/*!
- * @brief 文字列の後方から一致するかどうか比較する
- * @param s1 比較元文字列ポインタ
- * @param s2 比較先文字列ポインタ
- * @param len 比較する長さ
- * @return 等しい場合は0、p1が大きい場合は-1、p2が大きい場合は1
- * @details
- * strncmpの後方から比較する版
- */
-int strrncmp(const char *s1, const char *s2, int len)
-{
-    int i;
-    int l1 = strlen(s1);
-    int l2 = strlen(s2);
-
-    for (i = 1; i <= len; i++) {
-        int p1 = l1 - i;
-        int p2 = l2 - i;
-
-        if (l1 != l2) {
-            if (p1 < 0) {
-                return -1;
-            }
-            if (p2 < 0) {
-                return 1;
-            }
-        } else {
-            if (p1 < 0) {
-                return 0;
-            }
-        }
-
-        if (s1[p1] < s2[p2]) {
-            return -1;
-        }
-        if (s1[p1] > s2[p2]) {
-            return -1;
-        }
-    }
-
-    return 0;
-}
-
 /*
  * @brief マルチバイト文字のダメ文字('\')を考慮しつつ文字列比較を行う
  * @param src 比較元の文字列

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -40,7 +40,6 @@ char *angband_strstr(const char *haystack, std::string_view needle);
 char *angband_strchr(const char *ptr, char ch);
 char *ltrim(char *p);
 char *rtrim(char *p);
-int strrncmp(const char *s1, const char *s2, int len);
 bool str_find(const std::string &src, std::string_view find);
 std::string str_trim(std::string_view str);
 std::string str_rtrim(std::string_view str);

--- a/src/util/string-processor.h
+++ b/src/util/string-processor.h
@@ -1,8 +1,12 @@
+/*!
+ * @file string-processor.h
+ * @brief 文字列処理の汎用ユーティリティの宣言
+ */
+
 #pragma once
 
 #include <charconv>
 #include <cstdint>
-#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -15,6 +19,10 @@
  * @param str 変換する文字列
  * @param base 基数（2〜36。省略した場合のデフォルト値は10）
  * @return 変換した数値。文字列全体が数値として解釈できない場合や基数が範囲外の場合はtl::nullopt
+ * @details
+ * T には整数型を指定すること。
+ * 文字列の一部だけが数値として解釈できる場合や、変換結果が T に収まらない場合も
+ * tl::nullopt を返す。先頭の空白の読み飛ばしや基数の接頭辞("0x"など)の解釈は行わない。
  */
 template <typename T>
 tl::optional<T> str_to_num(std::string_view str, int base = 10)


### PR DESCRIPTION
## 概要

`src/util/string-processor.cpp` / `.h` を整理しました。ゲーム全体で最も広く使われる文字列ユーティリティ群 (`angband_strcpy` 36箇所、`angband_strchr` 32箇所、`str_tolower` 15箇所など) でありながら、ユニットテストが1件もなく、Angband 由来の英語コメントと Doxygen 形式でないコメントが混在している状態でした。

レビューの過程で、2バイト文字の扱いを中心に範囲外アクセスと無限ループを含む複数の不具合が見つかったため、それらの修正も含めています。

## 変更内容

### 不具合の修正

| 関数 | 内容 |
| --- | --- |
| `angband_strcpy` | 日本語版が `src` を NUL 終端前提で走査しており、非 NUL 終端の `std::string_view` を渡すと範囲外を読んでいた。あわせて英語版と食い違っていた戻り値の意味を `src.length()` に統一 |
| `angband_strchr` | 2バイト文字の後半バイトを読み飛ばす `ptr++` と `for` の `ptr++` が重なり、末尾が前半バイトだけで終わる文字列で終端を跨いでその先を読んでいた |
| `angband_strcat` | `bufsize` が 0 のとき `bufsize - 1` が桁溢れしていた |
| `rtrim` | 空文字列を渡すと `p[-1]` を読んでいた |
| `str_toupper` / `str_tolower` | 負の `char` を `toupper` / `tolower` に渡す未定義動作。また末尾が2バイト文字の前半バイトだけの場合に範囲外を読んでいた |
| `str_upcase_first` | 2バイト文字の前半バイトをロケール依存の変換にかけていた |
| `str_erase` / `str_substr` | 末尾が2バイト文字の前半バイトだけの場合に、イテレータが `end()` を越える、`substr()` が例外を送出する可能性があった |
| `str_separate` | 分割幅が小さすぎて1要素も取り出せない場合に無限ループしていた |
| `strrncmp` | 未使用かつ `s1 > s2` でも -1 を返していたため削除 |

`str_find` のレビュー中に、`MonraceDefinition::is_catchable_for_fishing()` が `char` 単体のアドレスを文字列として `strlen` にかけ、オブジェクト外を読んでいるのを見つけたため、既存の `symbol_char_is_any_of()` に置き換えました。

### Doxygen コメントの整理

- Angband 由来の英語コメントを日本語化し、形式を `/*!` に統一
- コメントの無かった `hexify_upper` / `hexify_lower` / `octify` / `is_numeric` などに追加
- 実態と食い違っていた記述を修正 (`str_split` の `num` は要素数を揃えるものではなく領域確保のヒントである、`str_separate` の分割単位は文字数ではなくバイト数である、など)
- ファイル先頭にダメ文字の説明をまとめ、各関数の `@details` から参照する形に

### 2バイト文字の走査の共通化

「2バイト文字の後半バイトを読み飛ばす」という同じ判断が各関数に手書きで散っていたため、文字のバイト数を返す `char_byte_length()` にまとめ、走査する関数をすべて添字による走査に揃えました。

- `angband_strcpy` は切り詰め位置の算出を `adjust_substr_pos()` に委譲。境界の補正が1箇所に集まり、1バイトずつのコピーが `std::string_view::copy` に戻ります
- 完全なコピペだった `str_toupper` / `str_tolower` を `convert_each_char()` にまとめ

`str_replace` は文字境界を置き換え前の文字列から決める必要があり、前方走査に書き換えると挙動が変わるため元の形を残しています。

### ユニットテストの追加

`src/test/util/test-string-processor.cpp` を追加しました。実装からではなく、Doxygen で確定させた仕様から各関数の境界と前提条件を検証しています。

文字コードへの依存度に応じて3層に分けています。

1. 文字コードに依存しないもの (全ビルドで実行)
2. 2バイト文字を分断しないことの検証 (`#ifdef JP`)
3. ダメ文字の検証 (`#if defined(JP) && defined(SJIS)`)

ダメ文字は Shift_JIS でしか再現できないため、MSVC の CI (Debug 構成が JP + SJIS) で実行されます。テストデータは、日本語版のビルドが文字列リテラルを変換することでバイト列が変わらないよう、16進エスケープで記述しています。

## 動作確認

| 構成 | 結果 |
| --- | --- |
| 日本語版 (EUC-JP, gcc) | 167 ケース / 12011 アサーション 成功 |
| 英語版 (gcc) | 成功 |
| Shift_JIS 強制 (`iskanji` を一時的に差し替え) | ダメ文字のテストを含め成功 |

- `angband_strchr` の範囲外読み取りは AddressSanitizer で再現を確認し、修正後に検出されないことを確認しました
- 走査の共通化については、代表的なバイト8種から成る長さ4までの全文字列 (4681通り) と全パラメータの組み合わせについて、旧実装と戻り値・出力が完全に一致することを EUC-JP と Shift_JIS の両方で確認しました
- ヘッドレス起動でキャラクター作成から持ち物表示まで操作し、日本語の表示と銘の解析が正常なことを確認しました

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 日本語文字コードに対応した文字列処理を強化しました。
  * 文字列の分割、検索、置換、削除、部分取得などで、マルチバイト文字を正しく扱えるようになりました。
  * 数値変換や境界条件を含む文字列処理のテストを追加しました。

* **バグ修正**
  * 2バイト文字の途中で文字列を分断・誤認識する問題を修正しました。
  * Shift_JIS特有の文字を検索や分割時に誤って処理しないよう改善しました。
  * 釣りで捕獲可能な魚の判定をより正確にしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->